### PR TITLE
fix: set Enabled=true for providers during onboarding

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -1232,7 +1232,7 @@ func runOnboard(c *cli.Context) error {
 	cfg := config.Defaults()
 	if apiKey != "" || provider == "ollama" {
 		cfg.Providers = map[string]config.ProviderConfig{
-			provider: {APIKey: apiKey},
+			provider: {APIKey: apiKey, Enabled: true},
 		}
 		cfg.ProviderDefaults.Default = provider
 	}


### PR DESCRIPTION
## Summary

Fixes a bug where NVIDIA, Groq, and Ollama providers weren't being registered after running the onboarding flow.

## Bug

Providers configured during onboarding weren't being registered in the agent.

## Root Cause

The `Enabled` field was not being set to `true` in the `ProviderConfig` during onboarding. The NVIDIA, Groq, and Ollama provider registration code checks the `Enabled` field before registering, so providers were being skipped.

## Fix

Added `Enabled: true` to the `ProviderConfig` when setting up providers during onboarding:

```go
cfg.Providers = map[string]config.ProviderConfig{
    provider: {APIKey: apiKey, Enabled: true},
}
```

## Affected Providers

- NVIDIA
- Groq  
- Ollama

All three providers check the `Enabled` field before registration.