### PR TITLE
fix: update model when changing providers and preserve tool_call_id

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -2382,6 +2382,7 @@ func setDefaultProvider(cfg *config.Config) *config.Config {
 	}
 
 	cfg.ProviderDefaults.Default = configured[choice-1]
+	cfg.Agents.Defaults.Model = providers.GetDefaultModel(cfg.ProviderDefaults.Default)
 	fmt.Printf("\nDefault provider set to: %s\n", getProviderDisplayName(cfg.ProviderDefaults.Default))
 
 	return cfg

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -345,9 +345,10 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 				toolMsg := a.formatToolResult(tc.ID, tc.Function.Name, result)
 				messages = append(messages, toolMsg)
 				sess.AddMessage(session.Message{
-					Role:      session.RoleTool,
-					Content:   result,
-					Timestamp: time.Now(),
+					Role:       session.RoleTool,
+					Content:    result,
+					ToolCallID: tc.ID,
+					Timestamp:  time.Now(),
 				})
 				continue
 			}
@@ -368,9 +369,10 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 
 			// Add to session
 			sess.AddMessage(session.Message{
-				Role:      session.RoleTool,
-				Content:   result,
-				Timestamp: time.Now(),
+				Role:       session.RoleTool,
+				Content:    result,
+				ToolCallID: tc.ID,
+				Timestamp:  time.Now(),
 			})
 		}
 
@@ -404,8 +406,9 @@ func (a *Agent) buildMessages(systemPrompt string, sess *session.Session) []prov
 	providerMsgs := make([]providers.Message, 0, len(sess.Messages))
 	for _, msg := range sess.Messages {
 		providerMsg := providers.Message{
-			Role:    providers.MessageRole(msg.Role),
-			Content: msg.Content,
+			Role:       providers.MessageRole(msg.Role),
+			Content:    msg.Content,
+			ToolCallID: msg.ToolCallID,
 		}
 
 		// Convert tool calls

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -25,10 +25,11 @@ type ToolCall struct {
 
 // Message represents a single message in a session.
 type Message struct {
-	Role      Role       `json:"role"`
-	Content   string     `json:"content"`
-	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
-	Timestamp time.Time  `json:"timestamp"`
+	Role       Role       `json:"role"`
+	Content    string     `json:"content"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+	Timestamp  time.Time  `json:"timestamp"`
 }
 
 // Session represents a conversation session.


### PR DESCRIPTION
## Summary

Fixes two bugs discovered during testing on a fresh VM installation:

1. **Model not updated when changing providers** - `joshbot config` → "Set default provider" only updated the provider name, not the default model, causing 404 errors with NVIDIA NIM when switching from OpenRouter

2. **Missing tool_call_id field** - Tool result messages saved to session didn't include `tool_call_id`, causing "missing field tool_call_id" errors with strict providers like Arcee AI

## Changes

### `cmd/joshbot/main.go`
- `setDefaultProvider()` now updates `cfg.Agents.Defaults.Model` using `providers.GetDefaultModel()` after changing the provider

### `internal/session/session.go`
- Added `ToolCallID string` field to `Message` struct

### `internal/agent/agent.go`
- Tool result messages now save `ToolCallID` from the tool call
- `buildMessages()` now restores `ToolCallID` when constructing provider messages

## Testing

- All existing tests pass
- Build succeeds

## Related Issues

Fixes errors observed when:
- Switching from OpenRouter to NVIDIA NIM via `joshbot config`
- Using Arcee AI model with multiple tool calls in a conversation