### PR TITLE
feat: add NVIDIA NIM API as a provider

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -285,6 +285,20 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 		multiProvider.Register("openrouter", openrouterProvider, cfg.Agents.Defaults.Model, 0)
 	}
 
+	// Register NVIDIA NIM (if configured) - first fallback
+	if p, ok := cfg.Providers["nvidia"]; ok && p.APIKey != "" && p.Enabled {
+		nvidiaProvider := providers.NewLiteLLMProvider(providers.Config{
+			APIKey:       p.APIKey,
+			APIBase:      p.APIBase,
+			ExtraHeaders: p.ExtraHeaders,
+		})
+		priority := 1
+		if idx := indexOf(cfg.ProviderDefaults.FallbackOrder, "nvidia"); idx >= 0 {
+			priority = idx + 1
+		}
+		multiProvider.Register("nvidia", nvidiaProvider, "", priority)
+	}
+
 	// Register Groq (if configured)
 	if p, ok := cfg.Providers["groq"]; ok && p.APIKey != "" && p.Enabled {
 		groqProvider := providers.NewLiteLLMProvider(providers.Config{

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -91,6 +91,8 @@ func normalizeProviderName(name string) string {
 		return "ollama"
 	case "groq":
 		return "groq"
+	case "nvidia", "nim":
+		return "nvidia"
 	default:
 		return name
 	}
@@ -148,6 +150,14 @@ func init() {
 		// Set default API base for Groq if not specified
 		if cfg.APIBase == "" {
 			cfg.APIBase = "https://api.groq.com/openai/v1"
+		}
+		return NewLiteLLMProvider(cfg), nil
+	})
+
+	RegisterProvider("nvidia", func(cfg Config) (Provider, error) {
+		// Set default API base for NVIDIA NIM API if not specified
+		if cfg.APIBase == "" {
+			cfg.APIBase = "https://integrate.api.nvidia.com"
 		}
 		return NewLiteLLMProvider(cfg), nil
 	})


### PR DESCRIPTION
## Summary

Adds NVIDIA NIM (NVIDIA Inference Microservices) as a new LLM provider with OpenAI-compatible API support.

## Changes

- **Provider Registry** (`internal/providers/registry.go`): Added NVIDIA provider factory with 'nim' alias support and default API base (`https://integrate.api.nvidia.com`)
- **Main Application** (`cmd/joshbot/main.go`): Registered NVIDIA as first fallback (priority 1) in the multi-provider setup

## Features

- **OpenAI-compatible API**: Reuses existing LiteLLMProvider implementation
- **Free tier access**: NVIDIA offers free tier for developers at [build.nvidia.com](https://build.nvidia.com)
- **First fallback by default**: Priority 1 ensures it's used before other providers when available

## Usage

Add to your `~/.joshbot/config.json`:

```json
{
  "providers": {
    "nvidia": {
      "enabled": true,
      "api_key": "your-nvidia-api-key"
    }
  }
}
```

Get your free API key at: https://build.nvidia.com

## Testing

Run existing tests to verify:
```bash
go test ./internal/providers/...
```