### PR TITLE
Address remaining review findings: filesystem dispatch, safer defaults, and docs alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The default model is `openai/gpt-4`. For free alternatives via OpenRouter, try `
 | `write_file` | Write/create files |
 | `edit_file` | Find-and-replace editing |
 | `list_dir` | List directory contents |
-| `exec` | Execute shell commands (with safety guards) |
+| `shell` | Execute shell commands (with safety guards) |
 | `web_search` | Search the web (requires Brave API key) |
 | `web_fetch` | Fetch and extract web page content |
 | `message` | Send messages to channels |

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -254,6 +254,7 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, *providers.LiteLLMPro
 		sessionMgr,
 		logger,
 		agent.WithMemoryLoader(memoryManager),
+		agent.WithHistoryAppender(memoryManager),
 		agent.WithSkillsLoader(skillsLoader),
 		agent.WithBudgetManager(budget),
 		agent.WithCompressor(compressor),

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -1,111 +1,23 @@
-# joshbot Review Report
+# joshbot Review Notes
 
-Generated: 2026-02-14
+Generated: 2026-02-23
 
----
+This document tracks high-level review outcomes for the Go implementation of joshbot.
 
-## Documentation Review (README.md)
+## Status Snapshot
 
-### GAPS — Completely Missing
+### Addressed
+- Significant-turn history persistence is now wired in the agent loop and recorded into `HISTORY.md`.
+- `memory_window` is enforced in message construction before token compression.
+- Prompt budget accounting now includes system prompt token cost.
+- Filesystem operation dispatch now validates paths per operation (instead of globally requiring `path`).
+- Skill/docs naming aligned to runtime shell tool (`shell`, not `exec`).
+- Default `restrict_to_workspace` is now enabled.
 
-| # | Issue | Severity |
-|---|-------|----------|
-| 1 | **No uninstall instructions** — no guidance on `pip uninstall`, cleaning `~/.joshbot/`, or env vars | HIGH |
-| 2 | **No LICENSE file** — says MIT but no actual LICENSE file exists | HIGH |
-| 3 | **No voice transcription setup** — advertised feature but setup path (Groq key) is hidden | HIGH |
-| 4 | **No troubleshooting / FAQ section** — common failures undocumented | MEDIUM |
-| 5 | **No upgrade instructions** | MEDIUM |
-| 6 | **No proxy config docs** — `TelegramConfig.proxy` exists but isn't in README | MEDIUM |
-| 7 | **`custom` and `vllm` providers undocumented** — self-hosting users have no guidance | MEDIUM |
-| 8 | **No CONTRIBUTING guide** | MEDIUM |
-| 9 | **`api_base` / `extra_headers` provider options undocumented** | MEDIUM |
-| 10 | **Heartbeat feature advertised but never explained** | MEDIUM |
-| 11 | **`gateway` config section (`host`/`port`) not documented** | LOW |
-| 12 | **No `.env.example` file** | LOW |
-| 13 | **No CHANGELOG** | LOW |
+### Remaining Work
+- Improve model context window lookup accuracy beyond heuristic buckets.
+- Expand filesystem/shell security hardening and add explicit threat-model tests.
+- Add richer end-to-end tests for memory consolidation quality.
 
-### ISSUES — Incorrect or Misleading
-
-| # | Issue | Status |
-|---|-------|--------|
-| 1 | **Line 12 garbled text** — "Provider LLM**- **Multi-" mangled markdown | |
-| 2 | **Line 23 placeholder URL** — `yourusername/joshbot` should be `bigknoxy/joshbot` | |
-| 3 | **No venv in install instructions** — risky bare-metal pip install | |
-| 4 | **`allow_from` values unclear** — should say "Telegram user ID as string (number)" | |
-| 5 | **Empty `allow_from: []` silently allows everyone** — security-critical default undocumented | |
-| 6 | **Docker onboarding gap** — no guidance on interactive `onboard` in container context | |
-| 7 | **Config example incomplete** — missing `proxy`, `gateway`, `api_base`, `workspace`, `max_tool_iterations` | |
-| 8 | **Prerequisites buried at bottom** — Python 3.11+ requirement after Docker section | |
-
----
-
-## QA Review
-
-### CRITICAL (5 issues)
-
-| # | Issue | File | Status |
-|---|-------|------|--------|
-| 1 | **Shell tool deny-list trivially bypassed** — base64, env vars, pipes, subshells, command chaining all work | `tools/shell.py` | |
-| 2 | **Filesystem symlink bypass** — symlink inside workspace -> read any file on system | `tools/filesystem.py` | |
-| 3 | **Message bus silently drops messages** — if all handlers throw, message is lost with no retry/dead-letter | `bus/queue.py` | |
-| 4 | **Memory consolidation partial failure** — MEMORY.md writes but HISTORY.md fails = inconsistent state | `agent/loop.py` | |
-| 5 | **API keys set as env vars** — could leak via debug logging or child processes | `providers/litellm_provider.py` | |
-
-### HIGH (6 issues)
-
-| # | Issue | File | Status |
-|---|-------|------|--------|
-| 6 | **Shell tool ignores workspace restriction** — `cd / && ls` bypasses `cwd` restriction | `tools/shell.py` | |
-| 7 | **Telegram allowlist checked after initial processing** — metadata could leak | `channels/telegram.py` | |
-| 8 | **Session cache grows unbounded** — no LRU eviction, memory exhaustion risk | `session/manager.py` | |
-| 9 | **Cron recurring job stops permanently on error** — no retry/reschedule | `cron/service.py` | |
-| 10 | **Default `restrict_to_workspace: false`** — new users have no file isolation | `config/schema.py` | |
-| 11 | **Heartbeat re-triggers same tasks** — HEARTBEAT.md never cleared after processing | `heartbeat/service.py` | |
-
-### MEDIUM (6 issues)
-
-| # | Issue | File | Status |
-|---|-------|------|--------|
-| 12 | Dead code / confusing `if False` in skills_summary_fn | `main.py` | |
-| 13 | Race condition in EditFileTool (TOCTOU between read and write) | `tools/filesystem.py` | |
-| 14 | Bus handler exception breaks other handlers in the chain | `bus/queue.py` | |
-| 15 | No timeout on LLM calls during memory consolidation | `agent/loop.py` | |
-| 16 | CLI PromptSession never properly closed | `channels/cli.py` | |
-| 17 | No input validation (empty/huge messages) | `agent/loop.py` | |
-
-### LOW (3 issues)
-
-| # | Issue | File | Status |
-|---|-------|------|--------|
-| 18 | Markdown-to-HTML regex edge cases in Telegram | `channels/telegram.py` | |
-| 19 | Inconsistent error return types across tools | various | |
-| 20 | No input validation on user messages | `agent/loop.py` | |
-
----
-
-## Recommended Test Coverage Priority
-
-```
-tests/
-├── test_shell_security.py       # CRITICAL - bypass vectors
-├── test_filesystem_security.py  # CRITICAL - symlink attacks
-├── test_message_bus.py          # CRITICAL - message loss
-├── test_memory_consolidation.py # HIGH - partial failure
-├── test_session_manager.py      # HIGH - corruption, memory
-├── test_config_loading.py       # MEDIUM - corrupted config
-└── test_integration.py          # Full flow tests
-```
-
----
-
-## What's Done Well
-
-- Clear 3-step Quick Start flow
-- Multi-provider config examples with concrete JSON
-- Memory system explanation (MEMORY.md vs HISTORY.md lifecycle)
-- Progressive skill loading levels well-explained
-- Shell safety documentation builds trust
-- Environment variable convention with examples
-- Clean architecture section
-- Complete tools table (all 10 verified)
-- Chat commands table matches implementation
+## Notes
+- This repository is Go-first; prior Python-path findings were removed to avoid confusion.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bigknoxy/joshbot/internal/bus"
@@ -44,6 +45,11 @@ type SkillsLoader interface {
 	LoadSummary(ctx context.Context) (string, error)
 }
 
+// HistoryAppender appends condensed high-signal turns to HISTORY.md.
+type HistoryAppender interface {
+	AppendHistory(ctx context.Context, entry string) error
+}
+
 // Agent represents the main agent that processes messages using ReAct loop.
 type Agent struct {
 	cfg           *config.Config
@@ -51,6 +57,7 @@ type Agent struct {
 	tools         ToolExecutor
 	sessions      SessionManager
 	memory        MemoryLoader
+	history       HistoryAppender
 	skills        SkillsLoader
 	logger        *log.Logger
 	budget        *ctxpkg.BudgetManager
@@ -125,6 +132,15 @@ func WithMemoryLoader(loader MemoryLoader) Option {
 	}
 }
 
+// WithHistoryAppender injects a history appender implementation.
+func WithHistoryAppender(appender HistoryAppender) Option {
+	return func(a *Agent) {
+		if appender != nil {
+			a.history = appender
+		}
+	}
+}
+
 // WithSkillsLoader injects a skills loader implementation.
 func WithSkillsLoader(loader SkillsLoader) Option {
 	return func(a *Agent) {
@@ -182,6 +198,8 @@ func (a *Agent) Process(ctx context.Context, msg bus.InboundMessage) (string, er
 		return fmt.Sprintf("Error: Failed to load session: %v", err), nil
 	}
 
+	startSessionLen := len(sess.Messages)
+
 	// Build system prompt
 	systemPrompt := a.BuildSystemPrompt(ctx)
 
@@ -205,6 +223,16 @@ func (a *Agent) Process(ctx context.Context, msg bus.InboundMessage) (string, er
 			return "I'm sorry, but processing your request took too long. Please try again or simplify your request.", nil
 		}
 		return fmt.Sprintf("Error processing request: %v", err), nil
+	}
+
+	if a.history != nil {
+		newMessages := sess.Messages[startSessionLen:]
+		if shouldRecordSignificantTurn(newMessages, msg.Content, responseContent) {
+			entry := formatHistoryEntry(msg.Content, responseContent, newMessages)
+			if err := a.history.AppendHistory(ctx, entry); err != nil {
+				a.logger.Warn("Failed to append history", "error", err)
+			}
+		}
 	}
 
 	// Save session
@@ -399,11 +427,20 @@ func (a *Agent) buildMessages(systemPrompt string, sess *session.Session) []prov
 		providerMsgs = append(providerMsgs, providerMsg)
 	}
 
+	window := a.cfg.Agents.Defaults.MemoryWindow
+	if window > 0 && len(providerMsgs) > window {
+		providerMsgs = providerMsgs[len(providerMsgs)-window:]
+	}
+
 	// If we have a budget manager and compressor, consider compressing older messages
 	if a.budget != nil && a.compressor != nil {
 		model := a.cfg.Agents.Defaults.Model
 		maxCompletion := a.cfg.Agents.Defaults.MaxTokens
 		budget := a.budget.ComputeBudget(model, maxCompletion)
+		budget -= ctxpkg.TokenEstimator(systemPrompt)
+		if budget < 256 {
+			budget = 256
+		}
 
 		// Estimate total tokens for providerMsgs
 		totalTokens := 0
@@ -429,6 +466,58 @@ func (a *Agent) buildMessages(systemPrompt string, sess *session.Session) []prov
 	}
 
 	return msgs
+}
+
+func shouldRecordSignificantTurn(newMessages []session.Message, userContent, assistantContent string) bool {
+	if strings.TrimSpace(userContent) == "" || strings.TrimSpace(assistantContent) == "" {
+		return false
+	}
+
+	for _, m := range newMessages {
+		if m.Role == session.RoleTool {
+			return true
+		}
+	}
+
+	if len(userContent) > 220 || len(assistantContent) > 320 {
+		return true
+	}
+
+	signals := []string{"important", "decision", "decided", "preference", "prefer", "always", "never", "remember"}
+	text := strings.ToLower(userContent + " " + assistantContent)
+	for _, signal := range signals {
+		if strings.Contains(text, signal) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func formatHistoryEntry(userContent, assistantContent string, newMessages []session.Message) string {
+	toolCalls := 0
+	for _, m := range newMessages {
+		if m.Role == session.RoleTool {
+			toolCalls++
+		}
+	}
+
+	entry := fmt.Sprintf("User: %s | Assistant: %s", compactSnippet(userContent, 180), compactSnippet(assistantContent, 220))
+	if toolCalls > 0 {
+		entry += fmt.Sprintf(" | Tools used: %d", toolCalls)
+	}
+	return entry
+}
+
+func compactSnippet(s string, maxLen int) string {
+	s = strings.Join(strings.Fields(strings.TrimSpace(s)), " ")
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
 }
 
 // formatToolResult formats a tool result as a message for the LLM.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -130,6 +130,22 @@ func (m *mockMemoryLoader) LoadHistory(ctx context.Context, query string) (strin
 	return "", nil
 }
 
+type mockHistoryAppender struct {
+	entries []string
+	err     error
+	mu      sync.Mutex
+}
+
+func (m *mockHistoryAppender) AppendHistory(ctx context.Context, entry string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+	m.entries = append(m.entries, entry)
+	return nil
+}
+
 // mockSkillsLoader is a mock skills loader for testing.
 type mockSkillsLoader struct {
 	summaryFn func(ctx context.Context) (string, error)
@@ -793,6 +809,51 @@ func TestBuildSystemPrompt(t *testing.T) {
 		if !found {
 			t.Errorf("expected prompt to contain %q", expected)
 		}
+	}
+}
+
+func TestAgentProcessSignificantTurnAppendsHistory(t *testing.T) {
+	cfg := config.Defaults()
+	provider := &mockProvider{
+		chatFn: func(ctx context.Context, req providers.ChatRequest) (*providers.ChatResponse, error) {
+			return &providers.ChatResponse{
+				Choices: []providers.Choice{{
+					Message: providers.Message{Role: providers.RoleAssistant, Content: "I decided we should use SQLite and remember this preference."},
+				}},
+			}, nil
+		},
+	}
+	history := &mockHistoryAppender{}
+	agent := NewAgent(cfg, provider, &mockToolExecutor{}, newMockSessionManager(), newMockLogger(), WithHistoryAppender(history))
+
+	_, err := agent.Process(context.Background(), bus.InboundMessage{
+		SenderID:  "user1",
+		Content:   "Important: I prefer sqlite for local dev",
+		Channel:   "cli",
+		Timestamp: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+
+	if len(history.entries) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(history.entries))
+	}
+}
+
+func TestAgentBuildMessagesMemoryWindowApplied(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Agents.Defaults.MemoryWindow = 3
+	agent := NewAgent(cfg, &mockProvider{}, &mockToolExecutor{}, newMockSessionManager(), newMockLogger())
+
+	sess := session.NewSession("k")
+	for i := 0; i < 8; i++ {
+		sess.AddMessage(session.Message{Role: session.RoleUser, Content: "msg"})
+	}
+
+	msgs := agent.buildMessages("sys", sess)
+	if got := len(msgs); got != 4 { // system + 3 from window
+		t.Fatalf("expected 4 messages, got %d", got)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -299,7 +299,7 @@ func Defaults() *Config {
 			Exec: ExecConfig{
 				Timeout: DefaultExecTimeout,
 			},
-			RestrictToWorkspace: false,
+			RestrictToWorkspace: true,
 		},
 		Gateway: GatewayConfig{
 			Host: DefaultGatewayHost,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,6 +37,10 @@ func TestDefaults(t *testing.T) {
 		t.Errorf("expected exec timeout %d, got %d", DefaultExecTimeout, cfg.Tools.Exec.Timeout)
 	}
 
+	if !cfg.Tools.RestrictToWorkspace {
+		t.Error("expected restrict_to_workspace to be true by default")
+	}
+
 	if cfg.Gateway.Host != DefaultGatewayHost {
 		t.Errorf("expected gateway host %s, got %s", DefaultGatewayHost, cfg.Gateway.Host)
 	}

--- a/internal/tools/filesystem.go
+++ b/internal/tools/filesystem.go
@@ -121,30 +121,44 @@ func (t *FilesystemTool) Execute(ctx interface{}, args map[string]any) ToolResul
 	}
 
 	operation, _ := args["operation"].(string)
-	path, _ := args["path"].(string)
-
-	// Resolve path with workspace restriction
-	resolvedPath, err := t.resolvePath(workspace, path)
-	if err != nil {
-		return ToolResult{Error: err}
-	}
 
 	switch operation {
 	case "read_file":
+		resolvedPath, err := t.resolveRequiredPath(workspace, args)
+		if err != nil {
+			return ToolResult{Error: err}
+		}
 		return t.readFile(resolvedPath, args)
 	case "write_file":
+		resolvedPath, err := t.resolveRequiredPath(workspace, args)
+		if err != nil {
+			return ToolResult{Error: err}
+		}
 		return t.writeFile(resolvedPath, args)
 	case "edit_file":
+		resolvedPath, err := t.resolveRequiredPath(workspace, args)
+		if err != nil {
+			return ToolResult{Error: err}
+		}
 		return t.editFile(resolvedPath, args)
 	case "list_dir":
+		resolvedPath, err := t.resolveRequiredPath(workspace, args)
+		if err != nil {
+			return ToolResult{Error: err}
+		}
 		return t.listDir(resolvedPath)
 	case "glob":
 		return t.glob(workspace, args)
 	case "grep":
-		return t.grep(resolvedPath, args)
+		return t.grep(workspace, args)
 	default:
 		return ToolResult{Error: fmt.Errorf("unknown operation: %s", operation)}
 	}
+}
+
+func (t *FilesystemTool) resolveRequiredPath(workspace string, args map[string]any) (string, error) {
+	path, _ := args["path"].(string)
+	return t.resolvePath(workspace, path)
 }
 
 // resolvePath resolves a path with workspace restriction.
@@ -294,8 +308,13 @@ func (t *FilesystemTool) glob(workspace string, args map[string]any) ToolResult 
 		return ToolResult{Error: errors.New("pattern is required")}
 	}
 
-	// Resolve pattern relative to workspace
-	if !filepath.IsAbs(pattern) {
+	if filepath.IsAbs(pattern) {
+		pattern = filepath.Clean(pattern)
+		if t.restrict && !isWithinBase(pattern, workspace) {
+			return ToolResult{Error: fmt.Errorf("access denied: pattern %s is outside workspace %s", pattern, workspace)}
+		}
+	} else {
+		// Resolve pattern relative to workspace
 		pattern = filepath.Join(workspace, pattern)
 	}
 
@@ -310,6 +329,9 @@ func (t *FilesystemTool) glob(workspace string, args map[string]any) ToolResult 
 
 	output := fmt.Sprintf("Found %d files matching %s:\n", len(matches), args["pattern"])
 	for _, match := range matches {
+		if t.restrict && !isWithinBase(match, workspace) {
+			continue
+		}
 		// Make paths relative to workspace
 		rel, err := filepath.Rel(workspace, match)
 		if err != nil {
@@ -335,7 +357,11 @@ func (t *FilesystemTool) grep(workspace string, args map[string]any) ToolResult 
 	// If path is empty, search the entire workspace
 	searchPath := workspace
 	if path != "" {
-		searchPath = filepath.Join(workspace, path)
+		resolvedPath, err := t.resolvePath(workspace, path)
+		if err != nil {
+			return ToolResult{Error: err}
+		}
+		searchPath = resolvedPath
 	}
 
 	var matches []string
@@ -394,6 +420,14 @@ func (t *FilesystemTool) grep(workspace string, args map[string]any) ToolResult 
 	}
 
 	return ToolResult{Output: output}
+}
+
+func isWithinBase(path, base string) bool {
+	rel, err := filepath.Rel(filepath.Clean(base), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (!strings.HasPrefix(rel, "..") && rel != "")
 }
 
 // FilesystemToolConfig holds configuration for the filesystem tool.

--- a/internal/tools/filesystem_test.go
+++ b/internal/tools/filesystem_test.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFilesystemToolGlobWithoutPath(t *testing.T) {
+	ws := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ws, "a.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tool := NewFilesystemTool(ws, true)
+	res := tool.Execute(context.Background(), map[string]any{
+		"operation": "glob",
+		"pattern":   "*.txt",
+	})
+	if res.Error != nil {
+		t.Fatalf("glob should succeed without path: %v", res.Error)
+	}
+	if !strings.Contains(res.Output, "a.txt") {
+		t.Fatalf("expected output to contain a.txt, got: %s", res.Output)
+	}
+}
+
+func TestFilesystemToolGrepWithoutPath(t *testing.T) {
+	ws := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ws, "notes.md"), []byte("alpha\nbeta\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tool := NewFilesystemTool(ws, true)
+	res := tool.Execute(context.Background(), map[string]any{
+		"operation": "grep",
+		"search":    "beta",
+	})
+	if res.Error != nil {
+		t.Fatalf("grep should succeed without path: %v", res.Error)
+	}
+	if !strings.Contains(res.Output, "notes.md") {
+		t.Fatalf("expected grep output to contain notes.md, got: %s", res.Output)
+	}
+}
+
+func TestFilesystemToolGrepWithRelativePath(t *testing.T) {
+	ws := t.TempDir()
+	sub := filepath.Join(ws, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "file.txt"), []byte("needle\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tool := NewFilesystemTool(ws, true)
+	res := tool.Execute(context.Background(), map[string]any{
+		"operation": "grep",
+		"path":      "sub",
+		"search":    "needle",
+	})
+	if res.Error != nil {
+		t.Fatalf("grep with path should succeed: %v", res.Error)
+	}
+	if !strings.Contains(res.Output, "sub/file.txt") {
+		t.Fatalf("expected grep output to contain sub/file.txt, got: %s", res.Output)
+	}
+}
+
+func TestFilesystemToolGlobRestrictsAbsoluteOutsideWorkspace(t *testing.T) {
+	ws := t.TempDir()
+	tool := NewFilesystemTool(ws, true)
+	res := tool.Execute(context.Background(), map[string]any{
+		"operation": "glob",
+		"pattern":   "/etc/*",
+	})
+	if res.Error == nil {
+		t.Fatal("expected restriction error for absolute pattern outside workspace")
+	}
+}

--- a/skills/memory/SKILL.md
+++ b/skills/memory/SKILL.md
@@ -19,7 +19,7 @@ You have a two-file memory system for maintaining context across conversations:
 - Location: `memory/HISTORY.md` in your workspace
 - **Append-only** log of timestamped conversation summaries
 - NOT loaded into context (to save space) - search it when needed
-- Search with: `exec` tool running `grep -i "keyword" memory/HISTORY.md`
+- Search with: `grep` tool directly, or `shell` with `grep -i "keyword" memory/HISTORY.md`
 - Each entry is 2-5 sentences with timestamp `[YYYY-MM-DD HH:MM]`
 
 ## Best Practices


### PR DESCRIPTION
### Motivation
- Fix filesystem tool correctness so only operations that require a `path` validate/resolve it and optional operations (`glob`, `grep`) work without forcing `path` parameters.
- Harden defaults by enabling workspace-restriction by default to reduce accidental data exposure for new users.
- Align docs and skills with runtime tool naming and remove stale review artifacts to avoid confusion between docs and implementation.

### Description
- Adjusted `internal/tools/filesystem.go` to resolve `path` only for `read_file`, `write_file`, `edit_file`, and `list_dir`, added `resolveRequiredPath` helper, corrected `grep` handling to resolve optional `path`, improved `glob` behavior for absolute patterns, and added `isWithinBase` to filter out-of-workspace matches when restricted.
- Changed default configuration in `internal/config/config.go` to set `RestrictToWorkspace: true` and updated the corresponding expectation in `internal/config/config_test.go`.
- Added focused filesystem unit tests in `internal/tools/filesystem_test.go` covering `glob` and `grep` behavior with and without `path` and workspace restriction checks.
- Updated documentation and skills: replaced outdated `exec` naming with `shell`/`grep` in `README.md` and `skills/memory/SKILL.md`, and replaced stale `docs/REVIEW.md` with a current Go-focused review notes file.

### Testing
- Ran the full test suite with `go test ./...` and all packages passed successfully, including the new filesystem tests (`TestFilesystemToolGlobWithoutPath`, `TestFilesystemToolGrepWithoutPath`, `TestFilesystemToolGrepWithRelativePath`, `TestFilesystemToolGlobRestrictsAbsoluteOutsideWorkspace`).
- The config unit test asserting the default `restrict_to_workspace` value was updated and passed as part of the suite.
- No automated tests failed during validation; all targeted checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc805c5e88329bbb072825a5c722a)