### PR TITLE
feat(providers): enhance Ollama integration with model listing and timeout config

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -110,16 +110,20 @@ func runApp() error {
 		},
 		Commands: []*cli.Command{
 			{
-				Name:   "agent",
-				Usage:  "Start joshbot in interactive CLI mode",
-				Action: runAgent,
+				Name:  "agent",
+				Usage: "Start joshbot in interactive CLI mode",
 				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "model",
+						Usage: "Model to use (overrides config)",
+					},
 					&cli.StringFlag{
 						Name:    "message",
 						Aliases: []string{"m"},
 						Usage:   "Send a single message and exit (non-interactive mode)",
 					},
 				},
+				Action: runAgent,
 			},
 			{
 				Name:   "gateway",
@@ -137,6 +141,11 @@ func runApp() error {
 					&cli.BoolFlag{
 						Name:  "keep-data",
 						Usage: "Reconfigure while preserving all existing data",
+					},
+					&cli.StringFlag{
+						Name:    "model",
+						Aliases: []string{"m"},
+						Usage:   "Model to use (overrides config)",
 					},
 				},
 				Action: runOnboard,
@@ -335,9 +344,18 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 
 	// Register Ollama (if configured)
 	if p, ok := cfg.Providers["ollama"]; ok && p.Enabled {
+		apiBase := p.APIBase
+		if apiBase == "" {
+			apiBase = providers.GetDefaultAPIBase()
+		}
+		timeout := p.Timeout
+		if timeout == 0 {
+			timeout = 120 * time.Second
+		}
 		ollamaProvider, err := providers.GetProvider("ollama", providers.Config{
-			APIBase:      p.APIBase,
+			APIBase:      apiBase,
 			ExtraHeaders: p.ExtraHeaders,
+			Timeout:      timeout,
 		})
 		if err != nil {
 			log.Warn("Failed to create Ollama provider", "error", err)
@@ -432,6 +450,11 @@ func runAgent(c *cli.Context) error {
 
 	if len(cfg.Providers) == 0 {
 		return fmt.Errorf("no providers configured. Run 'joshbot onboard' first")
+	}
+
+	// Override model from CLI flag if provided
+	if modelFlag := c.String("model"); modelFlag != "" {
+		cfg.Agents.Defaults.Model = modelFlag
 	}
 
 	log.Info("Starting agent mode", "model", cfg.Agents.Defaults.Model)
@@ -1172,6 +1195,7 @@ func getChannelID(msg bus.InboundMessage) string {
 func runOnboard(c *cli.Context) error {
 	force := c.Bool("force")
 	keepData := c.Bool("keep-data")
+	modelFlag := c.String("model")
 	homeDir := config.DefaultHome
 
 	// Welcome banner
@@ -1271,7 +1295,11 @@ func runOnboard(c *cli.Context) error {
 		// Use defaults for non-interactive setup
 		personalityChoice = "2" // Friendly
 		soulContent = getPersonalitySoul(personalityChoice)
-		model = config.DefaultModel
+		if modelFlag != "" {
+			model = modelFlag
+		} else {
+			model = config.DefaultModel
+		}
 	} else {
 		// Interactive prompts - pass existing config for defaults
 		provider = selectProvider(existingCfg)
@@ -1279,7 +1307,7 @@ func runOnboard(c *cli.Context) error {
 		personalityChoice = selectPersonality(existingCfg)
 		soulContent = getPersonalitySoul(personalityChoice)
 		userName = promptUserName(existingCfg)
-		model = selectModel(existingCfg, provider)
+		model = selectModel(existingCfg, provider, modelFlag)
 		telegramConfig = setupTelegram(existingCfg)
 	}
 
@@ -1480,15 +1508,18 @@ func promptUserName(existingCfg *config.Config) string {
 }
 
 // selectModel prompts the user to select a model and returns the choice.
-func selectModel(existingCfg *config.Config, provider string) string {
+func selectModel(existingCfg *config.Config, provider string, modelFlag string) string {
 	// Get provider's default model, fall back to config default
 	defaultModel := providers.GetDefaultModel(provider)
 	if defaultModel == "" {
 		defaultModel = config.DefaultModel
 	}
 
-	// Use existing model as default if available
-	if existingCfg != nil && existingCfg.Agents.Defaults.Model != "" {
+	// CLI flag has highest priority
+	if modelFlag != "" {
+		defaultModel = modelFlag
+	} else if existingCfg != nil && existingCfg.Agents.Defaults.Model != "" {
+		// Use existing model as default if available
 		defaultModel = existingCfg.Agents.Defaults.Model
 	}
 
@@ -2156,6 +2187,41 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 			}
 		}
 		p.APIBase = strings.TrimSpace(apiBase)
+
+		ollamaClient := providers.NewOllamaClient(p.APIBase)
+		models, err := ollamaClient.ListModels()
+		if err != nil {
+			fmt.Printf("\nCould not fetch models from Ollama: %v\n", err)
+		}
+
+		modelName := promptOllamaModelSelection(models)
+		if modelName == "" && exists && p.Model != "" {
+			modelName = p.Model
+		}
+		if modelName == "" {
+			fmt.Print("Enter model name: ")
+			fmt.Scanln(&modelName)
+			modelName = strings.TrimSpace(modelName)
+		}
+		p.Model = modelName
+
+		timeoutSecs := 300
+		if exists && p.Timeout > 0 {
+			timeoutSecs = int(p.Timeout.Seconds())
+		}
+		fmt.Printf("Timeout in seconds (CPU models need longer) [%d]: ", timeoutSecs)
+		var timeoutInput string
+		fmt.Scanln(&timeoutInput)
+		if timeoutInput != "" {
+			fmt.Sscanf(timeoutInput, "%d", &timeoutSecs)
+		}
+		p.Timeout = time.Duration(timeoutSecs) * time.Second
+
+		fmt.Println(`=== Ollama Tips ===
+• CPU-only: Pull smaller models: ollama pull llama3.2:3b
+• List models: ollama list
+• Test model: ollama run <model-name>
+• Check GPU: ollama run llama3.2 (faster with GPU)`)
 	}
 
 	// Validate credentials if API key was provided
@@ -2184,6 +2250,47 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 
 	fmt.Println()
 	return cfg
+}
+
+func formatSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+func promptOllamaModelSelection(models []providers.ModelInfo) string {
+	if len(models) == 0 {
+		return ""
+	}
+
+	fmt.Println("\nAvailable models:")
+	for i, m := range models {
+		sizeStr := ""
+		if m.Size > 0 {
+			sizeStr = fmt.Sprintf(" (%s)", formatSize(m.Size))
+		}
+		fmt.Printf("  %d. %s%s\n", i+1, m.Name, sizeStr)
+	}
+	fmt.Println()
+
+	fmt.Printf("Enter number (1-%d) or model name: ", len(models))
+
+	reader := bufio.NewReader(os.Stdin)
+	input, _ := reader.ReadString('\n')
+	input = strings.TrimSpace(input)
+
+	if num, err := strconv.Atoi(input); err == nil && num >= 1 && num <= len(models) {
+		return models[num-1].Name
+	}
+
+	return input
 }
 
 // validateProviderCredentials tests the API credentials for a provider.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Logger is a simple logger interface for the config package.
@@ -66,8 +67,10 @@ var DefaultWorkspace = filepath.Join(DefaultHome, "workspace")
 type ProviderConfig struct {
 	APIKey       string            `mapstructure:"api_key" json:"api_key,omitempty" yaml:"api_key,omitempty"`
 	APIBase      string            `mapstructure:"api_base" json:"api_base,omitempty" yaml:"api_base,omitempty"`
+	Model        string            `mapstructure:"model" json:"model,omitempty" yaml:"model,omitempty"`
 	ExtraHeaders map[string]string `mapstructure:"extra_headers" json:"extra_headers,omitempty" yaml:"extra_headers,omitempty"`
 	Enabled      bool              `mapstructure:"enabled" json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Timeout      time.Duration     `mapstructure:"timeout" json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
 // ProviderDefaults holds default provider settings

--- a/internal/providers/errors.go
+++ b/internal/providers/errors.go
@@ -33,7 +33,8 @@ func (e *FallbackError) Unwrap() error {
 
 // IsFallbackError returns true if the error should trigger a fallback to another provider.
 // Non-fallback errors (400, 401, 403, context cancelled) are returned immediately.
-func IsFallbackError(err error) bool {
+// The providerName parameter is used to determine provider-specific behavior (e.g., Ollama 404).
+func IsFallbackError(err error, providerName string) bool {
 	if err == nil {
 		return false
 	}
@@ -46,13 +47,13 @@ func IsFallbackError(err error) bool {
 	// Check for FallbackError type
 	var fallbackErr *FallbackError
 	if errors.As(err, &fallbackErr) {
-		return isFallbackStatusCode(fallbackErr.StatusCode)
+		return ShouldFallback(fallbackErr.Provider, fallbackErr.StatusCode, fallbackErr.Message)
 	}
 
 	// Parse HTTP status from error message
 	statusCode := extractStatusCode(err.Error())
 	if statusCode > 0 {
-		return isFallbackStatusCode(statusCode)
+		return ShouldFallback(providerName, statusCode, err.Error())
 	}
 
 	// Network errors (no status code) - fallback
@@ -77,6 +78,18 @@ func isFallbackStatusCode(statusCode int) bool {
 	default:
 		return false
 	}
+}
+
+// ShouldFallback determines if an error should trigger fallback to another provider.
+// For Ollama, 404 (model not found) should NOT trigger fallback - the user needs to pull the model.
+func ShouldFallback(provider string, statusCode int, errMsg string) bool {
+	// For Ollama, don't fallback on 404 (model not found)
+	// User needs to run: ollama pull <model>
+	if provider == "ollama" && statusCode == 404 {
+		return false
+	}
+
+	return isFallbackStatusCode(statusCode)
 }
 
 // extractStatusCode parses HTTP status code from error message.

--- a/internal/providers/multiprovider.go
+++ b/internal/providers/multiprovider.go
@@ -160,7 +160,7 @@ func (mp *MultiProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 		)
 
 		// Check if we should fallback
-		if !IsFallbackError(err) {
+		if !IsFallbackError(err, entry.Name) {
 			mp.logger.Debug("Non-fallback error, stopping",
 				"provider", entry.Name,
 				"error_type", fmt.Sprintf("%T", err),
@@ -206,7 +206,7 @@ func (mp *MultiProvider) ChatStream(ctx context.Context, req ChatRequest) (<-cha
 
 		lastErr = err
 
-		if !IsFallbackError(err) {
+		if !IsFallbackError(err, entry.Name) {
 			return nil, err
 		}
 

--- a/internal/providers/ollama.go
+++ b/internal/providers/ollama.go
@@ -1,0 +1,90 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+)
+
+const (
+	DefaultOllamaBaseURL = "http://localhost:11434"
+	ollamaBaseURLEnvVar  = "OLLAMA_BASE_URL"
+)
+
+type OllamaClient struct {
+	BaseURL string
+	client  *http.Client
+}
+
+type ModelInfo struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+type listModelsResponse struct {
+	Models []ModelInfo `json:"models"`
+}
+
+func NewOllamaClient(baseURL string) *OllamaClient {
+	if baseURL == "" {
+		baseURL = GetDefaultAPIBase()
+	}
+
+	return &OllamaClient{
+		BaseURL: baseURL,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func GetDefaultAPIBase() string {
+	if baseURL := os.Getenv(ollamaBaseURLEnvVar); baseURL != "" {
+		return baseURL
+	}
+	return DefaultOllamaBaseURL
+}
+
+func (c *OllamaClient) ListModels() ([]ModelInfo, error) {
+	url := strings.TrimRight(c.BaseURL, "/") + "/api/tags"
+
+	httpReq, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Accept", "application/json")
+
+	log.Debug("Fetching Ollama models", "url", url)
+
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var result listModelsResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	log.Debug("Retrieved Ollama models", "count", len(result.Models))
+
+	return result.Models, nil
+}


### PR DESCRIPTION
## Summary

- Add **OllamaClient** for fetching available models via `/api/tags`
- Show **model list in configure wizard** for Ollama
- Add `--model` flag to `agent` and `onboard` commands
- Add **configurable timeout** to `ProviderConfig` (default 300s for CPU)
- Skip fallback on Ollama 404 (model not found - user needs to pull)
- Display **CPU tips** after Ollama configuration

## Changes

| File | Changes |
|------|---------|
| `internal/providers/ollama.go` | **NEW** - Ollama client for model listing |
| `internal/config/config.go` | Added `Timeout` field to `ProviderConfig` |
| `internal/providers/errors.go` | Added `ShouldFallback()` for Ollama-specific handling |
| `internal/providers/multiprovider.go` | Updated to pass provider name |
| `cmd/joshbot/main.go` | Model listing, `--model` flag, timeout config, CPU tips |

## New Features

### Model Listing in Configure Wizard
```
=== Configure Ollama ===

Available models:
  1. llama3.2 (3.8 GB)
  2. minimax-m2.5:cloud
  3. ministral-3:3b (3.0 GB)

Enter number (1-3) or model name:
```

### --model Flag
```bash
joshbot agent --model llama3.2
joshbot onboard --model llama3.2
```

### Configurable Timeout
- Default: 300 seconds (5 minutes) for CPU-only Ollama
- Configurable in the configure wizard

### Local Optimizations
- No fallback on "model not found" (404) - user needs to `ollama pull <model>`
- CPU tips displayed after configuration

## Testing

- ✅ `go build ./...` passes
- ✅ `go vet ./...` passes
- ✅ `go test ./...` passes

## Verification

Tested locally with Ollama running on `localhost:11434`.