### PR TITLE
feat: add one-line install/uninstall scripts via pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,21 @@ A lightweight personal AI assistant with self-learning, long-term memory, skill 
 
 ## Quick Start
 
-### 1. Install
+### Quick Install (Recommended)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash
+```
+
+This installs joshbot via [pipx](https://pipx.pypa.io/) in an isolated environment. Requires Python 3.11+.
+
+After install, run:
+
+```bash
+joshbot onboard
+```
+
+### Manual Install
 
 ```bash
 git clone https://github.com/bigknoxy/joshbot.git
@@ -411,6 +425,18 @@ joshbot/
 ## Upgrading
 
 ```bash
+pipx upgrade joshbot --pip-args='--force-reinstall'
+```
+
+Or reinstall:
+
+```bash
+pipx uninstall joshbot && pipx install "joshbot @ git+https://github.com/bigknoxy/joshbot.git"
+```
+
+If you installed from source:
+
+```bash
 cd joshbot
 git pull
 pip install .
@@ -418,11 +444,24 @@ pip install .
 
 Your config, sessions, and memory in `~/.joshbot/` are preserved across upgrades.
 
-## Uninstalling
+## Uninstall
+
+### Quick Uninstall
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/uninstall.sh | bash
+```
+
+This removes joshbot and optionally cleans up your data directory.
+
+### Manual Uninstall
 
 ```bash
 # Remove the package
 pip uninstall joshbot
+
+# Or if installed with pipx:
+pipx uninstall joshbot
 
 # Remove all data (config, sessions, memory, media)
 rm -rf ~/.joshbot

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors with fallback for non-tty
+if tput setaf 1 >/dev/null 2>&1; then
+    GREEN=$(tput setaf 2)
+    RED=$(tput setaf 1)
+    YELLOW=$(tput setaf 3)
+    RESET=$(tput sgr0)
+else
+    GREEN='\033[0;32m'
+    RED='\033[0;31m'
+    YELLOW='\033[0;33m'
+    RESET='\033[0m'
+fi
+
+info()  { printf "${GREEN}[INFO]${RESET} %s\n" "$1"; }
+success(){ printf "${GREEN}[OK]${RESET} %s\n" "$1"; }
+warn()  { printf "${YELLOW}[WARN]${RESET} %s\n" "$1"; }
+error() { printf "${RED}[ERROR]${RESET} %s\n" "$1" >&2; }
+
+# Check Python 3.11+
+info "Checking Python version..."
+if ! command -v python3 >/dev/null 2>&1; then
+    error "python3 not found. Install Python 3.11+ from https://python.org"
+    exit 1
+fi
+PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+PYTHON_MAJOR=${PYTHON_VERSION%%.*}
+PYTHON_MINOR=${PYTHON_VERSION##*.}
+if [[ "$PYTHON_MAJOR" -lt 3 ]] || [[ "$PYTHON_MAJOR" -eq 3 && "$PYTHON_MINOR" -lt 11 ]]; then
+    error "Python 3.11+ required, found $PYTHON_VERSION"
+    exit 1
+fi
+success "Python $PYTHON_VERSION"
+
+# Check/install pipx
+info "Checking pipx..."
+PIPX="pipx"
+if ! command -v pipx >/dev/null 2>&1; then
+    if python3 -m pipx --version >/dev/null 2>&1; then
+        PIPX="python3 -m pipx"
+    else
+        warn "pipx not found, installing..."
+        python3 -m pip install --user pipx 2>&1 | tail -1
+        python3 -m pipx ensurepath >/dev/null 2>&1 || true
+        PIPX="python3 -m pipx"
+        warn "You may need to restart your shell for PATH changes."
+    fi
+fi
+success "pipx available"
+
+# Check if already installed
+if command -v joshbot >/dev/null 2>&1; then
+    warn "joshbot is already installed."
+    info "To upgrade: pipx upgrade joshbot --pip-args='--force-reinstall'"
+    exit 0
+fi
+
+# Install joshbot
+info "Installing joshbot from GitHub..."
+$PIPX install "joshbot @ git+https://github.com/bigknoxy/joshbot.git" 2>&1 | tail -3
+
+# Verify — check PATH and common pipx locations
+JOSHBOT_BIN=""
+if command -v joshbot >/dev/null 2>&1; then
+    JOSHBOT_BIN="joshbot"
+elif [[ -x "$HOME/.local/bin/joshbot" ]]; then
+    JOSHBOT_BIN="$HOME/.local/bin/joshbot"
+fi
+
+if [[ -n "$JOSHBOT_BIN" ]]; then
+    success "joshbot installed!"
+    printf "\n  Next steps:\n"
+    printf "    joshbot onboard    # First-time setup\n"
+    printf "    joshbot agent      # Start chatting\n\n"
+    if ! command -v joshbot >/dev/null 2>&1; then
+        warn "Add ~/.local/bin to your PATH, then restart your shell."
+    fi
+else
+    error "Installation may have failed. Try: python3 -m pipx run joshbot --help"
+    exit 1
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN='\033[0;32m' RED='\033[0;31m' YELLOW='\033[1;33m' RESET='\033[0m'
+info() { printf "${GREEN}[INFO]${RESET} %s\n" "$1"; }
+success() { printf "${GREEN}[OK]${RESET} %s\n" "$1"; }
+warn() { printf "${YELLOW}[WARN]${RESET} %s\n" "$1"; }
+
+if ! command -v joshbot &>/dev/null && ! pipx list 2>/dev/null | grep -q joshbot; then
+    warn "joshbot is not installed"
+    exit 0
+fi
+
+pipx uninstall joshbot
+success "joshbot uninstalled"
+
+if [[ -d "$HOME/.joshbot" ]]; then
+    if [[ -r /dev/tty ]]; then
+        printf "Remove ~/.joshbot/ data directory? This includes config, memory, and sessions. (y/N): " >&2
+        read -r answer < /dev/tty
+        if [[ "$answer" =~ ^[Yy]$ ]]; then
+            rm -rf "$HOME/.joshbot"
+            success "Removed ~/.joshbot/"
+        else
+            info "Kept ~/.joshbot/"
+        fi
+    else
+        info "Skipped data cleanup (non-interactive)"
+    fi
+fi
+
+success "Uninstall complete"


### PR DESCRIPTION
## Summary

- **install.sh** — One-liner installer: `curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash`
- **uninstall.sh** — One-liner uninstaller: `curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/uninstall.sh | bash`
- **README.md** — Updated with Quick Install/Uninstall sections, pipx upgrade instructions

## Install Script
- Checks Python 3.11+ (exits with clear error if missing)
- Installs pipx if not present, runs ensurepath
- Detects if joshbot already installed (suggests upgrade)
- Installs from GitHub via `pipx install "joshbot @ git+https://github.com/bigknoxy/joshbot.git"`
- Verifies installation, prints next steps

## Uninstall Script
- Removes joshbot via `pipx uninstall joshbot`
- Prompts for `~/.joshbot/` data cleanup (reads from `/dev/tty` for curl-pipe safety)
- Safe default: keeps data unless user explicitly confirms

## Verified
- Both scripts pass `bash -n` syntax check
- Install tested: Python check, pipx check, joshbot install + CLI --help works
- Uninstall tested: pipx uninstall removes binary, ~/.joshbot preserved by default
- Cross-platform: uses printf (not echo -e), no GNU-specific flags