### PR TITLE
Significant-turn history persistence and memory-window token budgeting

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -254,6 +254,7 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, *providers.LiteLLMPro
 		sessionMgr,
 		logger,
 		agent.WithMemoryLoader(memoryManager),
+		agent.WithHistoryAppender(memoryManager),
 		agent.WithSkillsLoader(skillsLoader),
 		agent.WithBudgetManager(budget),
 		agent.WithCompressor(compressor),

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bigknoxy/joshbot/internal/bus"
@@ -44,6 +45,11 @@ type SkillsLoader interface {
 	LoadSummary(ctx context.Context) (string, error)
 }
 
+// HistoryAppender appends condensed high-signal turns to HISTORY.md.
+type HistoryAppender interface {
+	AppendHistory(ctx context.Context, entry string) error
+}
+
 // Agent represents the main agent that processes messages using ReAct loop.
 type Agent struct {
 	cfg           *config.Config
@@ -51,6 +57,7 @@ type Agent struct {
 	tools         ToolExecutor
 	sessions      SessionManager
 	memory        MemoryLoader
+	history       HistoryAppender
 	skills        SkillsLoader
 	logger        *log.Logger
 	budget        *ctxpkg.BudgetManager
@@ -125,6 +132,15 @@ func WithMemoryLoader(loader MemoryLoader) Option {
 	}
 }
 
+// WithHistoryAppender injects a history appender implementation.
+func WithHistoryAppender(appender HistoryAppender) Option {
+	return func(a *Agent) {
+		if appender != nil {
+			a.history = appender
+		}
+	}
+}
+
 // WithSkillsLoader injects a skills loader implementation.
 func WithSkillsLoader(loader SkillsLoader) Option {
 	return func(a *Agent) {
@@ -182,6 +198,8 @@ func (a *Agent) Process(ctx context.Context, msg bus.InboundMessage) (string, er
 		return fmt.Sprintf("Error: Failed to load session: %v", err), nil
 	}
 
+	startSessionLen := len(sess.Messages)
+
 	// Build system prompt
 	systemPrompt := a.BuildSystemPrompt(ctx)
 
@@ -205,6 +223,16 @@ func (a *Agent) Process(ctx context.Context, msg bus.InboundMessage) (string, er
 			return "I'm sorry, but processing your request took too long. Please try again or simplify your request.", nil
 		}
 		return fmt.Sprintf("Error processing request: %v", err), nil
+	}
+
+	if a.history != nil {
+		newMessages := sess.Messages[startSessionLen:]
+		if shouldRecordSignificantTurn(newMessages, msg.Content, responseContent) {
+			entry := formatHistoryEntry(msg.Content, responseContent, newMessages)
+			if err := a.history.AppendHistory(ctx, entry); err != nil {
+				a.logger.Warn("Failed to append history", "error", err)
+			}
+		}
 	}
 
 	// Save session
@@ -399,11 +427,20 @@ func (a *Agent) buildMessages(systemPrompt string, sess *session.Session) []prov
 		providerMsgs = append(providerMsgs, providerMsg)
 	}
 
+	window := a.cfg.Agents.Defaults.MemoryWindow
+	if window > 0 && len(providerMsgs) > window {
+		providerMsgs = providerMsgs[len(providerMsgs)-window:]
+	}
+
 	// If we have a budget manager and compressor, consider compressing older messages
 	if a.budget != nil && a.compressor != nil {
 		model := a.cfg.Agents.Defaults.Model
 		maxCompletion := a.cfg.Agents.Defaults.MaxTokens
 		budget := a.budget.ComputeBudget(model, maxCompletion)
+		budget -= ctxpkg.TokenEstimator(systemPrompt)
+		if budget < 256 {
+			budget = 256
+		}
 
 		// Estimate total tokens for providerMsgs
 		totalTokens := 0
@@ -429,6 +466,58 @@ func (a *Agent) buildMessages(systemPrompt string, sess *session.Session) []prov
 	}
 
 	return msgs
+}
+
+func shouldRecordSignificantTurn(newMessages []session.Message, userContent, assistantContent string) bool {
+	if strings.TrimSpace(userContent) == "" || strings.TrimSpace(assistantContent) == "" {
+		return false
+	}
+
+	for _, m := range newMessages {
+		if m.Role == session.RoleTool {
+			return true
+		}
+	}
+
+	if len(userContent) > 220 || len(assistantContent) > 320 {
+		return true
+	}
+
+	signals := []string{"important", "decision", "decided", "preference", "prefer", "always", "never", "remember"}
+	text := strings.ToLower(userContent + " " + assistantContent)
+	for _, signal := range signals {
+		if strings.Contains(text, signal) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func formatHistoryEntry(userContent, assistantContent string, newMessages []session.Message) string {
+	toolCalls := 0
+	for _, m := range newMessages {
+		if m.Role == session.RoleTool {
+			toolCalls++
+		}
+	}
+
+	entry := fmt.Sprintf("User: %s | Assistant: %s", compactSnippet(userContent, 180), compactSnippet(assistantContent, 220))
+	if toolCalls > 0 {
+		entry += fmt.Sprintf(" | Tools used: %d", toolCalls)
+	}
+	return entry
+}
+
+func compactSnippet(s string, maxLen int) string {
+	s = strings.Join(strings.Fields(strings.TrimSpace(s)), " ")
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
 }
 
 // formatToolResult formats a tool result as a message for the LLM.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -130,6 +130,22 @@ func (m *mockMemoryLoader) LoadHistory(ctx context.Context, query string) (strin
 	return "", nil
 }
 
+type mockHistoryAppender struct {
+	entries []string
+	err     error
+	mu      sync.Mutex
+}
+
+func (m *mockHistoryAppender) AppendHistory(ctx context.Context, entry string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+	m.entries = append(m.entries, entry)
+	return nil
+}
+
 // mockSkillsLoader is a mock skills loader for testing.
 type mockSkillsLoader struct {
 	summaryFn func(ctx context.Context) (string, error)
@@ -793,6 +809,51 @@ func TestBuildSystemPrompt(t *testing.T) {
 		if !found {
 			t.Errorf("expected prompt to contain %q", expected)
 		}
+	}
+}
+
+func TestAgentProcessSignificantTurnAppendsHistory(t *testing.T) {
+	cfg := config.Defaults()
+	provider := &mockProvider{
+		chatFn: func(ctx context.Context, req providers.ChatRequest) (*providers.ChatResponse, error) {
+			return &providers.ChatResponse{
+				Choices: []providers.Choice{{
+					Message: providers.Message{Role: providers.RoleAssistant, Content: "I decided we should use SQLite and remember this preference."},
+				}},
+			}, nil
+		},
+	}
+	history := &mockHistoryAppender{}
+	agent := NewAgent(cfg, provider, &mockToolExecutor{}, newMockSessionManager(), newMockLogger(), WithHistoryAppender(history))
+
+	_, err := agent.Process(context.Background(), bus.InboundMessage{
+		SenderID:  "user1",
+		Content:   "Important: I prefer sqlite for local dev",
+		Channel:   "cli",
+		Timestamp: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+
+	if len(history.entries) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(history.entries))
+	}
+}
+
+func TestAgentBuildMessagesMemoryWindowApplied(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Agents.Defaults.MemoryWindow = 3
+	agent := NewAgent(cfg, &mockProvider{}, &mockToolExecutor{}, newMockSessionManager(), newMockLogger())
+
+	sess := session.NewSession("k")
+	for i := 0; i < 8; i++ {
+		sess.AddMessage(session.Message{Role: session.RoleUser, Content: "msg"})
+	}
+
+	msgs := agent.buildMessages("sys", sess)
+	if got := len(msgs); got != 4 { // system + 3 from window
+		t.Fatalf("expected 4 messages, got %d", got)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Persist high-signal conversation outcomes to HISTORY.md so preferences/decisions and tool-driven results are captured reliably. 
- Bound LLM context deterministically with a configured memory window before any compression to improve predictability for small/local models. 
- Improve token-budgeting accuracy by accounting for system prompt cost when deciding whether to compress history.

### Description

- Added a `HistoryAppender` interface and `WithHistoryAppender` option to `agent` to allow pluggable history persistence. 
- Captured `startSessionLen` at `Process` start and, after the ReAct loop, record a condensed history entry when `shouldRecordSignificantTurn` heuristics detect tool usage, important keywords, or long/high-information turns. 
- Implemented `shouldRecordSignificantTurn`, `formatHistoryEntry`, and `compactSnippet` helpers to determine significance and produce compact entries. 
- Enforced `memory_window` truncation in `buildMessages` before compression logic and subtracted the system prompt token cost from the computed budget so compression decisions are more accurate. 
- Wired the runtime to pass the memory manager as the history appender in `cmd/joshbot/main.go`. 
- Added tests and test scaffolding: `TestAgentProcessSignificantTurnAppendsHistory`, `TestAgentBuildMessagesMemoryWindowApplied`, and a `mockHistoryAppender` in `internal/agent/agent_test.go`.

### Testing

- Ran `go test ./internal/agent ./internal/integration ./...` and all targeted tests passed. 
- The new unit tests `TestAgentProcessSignificantTurnAppendsHistory` and `TestAgentBuildMessagesMemoryWindowApplied` were executed and succeeded. 
- Existing agent and integration tests were run to ensure no regressions and returned OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc805c5e88329bbb072825a5c722a)