### PR TITLE
fix(providers): use /v1 suffix for Ollama OpenAI compatibility

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -350,12 +350,13 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 		}
 		timeout := p.Timeout
 		if timeout == 0 {
-			timeout = 120 * time.Second
+			timeout = 300 * time.Second
 		}
 		ollamaProvider, err := providers.GetProvider("ollama", providers.Config{
 			APIBase:      apiBase,
 			ExtraHeaders: p.ExtraHeaders,
 			Timeout:      timeout,
+			Model:        p.Model,
 		})
 		if err != nil {
 			log.Warn("Failed to create Ollama provider", "error", err)
@@ -364,7 +365,11 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 			if idx := indexOf(cfg.ProviderDefaults.FallbackOrder, "ollama"); idx >= 0 {
 				priority = idx + 1
 			}
-			multiProvider.Register("ollama", ollamaProvider, "", priority)
+			model := p.Model
+			if model == "" {
+				model = providers.GetDefaultModel("ollama")
+			}
+			multiProvider.Register("ollama", ollamaProvider, model, priority)
 		}
 	}
 
@@ -1319,14 +1324,24 @@ func runOnboard(c *cli.Context) error {
 		if defaultModel == "" {
 			defaultModel = "arcee-ai/trinity-large-preview:free"
 		}
-		cfg.Providers = map[string]config.ProviderConfig{
-			provider: {APIKey: apiKey, Enabled: true},
-		}
-		cfg.ProviderDefaults.Default = provider
 		// Use selected model, or fall back to provider default
 		if model == "" {
 			model = defaultModel
 		}
+		// Build provider config
+		providerCfg := config.ProviderConfig{
+			APIKey:  apiKey,
+			Enabled: true,
+			Model:   model,
+		}
+		// For Ollama, set appropriate defaults
+		if provider == "ollama" {
+			providerCfg.Timeout = 300 * time.Second
+		}
+		cfg.Providers = map[string]config.ProviderConfig{
+			provider: providerCfg,
+		}
+		cfg.ProviderDefaults.Default = provider
 	}
 	cfg.Agents.Defaults.Model = model
 	if userName != "" {

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -216,7 +217,10 @@ func init() {
 	RegisterProviderWithInfo("ollama", ProviderInfo{
 		Factory: func(cfg Config) (Provider, error) {
 			if cfg.APIBase == "" {
-				cfg.APIBase = "http://localhost:11434"
+				cfg.APIBase = "http://localhost:11434/v1"
+			} else if !strings.HasSuffix(cfg.APIBase, "/v1") {
+				// Ensure /v1 suffix for OpenAI compatibility
+				cfg.APIBase = strings.TrimRight(cfg.APIBase, "/") + "/v1"
 			}
 			return NewLiteLLMProvider(cfg), nil
 		},


### PR DESCRIPTION
## Problem

1. **404 Error**: Ollama API calls were failing with `404 page not found` because the endpoint was `http://localhost:11434/chat/completions` instead of `http://localhost:11434/v1/chat/completions`

2. **Wrong Model**: When user configured Ollama in `joshbot configure`, the selected model wasn't being used. The agent would default to `llama3.1:8b` instead of the configured model.

3. **Incomplete Onboard UX**: When selecting Ollama during `joshbot onboard`, the provider wasn't fully configured - user still had to run `joshbot configure` separately.

## Solution

1. **Append `/v1` suffix** to Ollama base URL for OpenAI-compatible endpoint
2. **Pass configured model** to both provider config and `multiProvider.Register`
3. **Save model and timeout** to `ProviderConfig` during onboard for Ollama

## Changes

| File | Changes |
|------|---------|
| `internal/providers/registry.go` | Append `/v1` suffix to Ollama base URL |
| `cmd/joshbot/main.go` | Pass model to provider, save model/timeout during onboard |

## Testing

Tested with:
- Ollama running at `http://192.168.8.136:11434`
- Model: `qwen3:1.7b`

Before fix:
```
error: API request failed with status 404: 404 page not found
```

After fix:
```
2026-02-24 19:00:00 INFO joshbot: Starting agent mode model=qwen3:1.7b
```