### PR TITLE
Add OpenRC support and cron @reboot fallback for onboarding

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
@@ -1055,6 +1056,9 @@ func runOnboard(c *cli.Context) error {
 		if err := doServiceInstall(); err != nil {
 			fmt.Printf("Warning: Could not install service: %v\n", err)
 			fmt.Println("You can run 'joshbot service install' manually later.")
+			if err := promptCronStartupFallback(); err != nil {
+				fmt.Printf("Warning: Could not configure cron startup fallback: %v\n", err)
+			}
 		}
 	}
 
@@ -1330,6 +1334,80 @@ func promptServiceInstall() bool {
 	fmt.Scanln(&choice)
 
 	return choice == "1"
+}
+
+func promptCronStartupFallback() error {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+
+	fmt.Println("\nAutomatic startup fallback")
+	fmt.Println("I can install a cron @reboot entry to start joshbot on boot.")
+	fmt.Println("  1. Yes, install cron startup fallback")
+	fmt.Println("  2. No, I will configure startup manually")
+	fmt.Printf("Choice [2]: ")
+
+	var choice string
+	fmt.Scanln(&choice)
+	if choice != "1" {
+		return nil
+	}
+
+	if err := installCronStartupEntry(); err != nil {
+		return err
+	}
+
+	fmt.Println("Cron startup fallback installed.")
+	return nil
+}
+
+func installCronStartupEntry() error {
+	if _, err := exec.LookPath("crontab"); err != nil {
+		return fmt.Errorf("crontab not found")
+	}
+
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to detect executable path: %w", err)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to detect home directory: %w", err)
+	}
+
+	logPath := filepath.Join(home, ".joshbot", "logs", "gateway.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+		return fmt.Errorf("failed to create log directory: %w", err)
+	}
+
+	entry := fmt.Sprintf("@reboot %s gateway >> %s 2>&1", execPath, logPath)
+
+	existing, err := exec.Command("crontab", "-l").CombinedOutput()
+	existingText := strings.TrimSpace(string(existing))
+	if err != nil && existingText != "" && !strings.Contains(existingText, "no crontab for") {
+		return fmt.Errorf("failed to read existing crontab: %w", err)
+	}
+
+	if strings.Contains(existingText, entry) {
+		return nil
+	}
+
+	var newCron string
+	if existingText == "" || strings.Contains(existingText, "no crontab for") {
+		newCron = entry + "\n"
+	} else {
+		newCron = existingText + "\n" + entry + "\n"
+	}
+
+	cmd := exec.Command("crontab", "-")
+	cmd.Stdin = strings.NewReader(newCron)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to install cron entry: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	return nil
 }
 
 func doServiceInstall() error {

--- a/internal/service/factory_linux.go
+++ b/internal/service/factory_linux.go
@@ -2,10 +2,19 @@
 
 package service
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
 
 func newSystemdManager(cfg Config) (Manager, error) {
 	return newSystemd(cfg)
+}
+
+func newOpenRCManager(cfg Config) (Manager, error) {
+	return newOpenRC(cfg)
 }
 
 func newLaunchdManager(cfg Config) (Manager, error) {
@@ -17,5 +26,28 @@ func newUnsupportedManager() (Manager, error) {
 }
 
 func NewManager(cfg Config) (Manager, error) {
-	return newSystemdManager(cfg)
+	if hasCommand("systemctl") {
+		return newSystemdManager(cfg)
+	}
+
+	if isAlpineLinux() || hasCommand("rc-update") {
+		return newOpenRCManager(cfg)
+	}
+
+	return nil, ErrSystemdNotDetected
+}
+
+func hasCommand(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+func isAlpineLinux() bool {
+	content, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		return false
+	}
+
+	osRelease := strings.ToLower(string(content))
+	return strings.Contains(osRelease, "id=alpine") || strings.Contains(osRelease, "id_like=alpine")
 }

--- a/internal/service/launchd.go
+++ b/internal/service/launchd.go
@@ -31,6 +31,13 @@ func newLaunchd(cfg Config) (Manager, error) {
 		home, _ := os.UserHomeDir()
 		cfg.WorkingDir = filepath.Join(home, ".joshbot")
 	}
+	if cfg.ExecPath == "" {
+		execPath, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("failed to detect executable path: %w", err)
+		}
+		cfg.ExecPath = execPath
+	}
 
 	home, _ := os.UserHomeDir()
 	agentsDir := filepath.Join(home, "Library", "LaunchAgents")

--- a/internal/service/openrc.go
+++ b/internal/service/openrc.go
@@ -1,0 +1,164 @@
+//go:build linux
+
+package service
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type openrcManager struct {
+	config     Config
+	scriptPath string
+	isRoot     bool
+}
+
+func newOpenRC(cfg Config) (*openrcManager, error) {
+	if cfg.Name == "" {
+		cfg.Name = "joshbot"
+	}
+	if cfg.DisplayName == "" {
+		cfg.DisplayName = "Joshbot AI Assistant"
+	}
+	if cfg.Description == "" {
+		cfg.Description = "Personal AI assistant with Telegram integration"
+	}
+	if cfg.WorkingDir == "" {
+		home, _ := os.UserHomeDir()
+		cfg.WorkingDir = filepath.Join(home, ".joshbot")
+	}
+	if cfg.ExecPath == "" {
+		execPath, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("failed to detect executable path: %w", err)
+		}
+		cfg.ExecPath = execPath
+	}
+
+	return &openrcManager{
+		config:     cfg,
+		scriptPath: filepath.Join("/etc/init.d", cfg.Name),
+		isRoot:     os.Geteuid() == 0,
+	}, nil
+}
+
+func (o *openrcManager) Name() string { return "openrc" }
+
+func (o *openrcManager) IsInstalled() bool {
+	_, err := os.Stat(o.scriptPath)
+	return err == nil
+}
+
+func (o *openrcManager) Install() (Result, error) {
+	if o.IsInstalled() {
+		return Result{}, fmt.Errorf("service already installed at %s", o.scriptPath)
+	}
+
+	script := fmt.Sprintf(`#!/sbin/openrc-run
+name="%s"
+description="%s"
+
+command="%s"
+command_args="gateway"
+command_background=true
+pidfile="/run/%s.pid"
+directory="%s"
+
+depend() {
+    need net
+}
+`, o.config.DisplayName, o.config.Description, o.config.ExecPath, o.config.Name, o.config.WorkingDir)
+
+	tmpFile, err := os.CreateTemp("", "joshbot-openrc-*.tmp")
+	if err != nil {
+		return Result{}, fmt.Errorf("failed to create temp init script: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(script); err != nil {
+		return Result{}, fmt.Errorf("failed to write init script: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return Result{}, fmt.Errorf("failed to close temp script: %w", err)
+	}
+
+	if err := o.runCommand("cp", tmpFile.Name(), o.scriptPath); err != nil {
+		return Result{}, fmt.Errorf("failed to install init script: %w", err)
+	}
+	if err := o.runCommand("chmod", "755", o.scriptPath); err != nil {
+		return Result{}, fmt.Errorf("failed to set init script permissions: %w", err)
+	}
+	if err := o.runCommand("rc-update", "add", o.config.Name, "default"); err != nil {
+		return Result{}, fmt.Errorf("failed to enable service in OpenRC: %w", err)
+	}
+
+	return Result{Success: true, Message: "OpenRC service installed successfully", LogPath: "rc-service joshbot status"}, nil
+}
+
+func (o *openrcManager) Uninstall() (Result, error) {
+	if !o.IsInstalled() {
+		return Result{}, fmt.Errorf("service not installed")
+	}
+
+	_ = o.runCommand("rc-service", o.config.Name, "stop")
+	_ = o.runCommand("rc-update", "del", o.config.Name, "default")
+
+	if err := o.runCommand("rm", o.scriptPath); err != nil {
+		return Result{}, fmt.Errorf("failed to remove init script: %w", err)
+	}
+
+	return Result{Success: true, Message: "OpenRC service uninstalled successfully"}, nil
+}
+
+func (o *openrcManager) Start() error {
+	if !o.IsInstalled() {
+		return fmt.Errorf("service not installed")
+	}
+	return o.runCommand("rc-service", o.config.Name, "start")
+}
+
+func (o *openrcManager) Stop() error {
+	if !o.IsInstalled() {
+		return fmt.Errorf("service not installed")
+	}
+	return o.runCommand("rc-service", o.config.Name, "stop")
+}
+
+func (o *openrcManager) Status() (Status, error) {
+	if !o.IsInstalled() {
+		return Status{Installed: false, Running: false, Status: "not installed"}, nil
+	}
+
+	out, err := exec.Command("rc-service", o.config.Name, "status").CombinedOutput()
+	output := strings.ToLower(string(out))
+	running := strings.Contains(output, "started") || strings.Contains(output, "status: started")
+	if err != nil && !running {
+		return Status{Installed: true, Running: false, Status: strings.TrimSpace(string(out))}, nil
+	}
+
+	status := "stopped"
+	if running {
+		status = "running"
+	}
+	return Status{Installed: true, Running: running, Status: status}, nil
+}
+
+func (o *openrcManager) runCommand(name string, args ...string) error {
+	var cmd *exec.Cmd
+	if o.isRoot {
+		cmd = exec.Command(name, args...)
+	} else {
+		cmd = exec.Command("sudo", append([]string{name}, args...)...)
+	}
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		if len(out) > 0 {
+			return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/service/systemd.go
+++ b/internal/service/systemd.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ErrSystemdNotDetected is returned when systemd is not available on the system.
-var ErrSystemdNotDetected = fmt.Errorf("systemd not detected. You may need to use a different init system or run 'joshbot gateway' manually")
+var ErrSystemdNotDetected = fmt.Errorf("systemd not detected. On Alpine/OpenRC systems use an OpenRC service, a crond @reboot entry, or run joshbot in a container with --restart unless-stopped")
 
 // checkSystemctl checks if systemctl exists in PATH.
 func checkSystemctl() error {
@@ -46,6 +46,13 @@ func newSystemd(cfg Config) (*systemdManager, error) {
 	if cfg.WorkingDir == "" {
 		home, _ := os.UserHomeDir()
 		cfg.WorkingDir = filepath.Join(home, ".joshbot")
+	}
+	if cfg.ExecPath == "" {
+		execPath, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("failed to detect executable path: %w", err)
+		}
+		cfg.ExecPath = execPath
 	}
 
 	return &systemdManager{


### PR DESCRIPTION
### Motivation
- Improve onboarding/service install UX on non-systemd Linux (Alpine/OpenRC) by performing a real installation instead of only showing guidance.
- Provide a practical automatic fallback (`crontab @reboot`) when service installation cannot be performed so users get a working startup path.
- Make service managers more robust when callers omit `ExecPath` by deriving the executable path automatically.

### Description
- Add an OpenRC service manager (`internal/service/openrc.go`) that installs an `/etc/init.d/joshbot` script, enables it with `rc-update add ... default`, and implements `Install`, `Uninstall`, `Start`, `Stop`, and `Status` methods.
- Update the Linux factory (`internal/service/factory_linux.go`) so `NewManager` detects the init system and returns a systemd manager when `systemctl` exists or an OpenRC manager when Alpine/OpenRC is detected.
- Improve `systemd` and `launchd` managers to populate `ExecPath` from `os.Executable()` when `ExecPath` is not provided to avoid invalid service definitions.
- Enhance the onboarding flow (`cmd/joshbot/main.go`) to prompt for and install a `crontab` `@reboot` entry as an interactive fallback when automatic service installation fails, including log directory creation and duplicate-entry protection.

### Testing
- Ran formatting with `go fmt ./cmd/joshbot ./internal/service` which completed successfully.
- Ran unit/integration tests with `go test ./...` and all testable packages passed.
- Performed cross-platform builds with `GOOS=linux GOARCH=amd64 go build ./... && GOOS=darwin GOARCH=arm64 go build ./... && GOOS=windows GOARCH=amd64 go build ./...` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc05789f88329ac46dd8bf6b37360)