### PR TITLE
fix: update default model and suppress noisy console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Config file: `~/.joshbot/config.json`
   "agents": {
     "defaults": {
       "workspace": "~/.joshbot/workspace",
-      "model": "google/gemma-2-9b-it:free",
+      "model": "arcee-ai/trinity-large-preview:free",
       "max_tokens": 8192,
       "temperature": 0.7,
       "max_tool_iterations": 20,
@@ -125,7 +125,7 @@ Config file: `~/.joshbot/config.json`
 
 ### Changing the LLM Model
 
-The default model is `google/gemma-2-9b-it:free` via OpenRouter (free, no credit card needed).
+The default model is `arcee-ai/trinity-large-preview:free` via OpenRouter (free, no credit card needed).
 
 **To use a better model** (requires OpenRouter credits):
 ```json

--- a/joshbot/config/schema.py
+++ b/joshbot/config/schema.py
@@ -25,7 +25,7 @@ class AgentDefaults(BaseModel):
     """Default agent configuration."""
 
     workspace: str = str(DEFAULT_WORKSPACE)
-    model: str = "google/gemma-2-9b-it:free"
+    model: str = "arcee-ai/trinity-large-preview:free"
     max_tokens: int = 8192
     temperature: float = 0.7
     max_tool_iterations: int = 20

--- a/joshbot/main.py
+++ b/joshbot/main.py
@@ -9,9 +9,14 @@ from pathlib import Path
 from typing import Optional
 
 import typer
+from loguru import logger
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Prompt, Confirm
+
+# Configure loguru to use WARNING level by default (not DEBUG)
+logger.remove()
+logger.add(sys.stderr, level="WARNING")
 
 app = typer.Typer(
     name="joshbot",

--- a/joshbot/providers/litellm_provider.py
+++ b/joshbot/providers/litellm_provider.py
@@ -6,11 +6,15 @@ import json
 import os
 from typing import Any
 
+import litellm
 from loguru import logger
 
 from ..config.schema import Config, ProviderConfig
 from .base import LLMProvider, LLMResponse, ToolCallRequest
 from .registry import PROVIDERS, resolve_model_name
+
+# Suppress litellm's noisy banner messages
+litellm.suppress_debug_info = True
 
 
 class LiteLLMProvider(LLMProvider):


### PR DESCRIPTION
## Summary

- **Default model updated**: Changed from `google/gemma-2-9b-it:free` (removed from OpenRouter, returns 404) to `arcee-ai/trinity-large-preview:free`
- **Suppressed litellm banner noise**: Added `litellm.suppress_debug_info = True` to prevent "Provider List" and "Give Feedback" banners from cluttering stdout
- **Reduced log verbosity**: Set default loguru level to WARNING (was DEBUG), eliminating ~15 lines of debug output on every startup

## Before
```
2026-02-14 05:45:22.656 | DEBUG    | joshbot.tools.registry:register:21 - Registered tool: read_file
2026-02-14 05:45:22.656 | DEBUG    | joshbot.tools.registry:register:21 - Registered tool: write_file
...
Provider List: https://docs.litellm.ai/docs/providers
Provider List: https://docs.litellm.ai/docs/providers
Give Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new
```

## After
Clean startup with only the welcome banner visible.

## Files Changed
- `joshbot/config/schema.py` — new default model
- `joshbot/providers/litellm_provider.py` — litellm suppression
- `joshbot/main.py` — loguru level set to WARNING
- `README.md` — updated model references

## Note for existing users
If your `~/.joshbot/config.json` has an explicit `"model": "google/gemma-2-9b-it:free"`, update it to `"arcee-ai/trinity-large-preview:free"` or remove the key to use the new default.