### PR TITLE
fix: CLI agent chat ID, provider-specific model defaults, testing protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,3 +241,62 @@ When using build tags for platform-specific implementations:
    - When user is root (uid 0), `sudo` command doesn't exist
    - Detect with `os.Getuid() == 0` and skip sudo prefix
    - Applies to systemd service installation, file operations needing elevated permissions
+
+## Testing Protocol
+
+**CRITICAL**: Before any release, perform end-to-end testing to catch issues early.
+
+### Pre-Release Testing Checklist
+
+```bash
+# 1. Build and install locally
+go install ./cmd/joshbot
+
+# 2. Clean up previous test config
+rm -rf ~/.joshbot
+
+# 3. Test onboarding with each provider
+joshbot onboard    # Test NVIDIA, OpenRouter, Groq, Ollama
+
+# 4. Test non-interactive mode
+joshbot agent -m "hello"
+
+# 5. Test interactive mode
+joshbot agent      # Send message, verify response, check for tool errors
+
+# 6. Test gateway mode (if Telegram changes)
+joshbot gateway    # Send Telegram message, verify response
+
+# 7. Verify status
+joshbot status
+
+# 8. Cleanup
+rm -rf ~/.joshbot
+```
+
+### Common Issues to Watch For
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| "no chat ID stored for channel: cli" | Session.SetChatID() not called in CLI mode | Call `session.SetChatID("cli", "cli_user")` before processing |
+| "no providers configured" | Provider.Enabled=false or missing API key | Set `Enabled: true` when saving config |
+| 401/403 auth errors | Wrong API base URL or missing /v1 path | Use registry defaults via `GetProvider()` |
+| Wrong model suggested | Hardcoded model in onboarding | Use `providers.GetDefaultModel(provider)` |
+
+### Parallel Testing with Subagents
+
+For comprehensive testing, use parallel subagents:
+
+```
+Subagent 1: Run gateway and monitor for errors
+  - Start joshbot gateway
+  - Watch logs for errors
+  - Keep running
+
+Subagent 2: Test CLI commands
+  - joshbot agent -m "test"
+  - Verify response
+  - Check for tool execution errors
+```
+
+This catches issues that single-threaded testing misses.

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -437,7 +437,7 @@ func runAgent(c *cli.Context) error {
 	log.Info("Starting agent mode", "model", cfg.Agents.Defaults.Model)
 
 	// Setup components
-	_, _, _, agentInstance, _, _, err := setupComponents(cfg)
+	_, _, _, agentInstance, _, messageSender, err := setupComponents(cfg)
 	if err != nil {
 		return err
 	}
@@ -448,13 +448,13 @@ func runAgent(c *cli.Context) error {
 
 	// Non-interactive mode: send single message and exit
 	if message := c.String("message"); message != "" {
-		return runAgentSingleMessage(ctx, agentInstance, message, os.Stdout)
+		return runAgentSingleMessage(ctx, agentInstance, message, os.Stdout, messageSender)
 	}
 
 	done := make(chan struct{})
 	setupGracefulShutdown(ctx, cancel, done)
 
-	if err := runAgentLoop(ctx, cancel, done, os.Stdin, os.Stdout, agentInstance); err != nil {
+	if err := runAgentLoop(ctx, cancel, done, os.Stdin, os.Stdout, agentInstance, messageSender); err != nil {
 		return err
 	}
 	return nil
@@ -464,7 +464,12 @@ type agentProcessor interface {
 	Process(context.Context, bus.InboundMessage) (string, error)
 }
 
-func runAgentLoop(ctx context.Context, cancel context.CancelFunc, done <-chan struct{}, input io.Reader, output io.Writer, agentInstance agentProcessor) error {
+func runAgentLoop(ctx context.Context, cancel context.CancelFunc, done <-chan struct{}, input io.Reader, output io.Writer, agentInstance agentProcessor, messageSender *tools.BusMessageSender) error {
+	// Set chat ID for CLI mode so message tools can send messages proactively
+	if messageSender != nil {
+		messageSender.SetChatID("cli", "cli_user")
+	}
+
 	reader := bufio.NewReader(input)
 	fmt.Fprintln(output, "joshbot agent mode. Type 'exit' to quit.")
 	for {
@@ -521,7 +526,12 @@ func runAgentLoop(ctx context.Context, cancel context.CancelFunc, done <-chan st
 }
 
 // runAgentSingleMessage sends a single message and prints the response.
-func runAgentSingleMessage(ctx context.Context, agentInstance agentProcessor, message string, output io.Writer) error {
+func runAgentSingleMessage(ctx context.Context, agentInstance agentProcessor, message string, output io.Writer, messageSender *tools.BusMessageSender) error {
+	// Set chat ID for CLI mode so message tools work
+	if messageSender != nil {
+		messageSender.SetChatID("cli", "cli_user")
+	}
+
 	msg := bus.InboundMessage{
 		SenderID:  "cli_user",
 		Content:   message,
@@ -1269,17 +1279,26 @@ func runOnboard(c *cli.Context) error {
 		personalityChoice = selectPersonality(existingCfg)
 		soulContent = getPersonalitySoul(personalityChoice)
 		userName = promptUserName(existingCfg)
-		model = selectModel(existingCfg)
+		model = selectModel(existingCfg, provider)
 		telegramConfig = setupTelegram(existingCfg)
 	}
 
 	// Build config
 	cfg := config.Defaults()
 	if apiKey != "" || provider == "ollama" {
+		// Get provider's default model as fallback
+		defaultModel := providers.GetDefaultModel(provider)
+		if defaultModel == "" {
+			defaultModel = "arcee-ai/trinity-large-preview:free"
+		}
 		cfg.Providers = map[string]config.ProviderConfig{
 			provider: {APIKey: apiKey, Enabled: true},
 		}
 		cfg.ProviderDefaults.Default = provider
+		// Use selected model, or fall back to provider default
+		if model == "" {
+			model = defaultModel
+		}
 	}
 	cfg.Agents.Defaults.Model = model
 	if userName != "" {
@@ -1343,14 +1362,22 @@ func runOnboard(c *cli.Context) error {
 func selectProvider(existingCfg *config.Config) string {
 	fmt.Println("\n[Step 1] LLM Provider")
 	fmt.Println("Choose your LLM provider:")
-	fmt.Println("  1. NVIDIA NIM (Recommended - Free tier available)")
-	fmt.Println("  2. OpenRouter (Many models, one API key)")
-	fmt.Println("  3. Groq (Fast inference)")
-	fmt.Println("  4. Ollama (Local, no API key needed)")
+
+	// Use provider registry for display names and descriptions
+	providerList := []string{"nvidia", "openrouter", "groq", "ollama"}
+	for i, p := range providerList {
+		displayName := providers.GetProviderDisplayName(p)
+		desc := providers.GetProviderDescription(p)
+		if desc != "" {
+			fmt.Printf("  %d. %s (%s)\n", i+1, displayName, desc)
+		} else {
+			fmt.Printf("  %d. %s\n", i+1, displayName)
+		}
+	}
 
 	// Show current default if exists
 	if existingCfg != nil && existingCfg.ProviderDefaults.Default != "" {
-		fmt.Printf("\nCurrent provider: %s\n", getProviderDisplayName(existingCfg.ProviderDefaults.Default))
+		fmt.Printf("\nCurrent provider: %s\n", providers.GetProviderDisplayName(existingCfg.ProviderDefaults.Default))
 	}
 
 	fmt.Print("\nChoice [1]: ")
@@ -1453,8 +1480,12 @@ func promptUserName(existingCfg *config.Config) string {
 }
 
 // selectModel prompts the user to select a model and returns the choice.
-func selectModel(existingCfg *config.Config) string {
-	defaultModel := config.DefaultModel
+func selectModel(existingCfg *config.Config, provider string) string {
+	// Get provider's default model, fall back to config default
+	defaultModel := providers.GetDefaultModel(provider)
+	if defaultModel == "" {
+		defaultModel = config.DefaultModel
+	}
 
 	// Use existing model as default if available
 	if existingCfg != nil && existingCfg.Agents.Defaults.Model != "" {

--- a/cmd/joshbot/main_test.go
+++ b/cmd/joshbot/main_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bigknoxy/joshbot/internal/bus"
+	"github.com/bigknoxy/joshbot/internal/tools"
 )
 
 type mockAgent struct {
@@ -27,7 +28,8 @@ func TestRunAgentLoopProcessesInput(t *testing.T) {
 	input := bytes.NewBufferString("hello\nexit\n")
 
 	mock := &mockAgent{}
-	if err := runAgentLoop(ctx, cancel, done, input, &output, mock); err != nil {
+	// messageSender is nil in tests - chat ID won't be set but that's fine for unit tests
+	if err := runAgentLoop(ctx, cancel, done, input, &output, mock, nil); err != nil {
 		t.Fatalf("runAgentLoop error = %v", err)
 	}
 
@@ -53,11 +55,39 @@ func TestRunAgentLoopExitsOnEOF(t *testing.T) {
 	input := bytes.NewBufferString("")
 
 	mock := &mockAgent{}
-	if err := runAgentLoop(ctx, cancel, done, input, &output, mock); err != nil {
+	// messageSender is nil in tests - chat ID won't be set but that's fine for unit tests
+	if err := runAgentLoop(ctx, cancel, done, input, &output, mock, nil); err != nil {
 		t.Fatalf("runAgentLoop error = %v", err)
 	}
 
 	if len(mock.calls) != 0 {
 		t.Fatalf("expected no agent calls, got %v", mock.calls)
+	}
+}
+
+func TestRunAgentLoopSetsChatID(t *testing.T) {
+	// Create a real BusMessageSender to verify SetChatID is called
+	msgBus := bus.NewMessageBus()
+	sender := tools.NewBusMessageSender(msgBus)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	var output bytes.Buffer
+	input := bytes.NewBufferString("hello\nexit\n")
+
+	mock := &mockAgent{}
+	if err := runAgentLoop(ctx, cancel, done, input, &output, mock, sender); err != nil {
+		t.Fatalf("runAgentLoop error = %v", err)
+	}
+
+	// Verify chat ID was set for CLI channel
+	chatID, ok := sender.GetChatID("cli")
+	if !ok {
+		t.Fatalf("expected chat ID to be set for cli channel")
+	}
+	if chatID != "cli_user" {
+		t.Fatalf("expected chat ID 'cli_user', got %q", chatID)
 	}
 }

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -9,9 +9,17 @@ import (
 // ProviderFactory is a function that creates a Provider with the given configuration.
 type ProviderFactory func(cfg Config) (Provider, error)
 
+// ProviderInfo contains metadata about a provider.
+type ProviderInfo struct {
+	Factory      ProviderFactory
+	DefaultModel string
+	DisplayName  string
+	Description  string
+}
+
 // registry is the global provider registry.
 var (
-	registry     = make(map[string]ProviderFactory)
+	registry     = make(map[string]ProviderInfo)
 	registryLock sync.RWMutex
 )
 
@@ -26,21 +34,36 @@ func RegisterProvider(name string, factory ProviderFactory) {
 		panic(fmt.Sprintf("provider already registered: %s", name))
 	}
 
-	registry[name] = factory
+	registry[name] = ProviderInfo{
+		Factory: factory,
+	}
+}
+
+// RegisterProviderWithInfo registers a provider with full metadata.
+func RegisterProviderWithInfo(name string, info ProviderInfo) {
+	registryLock.Lock()
+	defer registryLock.Unlock()
+
+	name = normalizeProviderName(name)
+	if _, exists := registry[name]; exists {
+		panic(fmt.Sprintf("provider already registered: %s", name))
+	}
+
+	registry[name] = info
 }
 
 // GetProvider returns a new provider instance by name with the given configuration.
 // Returns an error if the provider is not registered.
 func GetProvider(name string, cfg Config) (Provider, error) {
 	registryLock.RLock()
-	factory, exists := registry[normalizeProviderName(name)]
+	info, exists := registry[normalizeProviderName(name)]
 	registryLock.RUnlock()
 
 	if !exists {
 		return nil, fmt.Errorf("unknown provider: %s (available: %v)", name, AvailableProviders())
 	}
 
-	return factory(cfg)
+	return info.Factory(cfg)
 }
 
 // AvailableProviders returns a list of all registered provider names.
@@ -98,67 +121,138 @@ func normalizeProviderName(name string) string {
 	}
 }
 
+// GetDefaultModel returns the default model for a provider.
+// Returns empty string if provider not found or no default set.
+func GetDefaultModel(name string) string {
+	registryLock.RLock()
+	defer registryLock.RUnlock()
+
+	if info, exists := registry[normalizeProviderName(name)]; exists {
+		return info.DefaultModel
+	}
+	return ""
+}
+
+// GetProviderDisplayName returns a human-readable name for a provider.
+func GetProviderDisplayName(name string) string {
+	registryLock.RLock()
+	defer registryLock.RUnlock()
+
+	if info, exists := registry[normalizeProviderName(name)]; exists {
+		if info.DisplayName != "" {
+			return info.DisplayName
+		}
+		return name
+	}
+	return name
+}
+
+// GetProviderDescription returns the description for a provider.
+func GetProviderDescription(name string) string {
+	registryLock.RLock()
+	defer registryLock.RUnlock()
+
+	if info, exists := registry[normalizeProviderName(name)]; exists {
+		return info.Description
+	}
+	return ""
+}
+
 // init registers the built-in providers.
 func init() {
-	// Register the LiteLLM provider as the default
+	// Register OpenRouter
+	RegisterProviderWithInfo("openrouter", ProviderInfo{
+		Factory: func(cfg Config) (Provider, error) {
+			if cfg.APIBase == "" {
+				cfg.APIBase = "https://openrouter.ai/api/v1"
+			}
+			return NewLiteLLMProvider(cfg), nil
+		},
+		DefaultModel: "arcee-ai/trinity-large-preview:free",
+		DisplayName:  "OpenRouter",
+		Description:  "Many models, one API key",
+	})
+
+	// Register OpenAI
+	RegisterProviderWithInfo("openai", ProviderInfo{
+		Factory: func(cfg Config) (Provider, error) {
+			if cfg.APIBase == "" {
+				cfg.APIBase = "https://api.openai.com/v1"
+			}
+			return NewLiteLLMProvider(cfg), nil
+		},
+		DefaultModel: "gpt-4o",
+		DisplayName:  "OpenAI",
+		Description:  "GPT-4 and more",
+	})
+
+	// Register NVIDIA
+	RegisterProviderWithInfo("nvidia", ProviderInfo{
+		Factory: func(cfg Config) (Provider, error) {
+			if cfg.APIBase == "" {
+				cfg.APIBase = "https://integrate.api.nvidia.com/v1"
+			}
+			return NewLiteLLMProvider(cfg), nil
+		},
+		DefaultModel: "meta/llama-3.3-70b-instruct",
+		DisplayName:  "NVIDIA NIM",
+		Description:  "Free tier available",
+	})
+
+	// Register Groq
+	RegisterProviderWithInfo("groq", ProviderInfo{
+		Factory: func(cfg Config) (Provider, error) {
+			if cfg.APIBase == "" {
+				cfg.APIBase = "https://api.groq.com/openai/v1"
+			}
+			return NewLiteLLMProvider(cfg), nil
+		},
+		DefaultModel: "llama-3.3-70b-versatile",
+		DisplayName:  "Groq",
+		Description:  "Fast inference",
+	})
+
+	// Register Ollama
+	RegisterProviderWithInfo("ollama", ProviderInfo{
+		Factory: func(cfg Config) (Provider, error) {
+			if cfg.APIBase == "" {
+				cfg.APIBase = "http://localhost:11434"
+			}
+			return NewLiteLLMProvider(cfg), nil
+		},
+		DefaultModel: "llama3.1:8b",
+		DisplayName:  "Ollama",
+		Description:  "Local, no API key needed",
+	})
+
+	// Register Anthropic
+	RegisterProviderWithInfo("anthropic", ProviderInfo{
+		Factory: func(cfg Config) (Provider, error) {
+			if cfg.APIBase == "" {
+				cfg.APIBase = "https://api.anthropic.com/v1"
+			}
+			return NewLiteLLMProvider(cfg), nil
+		},
+		DefaultModel: "claude-sonnet-4-20250514",
+		DisplayName:  "Anthropic",
+		Description:  "Claude models",
+	})
+
+	// Register Azure (requires API base, no default model)
+	RegisterProviderWithInfo("azure", ProviderInfo{
+		Factory: func(cfg Config) (Provider, error) {
+			if cfg.APIBase == "" {
+				return nil, fmt.Errorf("azure provider requires api_base to be set")
+			}
+			return NewLiteLLMProvider(cfg), nil
+		},
+		DefaultModel: "",
+		DisplayName:  "Azure OpenAI",
+		Description:  "Enterprise Azure integration",
+	})
+
+	// Keep litellm as a generic fallback
 	RegisterProvider("litellm", func(cfg Config) (Provider, error) {
-		return NewLiteLLMProvider(cfg), nil
-	})
-
-	// Register common provider aliases that use LiteLLM
-	RegisterProvider("openrouter", func(cfg Config) (Provider, error) {
-		// Set default API base for OpenRouter if not specified
-		if cfg.APIBase == "" {
-			cfg.APIBase = "https://openrouter.ai/api/v1"
-		}
-		return NewLiteLLMProvider(cfg), nil
-	})
-
-	RegisterProvider("openai", func(cfg Config) (Provider, error) {
-		// Set default API base for OpenAI if not specified
-		if cfg.APIBase == "" {
-			cfg.APIBase = "https://api.openai.com/v1"
-		}
-		return NewLiteLLMProvider(cfg), nil
-	})
-
-	RegisterProvider("anthropic", func(cfg Config) (Provider, error) {
-		// Set default API base for Anthropic if not specified
-		if cfg.APIBase == "" {
-			cfg.APIBase = "https://api.anthropic.com/v1"
-		}
-		return NewLiteLLMProvider(cfg), nil
-	})
-
-	RegisterProvider("azure", func(cfg Config) (Provider, error) {
-		// Azure OpenAI requires specific configuration
-		if cfg.APIBase == "" {
-			return nil, fmt.Errorf("azure provider requires api_base to be set")
-		}
-		return NewLiteLLMProvider(cfg), nil
-	})
-
-	RegisterProvider("ollama", func(cfg Config) (Provider, error) {
-		// Default to local Ollama instance
-		if cfg.APIBase == "" {
-			cfg.APIBase = "http://localhost:11434"
-		}
-		return NewLiteLLMProvider(cfg), nil
-	})
-
-	RegisterProvider("groq", func(cfg Config) (Provider, error) {
-		// Set default API base for Groq if not specified
-		if cfg.APIBase == "" {
-			cfg.APIBase = "https://api.groq.com/openai/v1"
-		}
-		return NewLiteLLMProvider(cfg), nil
-	})
-
-	RegisterProvider("nvidia", func(cfg Config) (Provider, error) {
-		// Set default API base for NVIDIA NIM API if not specified
-		if cfg.APIBase == "" {
-			cfg.APIBase = "https://integrate.api.nvidia.com/v1"
-		}
 		return NewLiteLLMProvider(cfg), nil
 	})
 }

--- a/internal/tools/message.go
+++ b/internal/tools/message.go
@@ -31,8 +31,10 @@ func (t *MessageTool) Name() string {
 
 // Description returns a description of the tool.
 func (t *MessageTool) Description() string {
-	return `Send messages to chat channels. Use this tool to communicate back to the user ` +
-		`through the appropriate chat channel.`
+	return `Send a message to a DIFFERENT channel than the current conversation. ` +
+		`Use this to proactively reach out via Telegram while working on a task. ` +
+		`DO NOT use this to respond to the current conversation - just return your response as text. ` +
+		`Example: If the user asks you to notify them on Telegram when a long task is done, use this tool.`
 }
 
 // Parameters returns the parameters for the tool.
@@ -113,8 +115,10 @@ func (t *ChannelMessageTool) Name() string {
 
 // Description returns a description of the tool.
 func (t *ChannelMessageTool) Description() string {
-	return `Channel tools for sending messages to different communication channels. ` +
-		`Use send_message to reply through Telegram, CLI, or other configured channels.`
+	return `Send a message to a DIFFERENT channel than the current conversation. ` +
+		`Use this to proactively reach out via Telegram while working on a task. ` +
+		`DO NOT use this to respond to the current conversation - just return your response as text. ` +
+		`Example: If the user asks you to notify them on Telegram when a long task is done, use this tool.`
 }
 
 // Parameters returns the parameters for the tool.


### PR DESCRIPTION
## Summary

Three improvements in this PR:

### 1. Fix CLI Agent Not Responding
- **Root cause**: `session.SetChatID("cli", "cli_user")` was never called in CLI mode
- **Symptom**: LLM tried to use message tools, which failed with "no chat ID stored for channel: cli"
- **Fix**: Call `messageSender.SetChatID("cli", "cli_user")` in `runAgentLoop()`

### 2. Provider-Specific Default Models
- Added `ProviderInfo` struct with `DefaultModel`, `DisplayName`, `Description`
- Each provider now has a recommended default model:
  - **NVIDIA**: `meta/llama-3.3-70b-instruct` (free tier, great tool calling)
  - **OpenRouter**: `arcee-ai/trinity-large-preview:free` (current default)
  - **Groq**: `llama-3.3-70b-versatile` (fast, parallel tool calling)
  - **Ollama**: `llama3.1:8b` (most popular, most likely installed)
- Onboarding now uses `providers.GetDefaultModel(provider)` instead of hardcoded default

### 3. Testing Protocol
- Added comprehensive testing checklist to `AGENTS.md`
- Documents common issues and fixes
- Recommends parallel subagent testing for thorough coverage

## Testing

```bash
# Non-interactive mode
joshbot agent -m "hello"
# ✅ Works correctly (no more "no chat ID stored" error)

# Interactive mode
joshbot agent
> hi
# ✅ Agent responds without tool errors
```

## Verification
- ✅ `go build ./...`
- ✅ `go test ./...`
- ✅ `go vet ./...`
- ✅ Manual testing with NVIDIA config