### PR TITLE
feat: add joshbot update command and version infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-02-14
+
+### Added
+- `joshbot update` command for self-updating (supports pipx, pip, and source installs)
+- `joshbot update --check` to check for available updates without installing
+- `joshbot --version` flag to display current version
+- Version display in `joshbot status` output
+- Config schema versioning with automatic migration framework
+- CHANGELOG.md for tracking release history
+
+### Changed
+- Default model changed to `arcee-ai/trinity-large-preview:free` (previous default `google/gemma-2-9b-it:free` was removed from OpenRouter)
+- Default log level set to WARNING (was DEBUG) for cleaner console output
+- Version is now single source of truth from `joshbot/__init__.py` (pyproject.toml reads it dynamically)
+- Updated README with `joshbot update` as primary upgrade method and Docker upgrade instructions
+
+### Fixed
+- Suppressed litellm banner messages ("Provider List", "Give Feedback") that cluttered console output
+- Removed reference to defunct `google/gemma-2-9b-it:free` model
+
+## [0.1.0] - 2026-02-01
+
+### Added
+- Initial release
+- ReAct agent loop with multi-provider LLM support via litellm
+- Async message bus architecture
+- Telegram channel integration
+- CLI interactive mode
+- Tool system: filesystem, shell, web search/fetch, message, spawn, cron
+- Self-learning memory (MEMORY.md + HISTORY.md)
+- Skill self-creation system
+- Session management (JSONL)
+- Configuration via `~/.joshbot/config.json` with environment variable support
+- First-time onboarding flow (`joshbot onboard`)
+- Docker support with docker-compose
+- pipx-based installation via install.sh

--- a/README.md
+++ b/README.md
@@ -424,17 +424,33 @@ joshbot/
 
 ## Upgrading
 
+The easiest way to update joshbot:
+
+```bash
+joshbot update
+```
+
+Check for updates without installing:
+
+```bash
+joshbot update --check
+```
+
+Check your current version:
+
+```bash
+joshbot --version
+```
+
+### Manual upgrade methods
+
+**pipx (quick install):**
+
 ```bash
 pipx upgrade joshbot --pip-args='--force-reinstall'
 ```
 
-Or reinstall:
-
-```bash
-pipx uninstall joshbot && pipx install "joshbot @ git+https://github.com/bigknoxy/joshbot.git"
-```
-
-If you installed from source:
+**Source install:**
 
 ```bash
 cd joshbot
@@ -442,7 +458,14 @@ git pull
 pip install .
 ```
 
-Your config, sessions, and memory in `~/.joshbot/` are preserved across upgrades.
+**Docker:**
+
+```bash
+docker compose build
+docker compose up -d
+```
+
+Your config, sessions, and memory in `~/.joshbot/` are preserved across upgrades. See [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 ## Uninstall
 

--- a/joshbot/__init__.py
+++ b/joshbot/__init__.py
@@ -1,3 +1,3 @@
 """Joshbot - A lightweight personal AI assistant."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/joshbot/config/loader.py
+++ b/joshbot/config/loader.py
@@ -3,26 +3,36 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from loguru import logger
 
-from .schema import Config, DEFAULT_HOME
+from .schema import CURRENT_SCHEMA_VERSION, Config, DEFAULT_HOME
 
 
 CONFIG_FILE = DEFAULT_HOME / "config.json"
 
 
-def _deep_merge(base: dict, override: dict) -> dict:
-    """Deep merge two dicts, override takes priority."""
-    result = base.copy()
-    for key, value in override.items():
-        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
-            result[key] = _deep_merge(result[key], value)
-        else:
-            result[key] = value
-    return result
+def _migrate_v0_to_v1(raw: dict[str, Any]) -> dict[str, Any]:
+    """Migrate pre-versioned config to schema v1."""
+    raw["schema_version"] = 1
+    # Update defunct model if present
+    agents = raw.get("agents", {})
+    defaults = agents.get("defaults", {})
+    if defaults.get("model") == "google/gemma-2-9b-it:free":
+        defaults["model"] = "arcee-ai/trinity-large-preview:free"
+        logger.info(
+            "Migrated model from google/gemma-2-9b-it:free to arcee-ai/trinity-large-preview:free"
+        )
+    return raw
+
+
+# Registry: from_version -> migration function
+MIGRATIONS: dict[int, Callable[[dict[str, Any]], dict[str, Any]]] = {
+    0: _migrate_v0_to_v1,
+}
 
 
 def load_config() -> Config:
@@ -31,9 +41,47 @@ def load_config() -> Config:
         try:
             raw = json.loads(CONFIG_FILE.read_text())
             logger.debug(f"Loaded config from {CONFIG_FILE}")
+
+            # Check schema version and run migrations if needed
+            schema_version = raw.get("schema_version", 0)
+            if schema_version > CURRENT_SCHEMA_VERSION:
+                logger.warning(
+                    f"Config schema v{schema_version} is newer than supported v{CURRENT_SCHEMA_VERSION}. "
+                    f"You may be running an older version of joshbot."
+                )
+            if schema_version < CURRENT_SCHEMA_VERSION:
+                logger.info(
+                    f"Migrating config from schema v{schema_version} to v{CURRENT_SCHEMA_VERSION}"
+                )
+                # Back up config
+                backup_path = CONFIG_FILE.with_suffix(".json.bak")
+                shutil.copy2(CONFIG_FILE, backup_path)
+                logger.info(f"Backed up config to {backup_path}")
+                # Run migrations sequentially
+                for version in range(schema_version, CURRENT_SCHEMA_VERSION):
+                    if version in MIGRATIONS:
+                        try:
+                            raw = MIGRATIONS[version](raw)
+                            logger.info(
+                                f"Migrated config schema v{version} → v{version + 1}"
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f"Config migration v{version} → v{version + 1} failed: {e}"
+                            )
+                            logger.warning("Using backup config from config.json.bak")
+                            return Config()
+                # Write migrated config back
+                CONFIG_FILE.write_text(json.dumps(raw, indent=2) + "\n")
+                logger.info(f"Wrote migrated config to {CONFIG_FILE}")
+
             return Config(**raw)
+        except json.JSONDecodeError as e:
+            logger.warning(f"Config file is corrupted: {e}, using defaults")
+            return Config()
         except Exception as e:
             logger.warning(f"Failed to load config: {e}, using defaults")
+            return Config()
     return Config()
 
 

--- a/joshbot/config/schema.py
+++ b/joshbot/config/schema.py
@@ -12,6 +12,9 @@ from pydantic_settings import BaseSettings
 DEFAULT_HOME = Path.home() / ".joshbot"
 DEFAULT_WORKSPACE = DEFAULT_HOME / "workspace"
 
+# Schema versioning for config migrations
+CURRENT_SCHEMA_VERSION = 1
+
 
 class ProviderConfig(BaseModel):
     """Configuration for a single LLM provider."""
@@ -91,6 +94,7 @@ class Config(BaseSettings):
 
     model_config = {"env_prefix": "JOSHBOT_", "env_nested_delimiter": "__"}
 
+    schema_version: int = CURRENT_SCHEMA_VERSION
     providers: dict[str, ProviderConfig] = Field(
         default_factory=lambda: {"openrouter": ProviderConfig()}
     )

--- a/joshbot/tools/web.py
+++ b/joshbot/tools/web.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from loguru import logger
 
+from .. import __version__
 from .base import Tool
 
 
@@ -114,7 +115,9 @@ class WebFetchTool(Tool):
             ) as client:
                 response = await client.get(
                     url,
-                    headers={"User-Agent": "Mozilla/5.0 (compatible; joshbot/0.1)"},
+                    headers={
+                        "User-Agent": f"Mozilla/5.0 (compatible; joshbot/{__version__})"
+                    },
                     timeout=20.0,
                 )
                 response.raise_for_status()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "joshbot"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A lightweight personal AI assistant with self-learning, long-term memory, and Telegram integration"
 requires-python = ">=3.11"
 dependencies = [
@@ -27,3 +27,6 @@ joshbot = "joshbot.main:app"
 
 [tool.hatch.build.targets.wheel]
 packages = ["joshbot"]
+
+[tool.hatch.version]
+path = "joshbot/__init__.py"


### PR DESCRIPTION
## Summary

Adds a `joshbot update` self-update command and closes all version/upgrade infrastructure gaps.

## What's New

### `joshbot update` command
- Auto-detects install method (pipx, pip, editable source, Docker)
- Fetches latest version from GitHub releases/tags API
- `--check` / `-c` flag to check without installing
- `--force` / `-f` flag to force reinstall
- Graceful error handling (no network, rate limits, subprocess failures)

### Version infrastructure
- `joshbot --version` flag
- Version displayed in `joshbot status`
- Single source of truth: `joshbot/__init__.py` → `pyproject.toml` reads it via hatch dynamic version
- Dynamic User-Agent in web.py (was hardcoded `joshbot/0.1`)

### Config schema versioning
- `schema_version` field added to Config (currently v1)
- Migration framework: sequential migrations with backup (`config.json.bak`)
- v0→v1 migration: updates defunct `gemma-2-9b-it:free` model to `trinity-large-preview:free`
- Forward-compatibility check: warns if config is from a newer version
- Specific error handling (corrupt JSON vs validation vs migration failures)

### Documentation
- CHANGELOG.md (Keep a Changelog format)
- README "Upgrading" section updated: `joshbot update` as primary method + Docker instructions
- References to CHANGELOG for release notes

## Files Changed (8)
- `joshbot/main.py` — update command, --version flag, version in status, TYPE_CHECKING imports
- `joshbot/config/schema.py` — CURRENT_SCHEMA_VERSION constant, schema_version field
- `joshbot/config/loader.py` — migration framework, backup, forward-compat, specific error handling
- `joshbot/__init__.py` — version bump to 0.2.0
- `pyproject.toml` — dynamic version via hatch
- `joshbot/tools/web.py` — dynamic User-Agent version
- `README.md` — updated upgrading section
- `CHANGELOG.md` — new file

## Verification
- [x] `joshbot --version` → `joshbot v0.2.0`
- [x] `joshbot status` → shows version
- [x] `joshbot update --check` → works (graceful no-network handling)
- [x] `joshbot update` → works (graceful no-network handling)
- [x] Config migration v0→v1 → correctly migrates old model + adds schema_version
- [x] Version comparison logic → tested with multiple cases
- [x] `pip show joshbot` → Version: 0.2.0 (hatch dynamic version works)
- [x] Full code review pass (main.py + loader.py) → all issues fixed

## Post-merge
Create GitHub release `v0.2.0` so `joshbot update --check` can detect it:
```bash
gh release create v0.2.0 --title "v0.2.0" --notes "See CHANGELOG.md"
```