### PR TITLE
feat: MultiProvider fallback system and configure command (v1.3.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           if [ "$GOOS" = "windows" ]; then
             EXTENSION=".exe"
           fi
-          OUTPUT_NAME="joshbot_${VERSION}_${GOOS}_${GOARCH}${EXTENSION}"
+          OUTPUT_NAME="joshbot_${{ steps.version.outputs.version }}_${GOOS}_${GOARCH}${EXTENSION}"
           go build -ldflags="-s -w -X github.com/bigknoxy/joshbot/cmd/joshbot.Version=${{ steps.version.outputs.version }}" \
             -trimpath \
             -o "$OUTPUT_NAME" \

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -104,6 +104,21 @@ func runApp() error {
 				Action: runStatus,
 			},
 			{
+				Name:  "configure",
+				Usage: "Configure LLM providers and settings",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "list",
+						Usage: "List configured providers",
+					},
+					&cli.BoolFlag{
+						Name:  "default",
+						Usage: "Set default provider",
+					},
+				},
+				Action: runConfigure,
+			},
+			{
 				Name:   "update",
 				Usage:  "Update joshbot to the latest version",
 				Action: runUpdate,
@@ -180,7 +195,7 @@ func loadConfig(cfgPath string) (*config.Config, error) {
 }
 
 // setupComponents initializes all required components.
-func setupComponents(cfg *config.Config) (*bus.MessageBus, *providers.LiteLLMProvider, *session.Manager, *agent.Agent, *tools.Registry, *tools.BusMessageSender, error) {
+func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *session.Manager, *agent.Agent, *tools.Registry, *tools.BusMessageSender, error) {
 	// Ensure directories exist
 	if err := cfg.EnsureDirs(); err != nil {
 		return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create directories: %w", err)
@@ -209,19 +224,61 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, *providers.LiteLLMPro
 	// Create BusMessageSender for tools that need to send messages
 	messageSender := tools.NewBusMessageSender(msgBus)
 
-	// Initialize provider - convert config to provider config
-	providerCfg := providers.DefaultConfig()
-	providerCfg.APIKey = getProviderAPIKey(cfg)
-	providerCfg.Model = cfg.Agents.Defaults.Model
-	providerCfg.MaxTokens = cfg.Agents.Defaults.MaxTokens
-	providerCfg.Temperature = cfg.Agents.Defaults.Temperature
+	// Get logger
+	logger := log.Get()
 
-	// Get API base from provider config
-	if p, ok := cfg.Providers["openrouter"]; ok {
-		providerCfg.APIBase = p.APIBase
+	// Create MultiProvider instead of single provider
+	multiProvider := providers.NewMultiProvider(providers.MultiProviderConfig{
+		DefaultProvider: cfg.ProviderDefaults.Default,
+		Logger:          &providers.DefaultLogger{},
+	})
+	if cfg.ProviderDefaults.Default == "" {
+		multiProvider.SetDefault("openrouter")
 	}
 
-	provider := providers.NewLiteLLMProvider(providerCfg)
+	// Register OpenRouter (always registered if configured)
+	if p, ok := cfg.Providers["openrouter"]; ok && p.APIKey != "" {
+		openrouterProvider := providers.NewLiteLLMProvider(providers.Config{
+			APIKey:       p.APIKey,
+			APIBase:      p.APIBase,
+			ExtraHeaders: p.ExtraHeaders,
+			Model:        cfg.Agents.Defaults.Model,
+			MaxTokens:    cfg.Agents.Defaults.MaxTokens,
+			Temperature:  cfg.Agents.Defaults.Temperature,
+		})
+		multiProvider.Register("openrouter", openrouterProvider, cfg.Agents.Defaults.Model, 0)
+	}
+
+	// Register Groq (if configured)
+	if p, ok := cfg.Providers["groq"]; ok && p.APIKey != "" && p.Enabled {
+		groqProvider := providers.NewLiteLLMProvider(providers.Config{
+			APIKey:       p.APIKey,
+			APIBase:      p.APIBase,
+			ExtraHeaders: p.ExtraHeaders,
+		})
+		priority := len(cfg.ProviderDefaults.FallbackOrder) + 1
+		if idx := indexOf(cfg.ProviderDefaults.FallbackOrder, "groq"); idx >= 0 {
+			priority = idx + 1
+		}
+		multiProvider.Register("groq", groqProvider, "", priority)
+	}
+
+	// Register Ollama (if configured)
+	if p, ok := cfg.Providers["ollama"]; ok && p.Enabled {
+		apiBase := p.APIBase
+		if apiBase == "" {
+			apiBase = "http://localhost:11434"
+		}
+		ollamaProvider := providers.NewLiteLLMProvider(providers.Config{
+			APIBase:      apiBase,
+			ExtraHeaders: p.ExtraHeaders,
+		})
+		priority := len(cfg.ProviderDefaults.FallbackOrder) + 1
+		if idx := indexOf(cfg.ProviderDefaults.FallbackOrder, "ollama"); idx >= 0 {
+			priority = idx + 1
+		}
+		multiProvider.Register("ollama", ollamaProvider, "", priority)
+	}
 
 	// Initialize session manager
 	sessionMgr, err := session.NewManager(cfg.SessionsDir())
@@ -229,13 +286,10 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, *providers.LiteLLMPro
 		return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create session manager: %w", err)
 	}
 
-	// Get logger
-	logger := log.Get()
-
 	// Build context budgeting/compression components
 	registry := ctxpkg.NewRegistry()
 	budget := ctxpkg.NewBudgetManager(registry, 100)
-	compressor := &ctxpkg.Compressor{Provider: provider}
+	compressor := &ctxpkg.Compressor{Provider: multiProvider}
 
 	// Create tools registry with defaults
 	toolsRegistry := tools.RegistryWithDefaults(
@@ -249,7 +303,7 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, *providers.LiteLLMPro
 	// Create agent with tools registry
 	agentInstance := agent.NewAgent(
 		cfg,
-		provider,
+		multiProvider,
 		toolsRegistry,
 		sessionMgr,
 		logger,
@@ -267,22 +321,22 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, *providers.LiteLLMPro
 	hb.Start()
 
 	// Start consolidator (self-learning memory consolidation)
-	consolidator := learning.NewConsolidator(memoryManager, provider, 10*time.Minute)
+	consolidator := learning.NewConsolidator(memoryManager, multiProvider, 10*time.Minute)
 	consolidator.Start()
 
 	logger.Info("Background services started", "cron_jobs_file", cfg.Agents.Defaults.Workspace)
 
-	return msgBus, provider, sessionMgr, agentInstance, toolsRegistry, messageSender, nil
+	return msgBus, multiProvider, sessionMgr, agentInstance, toolsRegistry, messageSender, nil
 }
 
-// getProviderAPIKey extracts the first available API key from config.
-func getProviderAPIKey(cfg *config.Config) string {
-	for _, p := range cfg.Providers {
-		if p.APIKey != "" {
-			return p.APIKey
+// indexOf returns the index of needle in haystack, or -1 if not found.
+func indexOf(haystack []string, needle string) int {
+	for i, s := range haystack {
+		if s == needle {
+			return i
 		}
 	}
-	return ""
+	return -1
 }
 
 // setupGracefulShutdown sets up signal handling for graceful shutdown.
@@ -420,9 +474,13 @@ func runUpdate(c *cli.Context) error {
 	tmpFile := filepath.Join(tmpDir, ".joshbot_new")
 
 	// Build download URL
+	extension := ""
+	if runtime.GOOS == "windows" {
+		extension = ".exe"
+	}
 	downloadURL := fmt.Sprintf(
-		"https://github.com/bigknoxy/joshbot/releases/download/%s/joshbot_%s_%s",
-		latestVersion, runtime.GOOS, runtime.GOARCH,
+		"https://github.com/bigknoxy/joshbot/releases/download/%s/joshbot_%s_%s_%s%s",
+		latestVersion, latestVersion, runtime.GOOS, runtime.GOARCH, extension,
 	)
 
 	if err := downloadBinary(downloadURL, tmpFile); err != nil {
@@ -472,7 +530,7 @@ func runUpdate(c *cli.Context) error {
 // getVersion returns the current version string.
 func getVersion() string {
 	if Version == "dev" {
-		return "v0.0.0"
+		return "dev"
 	}
 	// Ensure version has v prefix
 	if !strings.HasPrefix(Version, "v") {
@@ -1593,6 +1651,391 @@ func runStatus(c *cli.Context) error {
 	}
 
 	return nil
+}
+
+// runConfigure handles the configure command.
+func runConfigure(c *cli.Context) error {
+	// Load existing config
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	// --list flag: show providers and exit
+	if c.Bool("list") {
+		return listProviders(cfg)
+	}
+
+	// Interactive wizard
+	return runConfigureWizard(cfg)
+}
+
+// listProviders displays the configured providers.
+func listProviders(cfg *config.Config) error {
+	fmt.Println()
+	fmt.Println("╔═══════════════════════════════════════════╗")
+	fmt.Println("║        Configured Providers              ║")
+	fmt.Println("╚═══════════════════════════════════════════╝")
+	fmt.Println()
+
+	providers := []string{"openrouter", "groq", "ollama"}
+	defaultProvider := cfg.ProviderDefaults.Default
+
+	for _, name := range providers {
+		p, exists := cfg.Providers[name]
+		isDefault := name == defaultProvider
+		statusIcon := "○"
+		statusText := "not configured"
+
+		if exists && p.APIKey != "" {
+			statusIcon = "✓"
+			statusText = "configured"
+		}
+		if isDefault {
+			statusText += " (default)"
+		}
+
+		fmt.Printf("  %s %-12s %s\n", statusIcon, name, statusText)
+	}
+
+	fmt.Println()
+	return nil
+}
+
+// runConfigureWizard runs the interactive provider configuration wizard.
+func runConfigureWizard(cfg *config.Config) error {
+	providers := []string{"openrouter", "groq", "ollama"}
+
+	for {
+		// Display current state
+		fmt.Println()
+		fmt.Println("╔═══════════════════════════════════════════╗")
+		fmt.Println("║        Configure LLM Providers           ║")
+		fmt.Println("╚═══════════════════════════════════════════╝")
+		fmt.Println()
+		fmt.Println("Current providers:")
+
+		defaultProvider := cfg.ProviderDefaults.Default
+		for _, name := range providers {
+			p, exists := cfg.Providers[name]
+			isDefault := name == defaultProvider
+			icon := "○"
+			status := "not configured"
+
+			if exists && p.APIKey != "" {
+				icon = "✓"
+				status = "configured"
+			}
+			if isDefault {
+				status += " (default)"
+			}
+
+			fmt.Printf("  %s %s (%s)\n", icon, getProviderDisplayName(name), status)
+		}
+
+		fmt.Println()
+		fmt.Println("What would you like to do?")
+		fmt.Println("  1. Configure OpenRouter")
+		fmt.Println("  2. Configure Groq")
+		fmt.Println("  3. Configure Ollama")
+		fmt.Println("  4. Set default provider")
+		fmt.Println("  5. Configure fallback order")
+		fmt.Println("  6. Done")
+		fmt.Println()
+
+		fmt.Print("Choice [6]: ")
+
+		var choice string
+		fmt.Scanln(&choice)
+		if choice == "" {
+			choice = "6"
+		}
+
+		switch choice {
+		case "1":
+			cfg = configureProvider(cfg, "openrouter")
+		case "2":
+			cfg = configureProvider(cfg, "groq")
+		case "3":
+			cfg = configureProvider(cfg, "ollama")
+		case "4":
+			cfg = setDefaultProvider(cfg)
+		case "5":
+			cfg = configureFallbackOrder(cfg)
+		case "6":
+			// Save and exit
+			if err := config.Save(cfg); err != nil {
+				return fmt.Errorf("failed to save config: %w", err)
+			}
+			fmt.Println("\nConfiguration saved.")
+			return nil
+		default:
+			fmt.Println("Invalid choice. Please try again.")
+		}
+	}
+}
+
+// getProviderDisplayName returns the display name for a provider.
+func getProviderDisplayName(name string) string {
+	switch name {
+	case "openrouter":
+		return "OpenRouter"
+	case "groq":
+		return "Groq"
+	case "ollama":
+		return "Ollama"
+	default:
+		return name
+	}
+}
+
+// configureProvider prompts the user to configure a specific provider.
+func configureProvider(cfg *config.Config, provider string) *config.Config {
+	// Initialize providers map if needed
+	if cfg.Providers == nil {
+		cfg.Providers = make(map[string]config.ProviderConfig)
+	}
+
+	p, exists := cfg.Providers[provider]
+
+	fmt.Printf("\n=== Configure %s ===\n", getProviderDisplayName(provider))
+	fmt.Println()
+
+	// Get API key
+	fmt.Print("API key")
+	if exists && p.APIKey != "" {
+		fmt.Printf(" [%s]", maskAPIKey(p.APIKey))
+	}
+	fmt.Print(": ")
+
+	var apiKey string
+	fmt.Scanln(&apiKey)
+	apiKey = strings.TrimSpace(apiKey)
+
+	// If user entered something, use it; otherwise keep existing
+	if apiKey != "" {
+		p.APIKey = apiKey
+	}
+
+	// Get API base URL (different for each provider)
+	var apiBase string
+	switch provider {
+	case "openrouter":
+		if exists && p.APIBase != "" {
+			fmt.Printf("API base URL [%s]: ", p.APIBase)
+		} else {
+			fmt.Print("API base URL [https://openrouter.ai/api/v1]: ")
+		}
+		fmt.Scanln(&apiBase)
+		if apiBase == "" {
+			if p.APIBase == "" {
+				apiBase = "https://openrouter.ai/api/v1"
+			} else {
+				apiBase = p.APIBase
+			}
+		}
+		p.APIBase = strings.TrimSpace(apiBase)
+	case "groq":
+		if exists && p.APIBase != "" {
+			fmt.Printf("API base URL [%s]: ", p.APIBase)
+		} else {
+			fmt.Print("API base URL [https://api.groq.com/openai/v1]: ")
+		}
+		fmt.Scanln(&apiBase)
+		if apiBase == "" {
+			if p.APIBase == "" {
+				apiBase = "https://api.groq.com/openai/v1"
+			} else {
+				apiBase = p.APIBase
+			}
+		}
+		p.APIBase = strings.TrimSpace(apiBase)
+	case "ollama":
+		if exists && p.APIBase != "" {
+			fmt.Printf("Ollama base URL [%s]: ", p.APIBase)
+		} else {
+			fmt.Print("Ollama base URL [http://localhost:11434]: ")
+		}
+		fmt.Scanln(&apiBase)
+		if apiBase == "" {
+			if p.APIBase == "" {
+				apiBase = "http://localhost:11434"
+			} else {
+				apiBase = p.APIBase
+			}
+		}
+		p.APIBase = strings.TrimSpace(apiBase)
+	}
+
+	// Validate credentials if API key was provided
+	if p.APIKey != "" {
+		fmt.Println("\nValidating credentials...")
+		if err := validateProviderCredentials(provider, p.APIKey, p.APIBase); err != nil {
+			fmt.Printf("Warning: %v\n", err)
+			fmt.Print("Save anyway? (y/N): ")
+			var confirm string
+			fmt.Scanln(&confirm)
+			if strings.ToLower(confirm) != "y" {
+				return cfg
+			}
+		} else {
+			fmt.Println("Credentials validated successfully!")
+		}
+	}
+
+	p.Enabled = true
+	cfg.Providers[provider] = p
+
+	// If this is the first provider, set it as default
+	if cfg.ProviderDefaults.Default == "" {
+		cfg.ProviderDefaults.Default = provider
+	}
+
+	fmt.Println()
+	return cfg
+}
+
+// validateProviderCredentials tests the API credentials for a provider.
+func validateProviderCredentials(provider, apiKey, apiBase string) error {
+	switch provider {
+	case "openrouter", "groq":
+		// Test call to list models
+		req, err := http.NewRequest("GET", apiBase+"/models", nil)
+		if err != nil {
+			return fmt.Errorf("connection failed: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("connection failed: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == 401 {
+			return fmt.Errorf("invalid API key")
+		}
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		}
+		return nil
+	case "ollama":
+		resp, err := http.Get(apiBase + "/api/tags")
+		if err != nil {
+			return fmt.Errorf("cannot connect to Ollama at %s", apiBase)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		}
+		return nil
+	}
+	return nil
+}
+
+// setDefaultProvider prompts the user to select the default provider.
+func setDefaultProvider(cfg *config.Config) *config.Config {
+	// Find configured providers
+	var configured []string
+	for name, p := range cfg.Providers {
+		if p.APIKey != "" {
+			configured = append(configured, name)
+		}
+	}
+
+	if len(configured) == 0 {
+		fmt.Println("\nNo providers configured yet. Configure a provider first.")
+		return cfg
+	}
+
+	fmt.Println("\n=== Set Default Provider ===")
+	fmt.Println()
+
+	for i, name := range configured {
+		marker := " "
+		if name == cfg.ProviderDefaults.Default {
+			marker = "*"
+		}
+		fmt.Printf("  %d. %s %s\n", i+1, marker, getProviderDisplayName(name))
+	}
+	fmt.Println()
+
+	fmt.Print("Select default provider: ")
+
+	var choice int
+	fmt.Scanln(&choice)
+
+	if choice < 1 || choice > len(configured) {
+		fmt.Println("Invalid choice.")
+		return cfg
+	}
+
+	cfg.ProviderDefaults.Default = configured[choice-1]
+	fmt.Printf("\nDefault provider set to: %s\n", getProviderDisplayName(cfg.ProviderDefaults.Default))
+
+	return cfg
+}
+
+// configureFallbackOrder prompts the user to configure the fallback order.
+func configureFallbackOrder(cfg *config.Config) *config.Config {
+	// Find configured providers
+	var configured []string
+	for name, p := range cfg.Providers {
+		if p.APIKey != "" {
+			configured = append(configured, name)
+		}
+	}
+
+	if len(configured) < 2 {
+		fmt.Println("\nNeed at least 2 configured providers for fallback.")
+		return cfg
+	}
+
+	fmt.Println("\n=== Configure Fallback Order ===")
+	fmt.Println()
+	fmt.Println("Current fallback order:")
+	if len(cfg.ProviderDefaults.FallbackOrder) == 0 {
+		fmt.Println("  (not set - will use providers as configured)")
+	} else {
+		for i, name := range cfg.ProviderDefaults.FallbackOrder {
+			fmt.Printf("  %d. %s\n", i+1, getProviderDisplayName(name))
+		}
+	}
+	fmt.Println()
+	fmt.Println("Available providers:")
+	for i, name := range configured {
+		fmt.Printf("  %d. %s\n", i+1, getProviderDisplayName(name))
+	}
+	fmt.Println()
+	fmt.Print("Enter fallback order (e.g., 1,2,3): ")
+
+	var orderStr string
+	fmt.Scanln(&orderStr)
+	orderStr = strings.TrimSpace(orderStr)
+
+	if orderStr == "" {
+		cfg.ProviderDefaults.FallbackOrder = nil
+		fmt.Println("\nFallback order cleared.")
+		return cfg
+	}
+
+	// Parse order
+	var order []string
+	parts := strings.Split(orderStr, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if idx, err := strconv.Atoi(part); err == nil && idx >= 1 && idx <= len(configured) {
+			order = append(order, configured[idx-1])
+		}
+	}
+
+	if len(order) == 0 {
+		fmt.Println("Invalid order, keeping current.")
+		return cfg
+	}
+
+	cfg.ProviderDefaults.FallbackOrder = order
+	fmt.Println("\nFallback order updated.")
+
+	return cfg
 }
 
 // runServiceInstall installs joshbot as a system service.

--- a/docs/CONFIGURE_COMMAND_DESIGN.md
+++ b/docs/CONFIGURE_COMMAND_DESIGN.md
@@ -1,0 +1,371 @@
+# joshbot configure Command Design
+
+## 1. User Flow Diagram
+
+### Command Structure
+
+```
+joshbot configure              # Interactive wizard (all steps)
+joshbot configure --list        # Show configured providers
+joshbot configure --add <prov>  # Add specific provider (interactive)
+joshbot configure --remove <prov>  # Remove a provider
+joshbot configure --default <prov> # Set default provider
+joshbot configure --fallback   # Configure fallback order
+```
+
+### Interactive Wizard Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    joshbot configure                           │
+│                    (Interactive Wizard)                        │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  [Step 1] Current Configuration                                │
+│  ─────────────────────────────────────                          │
+│  Configured Providers:                                          │
+│    ✓ openrouter  (default)  sk-or-v1-abc****1234              │
+│    ✗ groq        (fallback) gsk_****wxyz                       │
+│    ✗ ollama     (fallback) http://localhost:11434              │
+│                                                                 │
+│  [1] Add a new provider                                         │
+│  [2] Remove a provider                                          │
+│  [3] Set default provider                                       │
+│  [4] Configure fallback order                                   │
+│  [5] Done                                                       │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+              ┌───────────────┼───────────────┐
+              ▼               ▼               ▼
+        ┌──────────┐   ┌──────────┐   ┌──────────┐
+        │Add       │   │Remove    │   │Set       │
+        │Provider  │   │Provider  │   │Default   │
+        └──────────┘   └──────────┘   └──────────┘
+              │               │               │
+              ▼               ▼               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  [Step 2] Add Provider                                         │
+│  ─────────────────────────────────────                          │
+│  Available Providers:                                           │
+│    [1] OpenRouter  - Use OpenAI-compatible APIs via OpenRouter │
+│    [2] Groq       - Fast inference with Groq API               │
+│    [3] Ollama    - Self-hosted models via Ollama                │
+│    [4] OpenAI    - Direct OpenAI API access                     │
+│    [5] Anthropic - Claude models via Anthropic API              │
+│                                                                 │
+│  Choose provider [1-5]: _                                       │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  [Step 3] Provider Configuration                               │
+│  ─────────────────────────────────────                          │
+│                                                                 │
+│  (For OpenRouter/Groq/OpenAI/Anthropic)                        │
+│  ════════════════════════════════════════                      │
+│  Enter API key: sk-or-v1-________________________               │
+│  (Get from: https://provider.example.com/keys)                 │
+│                                                                 │
+│  ─ OR ─                                                        │
+│                                                                 │
+│  (For Ollama)                                                  │
+│  ════════════════════════════════════════                      │
+│  Base URL [http://localhost:11434]: _                           │
+│                                                                 │
+│  Models available on this provider:                             │
+│    1. llama3.1:8b                                              │
+│    2. mistral:7b                                                │
+│    3. codellama:7b                                              │
+│  Select default model [1]: _                                    │
+│                                                                 │
+│  [S] Skip validation                                           │
+│  [V] Validate credentials now (recommended)                    │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ (if validation selected)
+┌─────────────────────────────────────────────────────────────────┐
+│  [Step 4] Validation                                           │
+│  ─────────────────────────────────────                          │
+│  Testing connection...                                          │
+│  ✓ Connection successful!                                       │
+│  ✓ Models retrieved: 3 available                               │
+│                                                                 │
+│  Would you like to test a quick chat? [y/N]: _                 │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  [Step 5] Set Default / Fallback                               │
+│  ─────────────────────────────────────                          │
+│                                                                 │
+│  Available providers:                                          │
+│    1. openrouter (newly added)                                 │
+│                                                                 │
+│  Use as:                                                       │
+│    [1] Default provider (primary)                               │
+│    [2] Fallback only                                           │
+│    [3] Both (default + fallback)                                │
+│                                                                 │
+│  Note: If you have 2+ providers, you can configure            │
+│        fallback order after adding all providers.              │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  [Step 6] Confirm & Save                                       │
+│  ─────────────────────────────────────                          │
+│                                                                 │
+│  Summary:                                                      │
+│    Provider:  Groq                                             │
+│    API Key:   gsk_****wxyz (masked)                            │
+│    Default:   Yes                                              │
+│                                                                 │
+│  [1] Save and continue                                         │
+│  [2] Save and exit                                             │
+│  [3] Cancel                                                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Fallback Configuration Flow (when 2+ providers)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Configure Fallback Order                                      │
+│  ─────────────────────────────────────                          │
+│                                                                 │
+│  Current fallback chain:                                       │
+│    1. openrouter  (default)                                     │
+│    2. groq        (fallback #1)                                │
+│    3. ollama     (fallback #2)                                 │
+│                                                                 │
+│  [1] Reorder fallbacks                                         │
+│  [2] Test fallback chain                                        │
+│  [3] Done                                                      │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ (if reorder selected)
+┌─────────────────────────────────────────────────────────────────┐
+│  Reorder Fallbacks                                             │
+│  ─────────────────────────────────────                          │
+│                                                                 │
+│  Drag to reorder (or enter numbers):                           │
+│    [1] openrouter  ████████████████████ (primary)              │
+│    [2] groq        ████████████ (fallback #1)                  │
+│    [3] ollama     ████████ (fallback #2)                       │
+│                                                                 │
+│  Enter new order (e.g., "3,1,2"): _                            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## 2. Config Schema Design
+
+### Current Schema (v1)
+
+```json
+{
+  "schema_version": 1,
+  "providers": {
+    "openrouter": {
+      "api_key": "",
+      "api_base": "",
+      "extra_headers": {}
+    }
+  },
+  ...
+}
+```
+
+### Proposed Schema (v2)
+
+```json
+{
+  "schema_version": 2,
+  "providers": {
+    "openrouter": {
+      "type": "openrouter",
+      "api_key": "sk-or-v1-...",
+      "api_base": "",
+      "extra_headers": {},
+      "enabled": true,
+      "models": ["default"]
+    },
+    "groq": {
+      "type": "groq",
+      "api_key": "gsk_...",
+      "api_base": "",
+      "enabled": true
+    },
+    "ollama": {
+      "type": "ollama",
+      "api_base": "http://localhost:11434",
+      "enabled": true
+    }
+  },
+  "provider_defaults": {
+    "default": "openrouter",
+    "fallback_order": ["groq", "ollama"]
+  },
+  "agents": {
+    "defaults": {
+      "model": "z-ai/glm-4.5-air:free"
+    }
+  }
+}
+```
+
+### Schema Changes
+
+1. **Add `type` field** to each provider (for clarity, allows renaming)
+2. **Add `enabled` field** to each provider (soft delete without removing config)
+3. **Add `models` field** to store available/cached models per provider
+4. **Add `provider_defaults` section**:
+   - `default`: Primary provider name
+   - `fallback_order`: Array of provider names in fallback priority
+
+### Config Code Changes
+
+```go
+// internal/config/config.go
+
+// ProviderConfig - enhanced with type and enabled status
+type ProviderConfig struct {
+    Type         string            `mapstructure:"type" json:"type" yaml:"type"`
+    APIKey       string            `mapstructure:"api_key" json:"api_key" yaml:"api_key"`
+    APIBase      string            `mapstructure:"api_base" json:"api_base" yaml:"api_base"`
+    ExtraHeaders map[string]string `mapstructure:"extra_headers" json:"extra_headers" yaml:"extra_headers"`
+    Enabled      bool              `mapstructure:"enabled" json:"enabled" yaml:"enabled"`
+    Models       []string          `mapstructure:"models" json:"models" yaml:"models"`
+}
+
+// ProviderDefaults holds default provider settings
+type ProviderDefaults struct {
+    Default      string   `mapstructure:"default" json:"default" yaml:"default"`
+    FallbackOrder []string `mapstructure:"fallback_order" json:"fallback_order" yaml:"fallback_order"`
+}
+
+// Config - root config updated
+type Config struct {
+    SchemaVersion    int                       `mapstructure:"schema_version" json:"schema_version"`
+    Providers        map[string]ProviderConfig `mapstructure:"providers" json:"providers" yaml:"providers"`
+    ProviderDefaults ProviderDefaults         `mapstructure:"provider_defaults" json:"provider_defaults" yaml:"provider_defaults"`
+    // ... rest unchanged
+}
+```
+
+## 3. Implementation Checklist
+
+### Phase 1: Schema & Config Changes
+
+- [ ] Update config schema version to 2
+- [ ] Add `ProviderDefaults` struct
+- [ ] Update `ProviderConfig` with new fields
+- [ ] Add migration function for v1 → v2
+- [ ] Update `Validate()` to check provider_defaults
+- [ ] Add helper methods: `GetDefaultProvider()`, `GetFallbackProviders()`
+
+### Phase 2: Provider Registry Enhancements
+
+- [ ] Add Groq provider registration (if not present)
+- [ ] Add `ValidateCredentials()` method to providers
+- [ ] Add `ListModels()` method to providers
+- [ ] Add `TestConnection()` helper
+
+### Phase 3: CLI Command Implementation
+
+- [ ] Create `internal/configure/wizard.go` - interactive wizard logic
+- [ ] Add `configure` command to main.go with subcommands:
+  - [ ] `configure` - run wizard
+  - [ ] `configure --list` - show providers
+  - [ ] `configure --add <provider>` - add specific
+  - [ ] `configure --remove <provider>` - remove
+  - [ ] `configure --default <provider>` - set default
+  - [ ] `configure --fallback` - configure fallback
+- [ ] Implement masking for API key display
+- [ ] Add input validation and sanitization
+
+### Phase 4: Onboard Integration
+
+- [ ] Update onboard wizard to use new provider flow
+- [ ] Offer to configure multiple providers during onboard
+- [ ] Set fallback order during onboard (if 2+ providers)
+
+### Phase 5: Provider Switching Logic
+
+- [ ] Update `setupComponents()` in main.go to use fallback chain
+- [ ] Add provider health check on startup
+- [ ] Implement automatic fallback on provider failure
+
+## 4. Edge Cases to Handle
+
+### Configuration Edge Cases
+
+1. **No providers configured**: Show helpful message, redirect to onboard or configure
+2. **All providers disabled**: Warn user, suggest enabling or adding
+3. **Default provider doesn't exist**: Auto-fallback to first available
+4. **Fallback order has invalid provider**: Remove from order, warn user
+5. **Circular fallback**: Detect and prevent (shouldn't happen with current design)
+
+### Input Validation
+
+1. **Empty API key**: Require at least 1 character, warn about empty keys
+2. **Invalid URL for Ollama**: Validate URL format, test connection
+3. **Duplicate provider**: Ask to update existing or use different name
+4. **API key with whitespace**: Auto-trim, warn user
+
+### Provider-Specific
+
+1. **OpenRouter**: Require valid API key format (sk-or-v1-...)
+2. **Groq**: Require gsk_ prefix
+3. **Ollama**: Validate base URL, test /api/tags endpoint
+
+### UX Edge Cases
+
+1. **Ctrl+C during prompts**: Clean exit, don't save partial config
+2. **Terminal too narrow**: Use simpler output format
+3. **Non-interactive mode**: Support flags for scripted setup
+4. **API key in environment variable**: Detect and use instead of prompting
+
+### Error Handling
+
+1. **Provider API timeout**: Show helpful error, offer retry
+2. **Invalid credentials**: Clear error message, allow re-entry
+3. **Config file corrupted**: Offer to reset or backup
+4. **Permission denied on save**: Clear error with fix instructions
+
+## 5. Provider API Endpoints
+
+| Provider | API Base | Auth | Models Endpoint |
+|----------|----------|------|-----------------|
+| OpenRouter | https://openrouter.ai/api/v1 | Bearer token | /models |
+| Groq | https://api.groq.com/openai/v1 | Bearer token | /models |
+| Ollama | http://localhost:11434 | None | /api/tags |
+| OpenAI | https://api.openai.com/v1 | Bearer token | /models |
+| Anthropic | https://api.anthropic.com/v1 | Bearer token (header) | N/A (list via web) |
+
+## 6. File Structure
+
+```
+internal/
+├── configure/
+│   ├── wizard.go        # Interactive wizard logic
+│   ├── prompts.go       # Input prompts and validation
+│   ├── providers.go     # Provider-specific configuration
+│   └── test.go         # Connection testing utilities
+cmd/
+└── joshbot/
+    └── main.go          # Add configure command
+```
+
+## 7. Quick Reference: Provider Identifiers
+
+```go
+const (
+    ProviderOpenRouter = "openrouter"
+    ProviderGroq       = "groq"
+    ProviderOllama     = "ollama"
+    ProviderOpenAI     = "openai"
+    ProviderAnthropic  = "anthropic"
+)
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,7 @@ func SetLogger(l Logger) {
 
 const (
 	// DefaultModel is the default LLM model.
-	DefaultModel = "z-ai/glm-4.5-air:free"
+	DefaultModel = "arcee-ai/trinity-large-preview:free"
 	// DefaultExecTimeout is the default shell execution timeout in seconds.
 	DefaultExecTimeout = 60
 	// DefaultGatewayHost is the default gateway host.
@@ -53,7 +53,7 @@ const (
 	// DefaultMemoryWindow is the default memory window size.
 	DefaultMemoryWindow = 50
 	// CurrentSchemaVersion is the current config schema version.
-	CurrentSchemaVersion = 1
+	CurrentSchemaVersion = 2
 )
 
 // DefaultHome is the default joshbot home directory.
@@ -64,9 +64,16 @@ var DefaultWorkspace = filepath.Join(DefaultHome, "workspace")
 
 // ProviderConfig holds configuration for a single LLM provider.
 type ProviderConfig struct {
-	APIKey       string            `mapstructure:"api_key" json:"api_key" yaml:"api_key"`
-	APIBase      string            `mapstructure:"api_base" json:"api_base" yaml:"api_base"`
-	ExtraHeaders map[string]string `mapstructure:"extra_headers" json:"extra_headers" yaml:"extra_headers"`
+	APIKey       string            `mapstructure:"api_key" json:"api_key,omitempty" yaml:"api_key,omitempty"`
+	APIBase      string            `mapstructure:"api_base" json:"api_base,omitempty" yaml:"api_base,omitempty"`
+	ExtraHeaders map[string]string `mapstructure:"extra_headers" json:"extra_headers,omitempty" yaml:"extra_headers,omitempty"`
+	Enabled      bool              `mapstructure:"enabled" json:"enabled,omitempty" yaml:"enabled,omitempty"`
+}
+
+// ProviderDefaults holds default provider settings
+type ProviderDefaults struct {
+	Default       string   `mapstructure:"default" json:"default" yaml:"default"`
+	FallbackOrder []string `mapstructure:"fallback_order" json:"fallback_order" yaml:"fallback_order"`
 }
 
 // AgentDefaults holds default agent configuration.
@@ -132,14 +139,15 @@ type UserConfig struct {
 
 // Config is the root configuration for joshbot.
 type Config struct {
-	SchemaVersion int                       `mapstructure:"schema_version" json:"schema_version" yaml:"schema_version"`
-	Providers     map[string]ProviderConfig `mapstructure:"providers" json:"providers" yaml:"providers"`
-	Agents        AgentsConfig              `mapstructure:"agents" json:"agents" yaml:"agents"`
-	Channels      ChannelsConfig            `mapstructure:"channels" json:"channels" yaml:"channels"`
-	Tools         ToolsConfig               `mapstructure:"tools" json:"tools" yaml:"tools"`
-	Gateway       GatewayConfig             `mapstructure:"gateway" json:"gateway" yaml:"gateway"`
-	LogLevel      string                    `mapstructure:"log_level" json:"log_level" yaml:"log_level"`
-	User          UserConfig                `mapstructure:"user" json:"user,omitempty" yaml:"user,omitempty"`
+	SchemaVersion    int                       `mapstructure:"schema_version" json:"schema_version" yaml:"schema_version"`
+	Providers        map[string]ProviderConfig `mapstructure:"providers" json:"providers" yaml:"providers"`
+	ProviderDefaults ProviderDefaults          `mapstructure:"provider_defaults" json:"provider_defaults,omitempty" yaml:"provider_defaults,omitempty"`
+	Agents           AgentsConfig              `mapstructure:"agents" json:"agents" yaml:"agents"`
+	Channels         ChannelsConfig            `mapstructure:"channels" json:"channels" yaml:"channels"`
+	Tools            ToolsConfig               `mapstructure:"tools" json:"tools" yaml:"tools"`
+	Gateway          GatewayConfig             `mapstructure:"gateway" json:"gateway" yaml:"gateway"`
+	LogLevel         string                    `mapstructure:"log_level" json:"log_level" yaml:"log_level"`
+	User             UserConfig                `mapstructure:"user" json:"user,omitempty" yaml:"user,omitempty"`
 }
 
 // parseConfigFromFile parses JSON config data into the Config struct.
@@ -525,6 +533,19 @@ func migrateConfig(cfg *Config) error {
 				logger.Info("Backed up config", "to", backupPath)
 			}
 		}
+	}
+
+	// Migration from v1 to v2
+	if cfg.SchemaVersion < 2 {
+		// Initialize ProviderDefaults if not present
+		if cfg.ProviderDefaults.Default == "" && len(cfg.ProviderDefaults.FallbackOrder) == 0 {
+			cfg.ProviderDefaults = ProviderDefaults{
+				Default:       "",
+				FallbackOrder: []string{},
+			}
+			logger.Info("Migrated config to v2: initialized ProviderDefaults")
+		}
+		cfg.SchemaVersion = 2
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -335,7 +335,7 @@ func TestConfigString(t *testing.T) {
 	cfg := Defaults()
 	str := cfg.String()
 
-	expected := "Config{SchemaVersion: 1, Model: z-ai/glm-4.5-air:free, LogLevel: info, Gateway: 0.0.0.0:18790}"
+	expected := "Config{SchemaVersion: 2, Model: arcee-ai/trinity-large-preview:free, LogLevel: info, Gateway: 0.0.0.0:18790}"
 	if str != expected {
 		t.Errorf("String() = %v, want %v", str, expected)
 	}

--- a/internal/providers/errors.go
+++ b/internal/providers/errors.go
@@ -1,0 +1,165 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// FallbackError wraps an error with context for fallback decisions
+type FallbackError struct {
+	StatusCode int    // HTTP status code (0 for network errors)
+	Message    string // Error message
+	Provider   string // Provider that returned the error
+	Model      string // Model that was being used
+	Cause      error  // Underlying error
+}
+
+func (e *FallbackError) Error() string {
+	if e.StatusCode > 0 {
+		return fmt.Sprintf("[%s/%s] HTTP %d: %s", e.Provider, e.Model, e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("[%s/%s] network error: %s", e.Provider, e.Model, e.Message)
+}
+
+func (e *FallbackError) Unwrap() error {
+	return e.Cause
+}
+
+// IsFallbackError returns true if the error should trigger a fallback to another provider.
+// Non-fallback errors (400, 401, 403, context cancelled) are returned immediately.
+func IsFallbackError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Context cancellation - never fallback
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Check for FallbackError type
+	var fallbackErr *FallbackError
+	if errors.As(err, &fallbackErr) {
+		return isFallbackStatusCode(fallbackErr.StatusCode)
+	}
+
+	// Parse HTTP status from error message
+	statusCode := extractStatusCode(err.Error())
+	if statusCode > 0 {
+		return isFallbackStatusCode(statusCode)
+	}
+
+	// Network errors (no status code) - fallback
+	if isNetworkError(err) {
+		return true
+	}
+
+	return false
+}
+
+// isFallbackStatusCode returns true for status codes that should trigger fallback.
+func isFallbackStatusCode(statusCode int) bool {
+	switch statusCode {
+	case 429: // Rate limit
+		return true
+	case 500, 502, 503, 504: // Server errors
+		return true
+	case 408: // Request timeout
+		return true
+	case 529: // Overloaded
+		return true
+	default:
+		return false
+	}
+}
+
+// extractStatusCode parses HTTP status code from error message.
+func extractStatusCode(errMsg string) int {
+	patterns := []string{
+		`API error \((\d{3})\)`,
+		`status (\d{3})`,
+		`HTTP (\d{3})`,
+		`API request failed with status (\d{3})`,
+	}
+
+	for _, pattern := range patterns {
+		re := regexp.MustCompile(pattern)
+		if matches := re.FindStringSubmatch(errMsg); len(matches) > 1 {
+			code, _ := strconv.Atoi(matches[1])
+			return code
+		}
+	}
+
+	return 0
+}
+
+// isNetworkError checks if the error is a network-level failure.
+func isNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for net.OpError
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	// Check for URL errors
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return urlErr.Timeout() || urlErr.Temporary()
+	}
+
+	// Check error message for network patterns
+	errMsg := strings.ToLower(err.Error())
+	networkPatterns := []string{
+		"connection refused",
+		"connection reset",
+		"timeout",
+		"no such host",
+		"network is unreachable",
+		"i/o timeout",
+		"eof",
+		"dial tcp",
+	}
+
+	for _, pattern := range networkPatterns {
+		if strings.Contains(errMsg, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ClassifyError returns a human-readable error classification.
+func ClassifyError(err error) string {
+	if err == nil {
+		return "none"
+	}
+
+	statusCode := extractStatusCode(err.Error())
+
+	switch statusCode {
+	case 429:
+		return "rate_limit"
+	case 500, 502, 503, 504:
+		return "server_error"
+	case 408:
+		return "timeout"
+	case 0:
+		if isNetworkError(err) {
+			return "network_error"
+		}
+		return "unknown"
+	default:
+		return fmt.Sprintf("http_%d", statusCode)
+	}
+}

--- a/internal/providers/multiprovider.go
+++ b/internal/providers/multiprovider.go
@@ -1,0 +1,311 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// ProviderEntry represents a single provider in the fallback chain.
+type ProviderEntry struct {
+	Name     string   // Provider name (e.g., "openrouter", "groq")
+	Provider Provider // The actual provider instance
+	Model    string   // Default model for this provider
+	Priority int      // Fallback order (0 = primary, higher = later fallback)
+}
+
+// MultiProviderConfig holds configuration for the multi-provider.
+type MultiProviderConfig struct {
+	DefaultProvider string
+	Logger          Logger
+}
+
+// MultiProvider implements Provider with automatic fallback on transient errors.
+type MultiProvider struct {
+	mu              sync.RWMutex
+	entries         map[string]*ProviderEntry
+	orderedEntries  []*ProviderEntry
+	defaultProvider string
+	logger          Logger
+}
+
+// NewMultiProvider creates a new MultiProvider.
+func NewMultiProvider(cfg MultiProviderConfig) *MultiProvider {
+	if cfg.Logger == nil {
+		cfg.Logger = &DefaultLogger{}
+	}
+
+	if cfg.DefaultProvider == "" {
+		cfg.DefaultProvider = "openrouter"
+	}
+
+	return &MultiProvider{
+		entries:         make(map[string]*ProviderEntry),
+		orderedEntries:  make([]*ProviderEntry, 0),
+		defaultProvider: cfg.DefaultProvider,
+		logger:          cfg.Logger,
+	}
+}
+
+// Register adds a provider to the fallback chain.
+func (mp *MultiProvider) Register(name string, provider Provider, model string, priority int) {
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
+
+	entry := &ProviderEntry{
+		Name:     name,
+		Provider: provider,
+		Model:    model,
+		Priority: priority,
+	}
+
+	mp.entries[name] = entry
+	mp.rebuildOrderedList()
+}
+
+// Unregister removes a provider from the chain.
+func (mp *MultiProvider) Unregister(name string) {
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
+
+	delete(mp.entries, name)
+	mp.rebuildOrderedList()
+}
+
+// SetDefault sets the default provider.
+func (mp *MultiProvider) SetDefault(name string) {
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
+	mp.defaultProvider = name
+}
+
+// rebuildOrderedList rebuilds the ordered entries slice sorted by priority.
+func (mp *MultiProvider) rebuildOrderedList() {
+	entries := make([]*ProviderEntry, 0, len(mp.entries))
+	for _, entry := range mp.entries {
+		entries = append(entries, entry)
+	}
+
+	// Sort by priority (bubble sort is fine for small lists)
+	for i := 0; i < len(entries)-1; i++ {
+		for j := i + 1; j < len(entries); j++ {
+			if entries[i].Priority > entries[j].Priority {
+				entries[i], entries[j] = entries[j], entries[i]
+			}
+		}
+	}
+
+	mp.orderedEntries = entries
+}
+
+// Name returns the name of this provider.
+func (mp *MultiProvider) Name() string {
+	return "multiprovider"
+}
+
+// Config returns the configuration of the default provider.
+func (mp *MultiProvider) Config() Config {
+	mp.mu.RLock()
+	defer mp.mu.RUnlock()
+
+	if entry, exists := mp.entries[mp.defaultProvider]; exists {
+		return entry.Provider.Config()
+	}
+
+	return DefaultConfig()
+}
+
+// Chat sends a chat request with automatic fallback.
+func (mp *MultiProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	providerName, modelName := mp.parseModel(req.Model)
+	providers := mp.getFallbackChain(providerName)
+
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("no providers configured")
+	}
+
+	var lastErr error
+	attempted := make([]string, 0, len(providers))
+
+	for _, entry := range providers {
+		// Check context before each attempt
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		tryReq := req
+		tryReq.Model = mp.resolveModel(entry, modelName)
+
+		mp.logger.Debug("Trying provider",
+			"provider", entry.Name,
+			"model", tryReq.Model,
+			"attempt", len(attempted)+1,
+		)
+
+		resp, err := entry.Provider.Chat(ctx, tryReq)
+		if err == nil {
+			return resp, nil
+		}
+
+		attempted = append(attempted, entry.Name)
+		lastErr = err
+
+		mp.logger.Warn("Provider failed",
+			"provider", entry.Name,
+			"model", tryReq.Model,
+			"error", err,
+		)
+
+		// Check if we should fallback
+		if !IsFallbackError(err) {
+			mp.logger.Debug("Non-fallback error, stopping",
+				"provider", entry.Name,
+				"error_type", fmt.Sprintf("%T", err),
+			)
+			return nil, err
+		}
+
+		mp.logger.Info("Falling back to next provider",
+			"failed_provider", entry.Name,
+			"reason", ClassifyError(err),
+		)
+	}
+
+	return nil, fmt.Errorf("all providers failed (tried: %s): %w",
+		strings.Join(attempted, " → "), lastErr)
+}
+
+// ChatStream sends a streaming chat request with fallback.
+func (mp *MultiProvider) ChatStream(ctx context.Context, req ChatRequest) (<-chan StreamChunk, error) {
+	providerName, modelName := mp.parseModel(req.Model)
+	providers := mp.getFallbackChain(providerName)
+
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("no providers configured")
+	}
+
+	var lastErr error
+
+	for _, entry := range providers {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		tryReq := req
+		tryReq.Model = mp.resolveModel(entry, modelName)
+
+		ch, err := entry.Provider.ChatStream(ctx, tryReq)
+		if err == nil {
+			return ch, nil
+		}
+
+		lastErr = err
+
+		if !IsFallbackError(err) {
+			return nil, err
+		}
+
+		mp.logger.Info("Stream fallback",
+			"failed_provider", entry.Name,
+			"error", err,
+		)
+	}
+
+	return nil, fmt.Errorf("all providers failed for stream: %w", lastErr)
+}
+
+// Transcribe delegates to the primary provider.
+func (mp *MultiProvider) Transcribe(ctx context.Context, audioData []byte, prompt string) (string, error) {
+	mp.mu.RLock()
+	entry, exists := mp.entries[mp.defaultProvider]
+	mp.mu.RUnlock()
+
+	if !exists {
+		return "", fmt.Errorf("no default provider configured")
+	}
+
+	return entry.Provider.Transcribe(ctx, audioData, prompt)
+}
+
+// parseModel parses "provider:model" format.
+func (mp *MultiProvider) parseModel(modelSpec string) (providerName, modelName string) {
+	if modelSpec == "" {
+		return mp.defaultProvider, ""
+	}
+
+	if idx := strings.Index(modelSpec, ":"); idx > 0 {
+		potentialProvider := modelSpec[:idx]
+		potentialModel := modelSpec[idx+1:]
+
+		mp.mu.RLock()
+		_, exists := mp.entries[potentialProvider]
+		mp.mu.RUnlock()
+
+		if exists {
+			return potentialProvider, potentialModel
+		}
+	}
+
+	return mp.defaultProvider, modelSpec
+}
+
+// resolveModel determines the model to use for a provider.
+func (mp *MultiProvider) resolveModel(entry *ProviderEntry, requestedModel string) string {
+	if requestedModel != "" {
+		return requestedModel
+	}
+	if entry.Model != "" {
+		return entry.Model
+	}
+	return entry.Provider.Config().Model
+}
+
+// getFallbackChain returns providers in fallback order.
+func (mp *MultiProvider) getFallbackChain(startProvider string) []*ProviderEntry {
+	mp.mu.RLock()
+	defer mp.mu.RUnlock()
+
+	result := make([]*ProviderEntry, 0, len(mp.orderedEntries))
+	seen := make(map[string]bool)
+
+	// Start with specified provider
+	if entry, exists := mp.entries[startProvider]; exists {
+		result = append(result, entry)
+		seen[startProvider] = true
+	}
+
+	// Add remaining by priority
+	for _, entry := range mp.orderedEntries {
+		if !seen[entry.Name] {
+			result = append(result, entry)
+			seen[entry.Name] = true
+		}
+	}
+
+	return result
+}
+
+// GetProviderNames returns all registered provider names.
+func (mp *MultiProvider) GetProviderNames() []string {
+	mp.mu.RLock()
+	defer mp.mu.RUnlock()
+
+	names := make([]string, 0, len(mp.entries))
+	for name := range mp.entries {
+		names = append(names, name)
+	}
+	return names
+}
+
+// HasProvider returns true if a provider is registered.
+func (mp *MultiProvider) HasProvider(name string) bool {
+	mp.mu.RLock()
+	defer mp.mu.RUnlock()
+	_, exists := mp.entries[name]
+	return exists
+}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -89,6 +89,8 @@ func normalizeProviderName(name string) string {
 		return "azure"
 	case "local", "ollama":
 		return "ollama"
+	case "groq":
+		return "groq"
 	default:
 		return name
 	}
@@ -138,6 +140,14 @@ func init() {
 		// Default to local Ollama instance
 		if cfg.APIBase == "" {
 			cfg.APIBase = "http://localhost:11434"
+		}
+		return NewLiteLLMProvider(cfg), nil
+	})
+
+	RegisterProvider("groq", func(cfg Config) (Provider, error) {
+		// Set default API base for Groq if not specified
+		if cfg.APIBase == "" {
+			cfg.APIBase = "https://api.groq.com/openai/v1"
 		}
 		return NewLiteLLMProvider(cfg), nil
 	})


### PR DESCRIPTION
## Summary

This PR implements a comprehensive MultiProvider fallback system and interactive provider configuration.

### Bug Fixes
- Fix version display to show 'dev' instead of 'v0.0.0'
- Fix update command download URL to include version in asset name
- Fix release workflow asset naming (VERSION variable was empty)

### Config Schema v2
- Add `ProviderDefaults` struct with `Default` and `FallbackOrder`
- Add `Enabled` field to `ProviderConfig`
- Change default model to `arcee-ai/trinity-large-preview:free`
- Add schema migration v1 → v2

### MultiProvider System
- Create `internal/providers/errors.go` with error classification
- Create `internal/providers/multiprovider.go` with fallback logic
- Fallback triggers: 429, 500-504, 408, network errors
- Support `provider:model` format for model specification

### Configure Command
- Add `joshbot configure` interactive wizard
- Support for OpenRouter, Groq, Ollama providers
- Validate API keys before saving
- Configure fallback order between providers
- `joshbot configure --list` to show configured providers

### Provider Support
- Add Groq to provider registry (`api.groq.com/openai/v1`)
- Update `setupComponents` to use MultiProvider
- Register providers based on config and fallback order

## Files Changed

| File | Changes |
|------|---------|
| `.github/workflows/release.yml` | Fix asset naming |
| `internal/config/config.go` | Schema v2, ProviderDefaults |
| `internal/providers/errors.go` | NEW: Error classification |
| `internal/providers/multiprovider.go` | NEW: Fallback system |
| `internal/providers/registry.go` | Add Groq provider |
| `cmd/joshbot/main.go` | Configure command, MultiProvider wiring |

## Testing

- All existing tests pass
- Configure command works interactively
- Version display correct
- MultiProvider builds and integrates with agent

## New User Experience

```
$ joshbot configure

╔═══════════════════════════════════════════╗
║        Configure LLM Providers            ║
╚═══════════════════════════════════════════╝

Current providers:
  ✓ OpenRouter (default)
  ○ Groq (not configured)
  ○ Ollama (not configured)

What would you like to do?
  1. Configure OpenRouter
  2. Configure Groq
  3. Configure Ollama
  4. Set default provider
  5. Configure fallback order
  6. Done
```