### PR TITLE
fix: version display and status output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
             EXTENSION=".exe"
           fi
           OUTPUT_NAME="joshbot_${{ steps.version.outputs.version }}_${GOOS}_${GOARCH}${EXTENSION}"
-          go build -ldflags="-s -w -X github.com/bigknoxy/joshbot/cmd/joshbot.Version=${{ steps.version.outputs.version }}" \
+          go build -ldflags="-s -w -X main.Version=${{ steps.version.outputs.version }}" \
             -trimpath \
             -o "$OUTPUT_NAME" \
             ./cmd/joshbot

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,7 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
-      - -X github.com/bigknoxy/joshbot/cmd/joshbot.Version={{.Version}}
+      - -X main.Version={{.Version}}
 
 archives:
   - id: default

--- a/.opencode/skills/release-management/SKILL.md
+++ b/.opencode/skills/release-management/SKILL.md
@@ -115,6 +115,8 @@ gh release edit v<X.Y.Z> --latest
 
 | Version | Date | Description |
 |---------|------|-------------|
+| v1.12.0 | 2026-02-24 | Exa crawl for web_fetch, version/status display fixes |
+| v1.11.0 | 2026-02-24 | Enhanced Ollama integration |
 | v1.9.1 | 2026-02-24 | Provider registration fix, -m flag |
 | v1.9.0 | 2026-02-23 | exa-cli tool |
 | v1.8.2 | 2026-02-23 | NVIDIA API URL fix |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2026-02-24
+
+### Added
+
+#### Web Fetch Enhancement
+- **Exa crawl integration** for web_fetch tool to handle JavaScript-rendered pages
+- Improved content extraction from dynamic websites
+
+### Fixed
+
+- **Version display** - Release binaries now show actual version instead of "dev"
+  - Fixed ldflags in GoReleaser, CI workflow, and Dockerfile
+- **Status command** - Telegram and Workspace restricted now show "enabled"/"disabled" instead of "(exists)"
+
 ## [1.11.0] - 2026-02-24
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY pkg/ ./pkg/
 ENV CGO_ENABLED=0
 RUN --mount=type=cache,target=/go/pkg/mod \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-    -ldflags="-s -w -X github.com/bigknoxy/joshbot/cmd/joshbot.Version=$(git describe --tags --always --dirty 2>/dev/null || echo 'dev')" \
+    -ldflags="-s -w -X main.Version=$(git describe --tags --always --dirty 2>/dev/null || echo 'dev')" \
     -trimpath \
     -o joshbot ./cmd/joshbot
 

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -1943,8 +1943,8 @@ func runStatus(c *cli.Context) error {
 		providerNames = []string{"none"}
 	}
 	fmt.Printf("Providers:      %s\n", strings.Join(providerNames, ", "))
-	fmt.Printf("Telegram:       %s\n", statusBool(cfg.Channels.Telegram.Enabled))
-	fmt.Printf("Workspace restricted: %s\n", statusBool(cfg.Tools.RestrictToWorkspace))
+	fmt.Printf("Telegram:       %s\n", boolToEnabled(cfg.Channels.Telegram.Enabled))
+	fmt.Printf("Workspace restricted: %s\n", boolToEnabled(cfg.Tools.RestrictToWorkspace))
 	fmt.Println()
 
 	if memorySize > 0 || historySize > 0 {


### PR DESCRIPTION
## Summary

- **Fix version injection** - Changed ldflags path from full module path to `main.Version` for correct version display in release binaries
- **Fix status output** - Telegram and Workspace restricted now show "enabled"/"disabled" instead of "(exists)"

## Changes

| File | Change |
|------|--------|
| `.goreleaser.yaml` | Fixed ldflags path |
| `.github/workflows/release.yml` | Fixed ldflags path |
| `Dockerfile` | Fixed ldflags path |
| `cmd/joshbot/main.go` | Use `boolToEnabled()` for boolean status display |
| `CHANGELOG.md` | Added v1.12.0 release notes |
| `.opencode/skills/release-management/SKILL.md` | Updated version history |

## Test Plan

```bash
go build -ldflags="-X main.Version=v1.12.0-test" ./cmd/joshbot
./joshbot status | grep -E "Version|Telegram|Workspace"
```

Expected output:
```
Version:        v1.12.0-test
Telegram:       disabled
Workspace restricted: enabled
```