### PR TITLE
docs: fix README issues, add LICENSE, AGENTS.md, and review tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,200 @@
+# AGENTS.md - Coding Agent Guidelines for joshbot
+
+## Project Overview
+
+joshbot is a lightweight personal AI assistant (~3,600 LOC Python) with self-learning
+memory, skill self-creation, and Telegram integration. Architecture: async message bus
+decoupling chat channels from a ReAct agent loop backed by multi-provider LLM via litellm.
+
+## Build & Run Commands
+
+```bash
+# Install (use a venv)
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e .
+
+# Run
+joshbot onboard          # First-time setup
+joshbot agent            # Interactive CLI mode
+joshbot gateway          # Telegram + all channels
+joshbot status           # Show config/status
+
+# Docker
+docker build -t joshbot .
+docker compose up -d
+```
+
+## Testing
+
+No test framework is configured yet. When adding tests:
+
+```bash
+pip install pytest pytest-asyncio
+pytest                          # Run all tests
+pytest tests/test_tools.py      # Run one file
+pytest tests/test_tools.py::test_shell_safety -xvs  # Run single test, verbose, no capture
+```
+
+Place tests in `tests/` with `test_` prefix. Use `pytest-asyncio` for async tests.
+Most components are testable in isolation (tools, config, bus, session, memory, skills).
+
+## Linting & Formatting
+
+Ruff is the preferred linter/formatter (cache exists for v0.12.5). No config is committed
+yet. When running:
+
+```bash
+pip install ruff mypy
+ruff check .               # Lint
+ruff format .              # Format
+ruff check --fix .         # Autofix
+mypy joshbot/              # Type checking
+```
+
+## Code Style
+
+### Module Structure
+
+Every `.py` file follows this order:
+1. Module docstring (single line)
+2. `from __future__ import annotations`
+3. Stdlib imports
+4. Third-party imports (blank line separator)
+5. Local imports using **relative paths** (blank line separator)
+
+```python
+"""Shell execution tool with safety guards."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any
+
+from loguru import logger
+
+from .base import Tool
+```
+
+### Imports
+
+- **Always relative** for local imports (`from ..bus.events import ...`, `from .base import ...`)
+- **Never absolute** (`from joshbot.bus.events import ...` -- don't do this)
+- **Lazy imports** for heavy/optional deps inside functions (litellm, telegram, httpx, readability)
+- **`TYPE_CHECKING` guard** for imports only needed at type-check time (avoids circular imports)
+
+### Type Annotations
+
+- **Required** on all function/method signatures (parameters and return types)
+- Modern syntax enabled by `from __future__ import annotations`:
+  - `str | None` not `Optional[str]`
+  - `list[str]` not `List[str]`
+  - `dict[str, Any]` not `Dict[str, Any]`
+- Use `-> None` for void returns
+- Use `Any` sparingly (LLM response data, generic dicts)
+
+### Naming Conventions
+
+| Element          | Convention         | Example                          |
+|------------------|--------------------|----------------------------------|
+| Classes          | PascalCase         | `AgentLoop`, `WebFetchTool`      |
+| Functions/methods| snake_case         | `build_system_prompt`            |
+| Private members  | `_prefix`          | `self._config`, `self._running`  |
+| Private methods  | `_prefix`          | `_parse_response`, `_resolve_path`|
+| Constants        | UPPER_SNAKE_CASE   | `MAX_OUTPUT`, `DANGEROUS_PATTERNS`|
+| Module variables | lowercase          | `app`, `console`                 |
+
+### Data Modeling
+
+- **`@dataclass`** for internal data types (InboundMessage, LLMResponse, Session, CronJob, etc.)
+- **Pydantic `BaseModel`** for config/validation only (Config, ProviderConfig, TelegramConfig)
+- Root `Config` extends `pydantic_settings.BaseSettings` for env var support
+
+### Interfaces & Extension Points
+
+- **`abc.ABC` + `@abstractmethod`** for base classes: `Tool`, `BaseChannel`, `LLMProvider`
+- **Registry pattern** for tools (`ToolRegistry`) and providers (`PROVIDERS` dict)
+- **Deferred initialization** via `set_*()` methods when dependencies aren't available at construction
+
+### Async Patterns
+
+- **Async-first**: all I/O-bound operations are `async def`
+- `asyncio.Queue` for message bus decoupling
+- `asyncio.create_task()` for background work (typing indicators, cron timers, heartbeat)
+- `asyncio.gather()` for concurrent service startup
+- `asyncio.wait_for()` with timeouts for queue processing and shell execution
+- `run_in_executor(None, ...)` for blocking operations (stdin input)
+
+### Error Handling
+
+- **Try/except with loguru** at service boundaries -- never silently swallow errors
+- **Tools return error strings** (`return f"Error: File not found: {path}"`) -- never raise
+- **Graceful degradation** with fallbacks (rich -> plain text, HTML -> plain text)
+- **No custom exception classes** -- use standard Python exceptions
+- **`asyncio.CancelledError`** handled explicitly in long-running loops
+
+### Logging
+
+- **loguru** exclusively (`from loguru import logger`) -- no stdlib `logging`
+- `logger.debug()` for routine operations
+- `logger.info()` for significant events (tool execution, service start/stop)
+- `logger.warning()` for recoverable issues
+- `logger.error()` for failures
+
+### String Formatting
+
+- **f-strings exclusively** -- no `.format()` or `%` formatting
+
+### Docstrings
+
+- Google-style when multi-line (with `Args:` sections)
+- Single-line for simple classes/methods
+- Module docstrings required (single line at top of every file)
+
+## Architecture Quick Reference
+
+```
+channels/ --> bus/MessageBus --> agent/AgentLoop --> providers/LiteLLMProvider
+(CLI,          (async queues)    (ReAct loop)        (litellm -> LLM API)
+ Telegram)                           |
+                                tools/ToolRegistry
+                                (filesystem, shell,
+                                 web, message, cron)
+```
+
+- **Message bus** decouples channels from agent via `InboundMessage`/`OutboundMessage`
+- **ReAct loop**: LLM -> tool calls -> reflect -> repeat (max 20 iterations)
+- **Memory**: `MEMORY.md` (always in context) + `HISTORY.md` (grep-searchable event log)
+- **Skills**: Markdown files with YAML frontmatter, progressive loading (summary -> full content)
+- **Sessions**: JSONL files in `~/.joshbot/sessions/`
+- **Config**: `~/.joshbot/config.json`, Pydantic-validated, env vars with `JOSHBOT_` prefix
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `joshbot/main.py` | CLI entry point, service wiring, onboard flow |
+| `joshbot/agent/loop.py` | Core ReAct agent loop, memory consolidation |
+| `joshbot/agent/context.py` | System prompt assembly |
+| `joshbot/agent/memory.py` | MEMORY.md + HISTORY.md management |
+| `joshbot/agent/skills.py` | Skill discovery and progressive loading |
+| `joshbot/tools/base.py` | Tool ABC (implement this to add new tools) |
+| `joshbot/tools/shell.py` | Shell exec with safety deny-list |
+| `joshbot/channels/base.py` | Channel ABC (implement this to add new channels) |
+| `joshbot/config/schema.py` | All Pydantic config models |
+| `joshbot/bus/queue.py` | Async message bus |
+
+## Adding New Components
+
+**New tool**: Create `joshbot/tools/my_tool.py`, extend `Tool` ABC (implement `name`,
+`description`, `parameters`, `execute`), register in `_build_tools()` in `main.py`.
+
+**New channel**: Create `joshbot/channels/my_channel.py`, extend `BaseChannel` (implement
+`name`, `start`, `stop`, `send`), add setup logic in `ChannelManager.setup_channels()`.
+
+**New skill**: Create `skills/{name}/SKILL.md` with YAML frontmatter. Auto-discovered.
+
+## Python Version
+
+Requires **Python 3.11+**. Uses modern syntax: union types (`X | Y`), generic builtins
+(`list[str]`), `match` statements are permitted.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 bigknoxy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,19 +9,32 @@ A lightweight personal AI assistant with self-learning, long-term memory, skill 
 - **Skill Self-Creation** - Creates new capabilities for itself as markdown files
 - **Telegram Integration** - Chat from your phone with full media support
 - **Interactive CLI** - Rich terminal interface with markdown rendering
-Provider LLM**- **Multi- - OpenRouter, Anthropic, OpenAI, Groq, DeepSeek, and more via litellm
+- **Multi-Provider LLM** - OpenRouter, Anthropic, OpenAI, Groq, DeepSeek, Gemini, and more via litellm
 - **Tool Use** - File operations, shell commands, web search, scheduling, and more
 - **Proactive Tasks** - Heartbeat system for autonomous task processing
 - **Scheduled Reminders** - Cron-based task scheduling with natural delay syntax
+
+## Requirements
+
+- **Python 3.11+** (required — uses modern syntax like `str | None`)
+- **An LLM API key** — OpenRouter free tier works, no credit card needed
+- **Linux or macOS** recommended (Windows may require extra setup for `readability-lxml` C dependencies)
+
+> **Note:** On Debian/Ubuntu, you may need system libraries for lxml: `sudo apt install libxml2-dev libxslt-dev`
 
 ## Quick Start
 
 ### 1. Install
 
 ```bash
-# From source
-git clone https://github.com/yourusername/joshbot.git
+git clone https://github.com/bigknoxy/joshbot.git
 cd joshbot
+
+# Create a virtual environment (recommended)
+python3 -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+
+# Install
 pip install .
 
 # Or install in dev mode
@@ -35,7 +48,7 @@ joshbot onboard
 ```
 
 This will:
-- Ask for your OpenRouter API key (free at [openrouter.ai/keys](https://openrouter.ai/keys))
+- Ask for your OpenRouter API key (free at [openrouter.ai/keys](https://openrouter.ai/keys)) — you can press Enter to skip and configure later
 - Let you choose a personality (Professional, Friendly, Sarcastic, Minimal, or Custom)
 - Set up your workspace and memory files
 
@@ -57,14 +70,18 @@ Config file: `~/.joshbot/config.json`
 {
   "providers": {
     "openrouter": {
-      "api_key": "sk-or-v1-your-key-here"
+      "api_key": "sk-or-v1-your-key-here",
+      "api_base": "",
+      "extra_headers": {}
     }
   },
   "agents": {
     "defaults": {
+      "workspace": "~/.joshbot/workspace",
       "model": "google/gemma-2-9b-it:free",
       "max_tokens": 8192,
       "temperature": 0.7,
+      "max_tool_iterations": 20,
       "memory_window": 50
     }
   },
@@ -72,7 +89,8 @@ Config file: `~/.joshbot/config.json`
     "telegram": {
       "enabled": false,
       "token": "",
-      "allow_from": []
+      "allow_from": [],
+      "proxy": ""
     }
   },
   "tools": {
@@ -81,9 +99,15 @@ Config file: `~/.joshbot/config.json`
     },
     "exec": { "timeout": 60 },
     "restrict_to_workspace": false
+  },
+  "gateway": {
+    "host": "0.0.0.0",
+    "port": 18790
   }
 }
 ```
+
+> **Security note:** `allow_from: []` (empty) means **anyone** can message your bot. Add your Telegram user ID to restrict access. `restrict_to_workspace: false` means tools can access files outside the workspace — set to `true` for sandboxed operation.
 
 ### Changing the LLM Model
 
@@ -118,7 +142,7 @@ The default model is `google/gemma-2-9b-it:free` via OpenRouter (free, no credit
 }
 ```
 
-**To use Groq (fast + voice transcription):**
+**To use Groq (fast inference):**
 ```json
 {
   "providers": {
@@ -130,9 +154,57 @@ The default model is `google/gemma-2-9b-it:free` via OpenRouter (free, no credit
 }
 ```
 
+**To use a custom OpenAI-compatible endpoint (e.g., local vLLM, Ollama):**
+```json
+{
+  "providers": {
+    "custom": {
+      "api_key": "your-key-or-empty",
+      "api_base": "http://localhost:8000/v1"
+    }
+  },
+  "agents": {
+    "defaults": { "model": "openai/your-model-name" }
+  }
+}
+```
+
+### Voice Transcription Setup
+
+Voice messages from Telegram are transcribed using Groq's Whisper API. To enable this, add a Groq provider **alongside** your main LLM provider:
+
+```json
+{
+  "providers": {
+    "openrouter": { "api_key": "sk-or-..." },
+    "groq": { "api_key": "gsk_..." }
+  }
+}
+```
+
+Get a free Groq API key at [console.groq.com](https://console.groq.com). Without this, voice messages are saved as files but not transcribed.
+
+### Proxy Configuration
+
+If you're behind a firewall or in a restricted region, configure a proxy for Telegram:
+
+```json
+{
+  "channels": {
+    "telegram": {
+      "enabled": true,
+      "token": "...",
+      "proxy": "socks5://user:pass@proxy-host:1080"
+    }
+  }
+}
+```
+
+Supports HTTP and SOCKS5 proxies.
+
 ### Environment Variables
 
-All config values can be set via environment variables with `JOSHBOT_` prefix:
+All config values can be set via environment variables with `JOSHBOT_` prefix and `__` for nesting:
 
 ```bash
 export JOSHBOT_PROVIDERS__OPENROUTER__API_KEY="sk-or-..."
@@ -145,7 +217,8 @@ export JOSHBOT_CHANNELS__TELEGRAM__TOKEN="123456:ABC..."
 1. Open Telegram and message [@BotFather](https://t.me/BotFather)
 2. Send `/newbot` and follow the prompts to create your bot
 3. Copy the bot token
-4. Add to config:
+4. Find your Telegram user ID by messaging [@userinfobot](https://t.me/userinfobot) — it returns a **number** like `123456789`
+5. Add to config:
 
 ```json
 {
@@ -153,21 +226,21 @@ export JOSHBOT_CHANNELS__TELEGRAM__TOKEN="123456:ABC..."
     "telegram": {
       "enabled": true,
       "token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz",
-      "allow_from": ["your_telegram_user_id"]
+      "allow_from": ["123456789"]
     }
   }
 }
 ```
 
-5. Start the gateway: `joshbot gateway`
-6. Message your bot on Telegram!
+> **Important:** `allow_from` takes Telegram **user IDs** (numbers as strings), not usernames. An empty list allows anyone to use your bot.
 
-**Finding your Telegram user ID:** Message [@userinfobot](https://t.me/userinfobot) on Telegram.
+6. Start the gateway: `joshbot gateway`
+7. Message your bot on Telegram!
 
 **Supported media:**
 - Text messages
 - Photos (downloaded and available as attachments)
-- Voice messages (transcribed via Groq Whisper if configured)
+- Voice messages (transcribed via Groq Whisper — see [Voice Transcription Setup](#voice-transcription-setup))
 - Documents (downloaded and referenced)
 
 ## Commands
@@ -197,13 +270,13 @@ These work in both CLI and Telegram:
 joshbot has a two-file memory system that learns from your conversations:
 
 ### MEMORY.md (Long-Term Facts)
-- Location: `~/.joshbot/workspace/memory/MEMORY.md`
+- Location: `~/.joshbot/workspace/memory/MEMORY.md` (default)
 - **Always loaded** into context
 - Contains: user preferences, project context, decisions, important notes
 - Updated automatically during memory consolidation
 
 ### HISTORY.md (Event Log)
-- Location: `~/.joshbot/workspace/memory/HISTORY.md`
+- Location: `~/.joshbot/workspace/memory/HISTORY.md` (default)
 - Append-only log of timestamped conversation summaries
 - Searchable (joshbot uses `grep` to search past events)
 - Each entry is 2-5 sentences with `[YYYY-MM-DD HH:MM]` timestamp
@@ -215,6 +288,15 @@ When a conversation exceeds the memory window (default: 50 messages):
 3. A summary is appended to HISTORY.md
 4. The session is trimmed to recent messages
 
+### Heartbeat (Proactive Tasks)
+
+The heartbeat service (active in gateway mode) reads `~/.joshbot/workspace/HEARTBEAT.md` every 30 minutes. Add tasks in checkbox format and joshbot will process them autonomously:
+
+```markdown
+- [ ] Check if the server is still running
+- [ ] Summarize today's news about AI
+```
+
 ## Skills System
 
 Skills are markdown files that extend joshbot's capabilities without code changes.
@@ -222,9 +304,9 @@ Skills are markdown files that extend joshbot's capabilities without code change
 ### Bundled Skills
 | Skill | Description |
 |-------|-------------|
-| `memory` | Memory system usage (always loaded) |
+| `memory` | Memory system usage (always loaded into context) |
 | `skill-creator` | How to create new skills |
-| `github` | GitHub CLI patterns |
+| `github` | GitHub CLI patterns (requires `gh` binary) |
 | `cron` | Scheduling guidance |
 
 ### Creating Custom Skills
@@ -256,6 +338,8 @@ tags: [development]
 Instructions and examples...
 ```
 
+The `requirements` field supports `bin:name` (checks for binary in PATH) and `env:VAR` (checks for environment variable). Skills with unmet requirements are listed as unavailable.
+
 ## Built-in Tools
 
 | Tool | Description |
@@ -265,7 +349,7 @@ Instructions and examples...
 | `edit_file` | Find-and-replace editing |
 | `list_dir` | List directory contents |
 | `exec` | Execute shell commands (with safety guards) |
-| `web_search` | Search the web (Brave API) |
+| `web_search` | Search the web (requires [Brave API key](https://brave.com/search/api/)) |
 | `web_fetch` | Fetch and extract web page content |
 | `message` | Send messages to channels |
 | `spawn` | Create background tasks |
@@ -285,16 +369,22 @@ The `exec` tool blocks dangerous commands including:
 
 ```bash
 docker build -t joshbot .
-docker run -v ~/.joshbot:/root/.joshbot joshbot gateway
+
+# First-time setup (interactive)
+docker run -it -v ~/.joshbot:/root/.joshbot joshbot onboard
+
+# Run gateway
+docker run -d -v ~/.joshbot:/root/.joshbot joshbot gateway
 ```
 
 ### Docker Compose
 
 ```bash
+# Configure ~/.joshbot/config.json first, then:
 docker compose up -d
 ```
 
-The `-v` mount persists config, sessions, memory, and skills across container restarts.
+The `-v` mount persists config, sessions, memory, and skills across container restarts. You can also pass API keys via environment variables in `docker-compose.yml` — see the comments in that file.
 
 ## Architecture
 
@@ -316,12 +406,44 @@ joshbot/
 - **ReAct loop**: LLM -> tools -> reflect -> repeat (max 20 iterations)
 - **Progressive skill loading**: Minimal context overhead, full content on demand
 - **Plain-file memory**: No databases, just markdown. Simple, debuggable, portable.
+- **Heartbeat**: Reads HEARTBEAT.md every 30 minutes for proactive autonomous tasks
 
-## Requirements
+## Upgrading
 
-- Python 3.11+
-- An LLM API key (OpenRouter free tier works)
+```bash
+cd joshbot
+git pull
+pip install .
+```
+
+Your config, sessions, and memory in `~/.joshbot/` are preserved across upgrades.
+
+## Uninstalling
+
+```bash
+# Remove the package
+pip uninstall joshbot
+
+# Remove all data (config, sessions, memory, media)
+rm -rf ~/.joshbot
+
+# If you set environment variables, remove them from your shell profile:
+# unset JOSHBOT_PROVIDERS__OPENROUTER__API_KEY
+# etc.
+```
+
+## Troubleshooting
+
+**"No providers configured"** — Run `joshbot onboard` or manually create `~/.joshbot/config.json` with at least one provider and API key.
+
+**LLM calls failing** — Check your API key is valid. Run `joshbot status` to verify configuration. Ensure your model name matches the provider (e.g., `claude-sonnet-4-20250514` for Anthropic, `openrouter/...` prefix for OpenRouter).
+
+**Telegram bot not responding** — Verify `channels.telegram.enabled` is `true` and the token is correct. Check that your user ID is in `allow_from` (or that the list is empty). If behind a firewall, configure the `proxy` field.
+
+**`readability-lxml` install fails** — Install system dependencies: `sudo apt install libxml2-dev libxslt-dev` (Debian/Ubuntu) or `brew install libxml2 libxslt` (macOS).
+
+**`web_search` returns errors** — This tool requires a Brave Search API key. Get one at [brave.com/search/api](https://brave.com/search/api/) and set it in `tools.web.search.api_key`.
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -1,0 +1,111 @@
+# joshbot Review Report
+
+Generated: 2026-02-14
+
+---
+
+## Documentation Review (README.md)
+
+### GAPS — Completely Missing
+
+| # | Issue | Severity |
+|---|-------|----------|
+| 1 | **No uninstall instructions** — no guidance on `pip uninstall`, cleaning `~/.joshbot/`, or env vars | HIGH |
+| 2 | **No LICENSE file** — says MIT but no actual LICENSE file exists | HIGH |
+| 3 | **No voice transcription setup** — advertised feature but setup path (Groq key) is hidden | HIGH |
+| 4 | **No troubleshooting / FAQ section** — common failures undocumented | MEDIUM |
+| 5 | **No upgrade instructions** | MEDIUM |
+| 6 | **No proxy config docs** — `TelegramConfig.proxy` exists but isn't in README | MEDIUM |
+| 7 | **`custom` and `vllm` providers undocumented** — self-hosting users have no guidance | MEDIUM |
+| 8 | **No CONTRIBUTING guide** | MEDIUM |
+| 9 | **`api_base` / `extra_headers` provider options undocumented** | MEDIUM |
+| 10 | **Heartbeat feature advertised but never explained** | MEDIUM |
+| 11 | **`gateway` config section (`host`/`port`) not documented** | LOW |
+| 12 | **No `.env.example` file** | LOW |
+| 13 | **No CHANGELOG** | LOW |
+
+### ISSUES — Incorrect or Misleading
+
+| # | Issue | Status |
+|---|-------|--------|
+| 1 | **Line 12 garbled text** — "Provider LLM**- **Multi-" mangled markdown | |
+| 2 | **Line 23 placeholder URL** — `yourusername/joshbot` should be `bigknoxy/joshbot` | |
+| 3 | **No venv in install instructions** — risky bare-metal pip install | |
+| 4 | **`allow_from` values unclear** — should say "Telegram user ID as string (number)" | |
+| 5 | **Empty `allow_from: []` silently allows everyone** — security-critical default undocumented | |
+| 6 | **Docker onboarding gap** — no guidance on interactive `onboard` in container context | |
+| 7 | **Config example incomplete** — missing `proxy`, `gateway`, `api_base`, `workspace`, `max_tool_iterations` | |
+| 8 | **Prerequisites buried at bottom** — Python 3.11+ requirement after Docker section | |
+
+---
+
+## QA Review
+
+### CRITICAL (5 issues)
+
+| # | Issue | File | Status |
+|---|-------|------|--------|
+| 1 | **Shell tool deny-list trivially bypassed** — base64, env vars, pipes, subshells, command chaining all work | `tools/shell.py` | |
+| 2 | **Filesystem symlink bypass** — symlink inside workspace -> read any file on system | `tools/filesystem.py` | |
+| 3 | **Message bus silently drops messages** — if all handlers throw, message is lost with no retry/dead-letter | `bus/queue.py` | |
+| 4 | **Memory consolidation partial failure** — MEMORY.md writes but HISTORY.md fails = inconsistent state | `agent/loop.py` | |
+| 5 | **API keys set as env vars** — could leak via debug logging or child processes | `providers/litellm_provider.py` | |
+
+### HIGH (6 issues)
+
+| # | Issue | File | Status |
+|---|-------|------|--------|
+| 6 | **Shell tool ignores workspace restriction** — `cd / && ls` bypasses `cwd` restriction | `tools/shell.py` | |
+| 7 | **Telegram allowlist checked after initial processing** — metadata could leak | `channels/telegram.py` | |
+| 8 | **Session cache grows unbounded** — no LRU eviction, memory exhaustion risk | `session/manager.py` | |
+| 9 | **Cron recurring job stops permanently on error** — no retry/reschedule | `cron/service.py` | |
+| 10 | **Default `restrict_to_workspace: false`** — new users have no file isolation | `config/schema.py` | |
+| 11 | **Heartbeat re-triggers same tasks** — HEARTBEAT.md never cleared after processing | `heartbeat/service.py` | |
+
+### MEDIUM (6 issues)
+
+| # | Issue | File | Status |
+|---|-------|------|--------|
+| 12 | Dead code / confusing `if False` in skills_summary_fn | `main.py` | |
+| 13 | Race condition in EditFileTool (TOCTOU between read and write) | `tools/filesystem.py` | |
+| 14 | Bus handler exception breaks other handlers in the chain | `bus/queue.py` | |
+| 15 | No timeout on LLM calls during memory consolidation | `agent/loop.py` | |
+| 16 | CLI PromptSession never properly closed | `channels/cli.py` | |
+| 17 | No input validation (empty/huge messages) | `agent/loop.py` | |
+
+### LOW (3 issues)
+
+| # | Issue | File | Status |
+|---|-------|------|--------|
+| 18 | Markdown-to-HTML regex edge cases in Telegram | `channels/telegram.py` | |
+| 19 | Inconsistent error return types across tools | various | |
+| 20 | No input validation on user messages | `agent/loop.py` | |
+
+---
+
+## Recommended Test Coverage Priority
+
+```
+tests/
+├── test_shell_security.py       # CRITICAL - bypass vectors
+├── test_filesystem_security.py  # CRITICAL - symlink attacks
+├── test_message_bus.py          # CRITICAL - message loss
+├── test_memory_consolidation.py # HIGH - partial failure
+├── test_session_manager.py      # HIGH - corruption, memory
+├── test_config_loading.py       # MEDIUM - corrupted config
+└── test_integration.py          # Full flow tests
+```
+
+---
+
+## What's Done Well
+
+- Clear 3-step Quick Start flow
+- Multi-provider config examples with concrete JSON
+- Memory system explanation (MEMORY.md vs HISTORY.md lifecycle)
+- Progressive skill loading levels well-explained
+- Shell safety documentation builds trust
+- Environment variable convention with examples
+- Clean architecture section
+- Complete tools table (all 10 verified)
+- Chat commands table matches implementation


### PR DESCRIPTION
## Summary

- **README.md**: Complete rewrite fixing all issues from docs review
- **LICENSE**: MIT license file (was missing despite README claiming MIT)
- **AGENTS.md**: Coding agent guidelines for build/lint/test commands and code style
- **docs/REVIEW.md**: QA + documentation review tracker with open issues

## README Fixes
- Fix garbled "Multi-Provider LLM" feature line
- Fix placeholder repo URL (`yourusername` -> `bigknoxy`)
- Add venv to install instructions
- Move Requirements/prerequisites before Quick Start
- Add Uninstall section (pip uninstall + ~/.joshbot cleanup)
- Add Voice Transcription setup (Groq as secondary provider)
- Add Proxy Configuration for Telegram
- Document `allow_from` behavior (empty = allow all, with security warning)
- Document custom/vllm providers with `api_base` examples
- Add Heartbeat/proactive tasks section
- Add Docker onboarding guidance (`-it` flag)
- Add Troubleshooting section (7 common issues)
- Add Gemini to provider list

## Review Tracker
`docs/REVIEW.md` tracks outstanding QA findings (5 critical, 6 high, 6 medium) for future work.