### PR TITLE
feat: add GitHub Copilot provider with OAuth authentication

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bigknoxy/joshbot/internal/channels"
 	"github.com/bigknoxy/joshbot/internal/config"
 	ctxpkg "github.com/bigknoxy/joshbot/internal/context"
+	"github.com/bigknoxy/joshbot/internal/copilot"
 	"github.com/bigknoxy/joshbot/internal/cron"
 	"github.com/bigknoxy/joshbot/internal/heartbeat"
 	"github.com/bigknoxy/joshbot/internal/learning"
@@ -212,6 +213,22 @@ func runApp() error {
 					},
 				},
 			},
+			{
+				Name:  "auth",
+				Usage: "Manage OAuth authentication for providers",
+				Subcommands: []*cli.Command{
+					{
+						Name:   "github-copilot",
+						Usage:  "Authenticate with GitHub Copilot",
+						Action: runAuthCopilot,
+					},
+					{
+						Name:   "status",
+						Usage:  "Show authentication status for all providers",
+						Action: runAuthStatus,
+					},
+				},
+			},
 		},
 		Before: func(c *cli.Context) error {
 			// Update log level if verbose is set
@@ -370,6 +387,42 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 				model = providers.GetDefaultModel("ollama")
 			}
 			multiProvider.Register("ollama", ollamaProvider, model, priority)
+		}
+	}
+
+	// Register GitHub Copilot (if configured)
+	if p, ok := cfg.Providers["github-copilot"]; ok && p.Enabled {
+		token, err := copilot.LoadToken(config.DefaultHome)
+		if err != nil || token == nil || token.AccessToken == "" {
+			log.Warn("GitHub Copilot not authenticated", "error", err)
+			log.Warn("Run: joshbot auth github-copilot")
+		} else {
+			copilotCfg := providers.Config{
+				APIKey:      token.AccessToken,
+				Model:       cfg.Agents.Defaults.Model,
+				MaxTokens:   cfg.Agents.Defaults.MaxTokens,
+				Temperature: cfg.Agents.Defaults.Temperature,
+			}
+			if p.Model != "" {
+				copilotCfg.Model = p.Model
+			}
+			if copilotCfg.Model == "" {
+				copilotCfg.Model = "gpt-4o"
+			}
+			copilotProvider, err := providers.GetProvider("github-copilot", copilotCfg)
+			if err != nil {
+				log.Warn("Failed to create GitHub Copilot provider", "error", err)
+			} else {
+				priority := len(cfg.ProviderDefaults.FallbackOrder) + 1
+				for i, name := range cfg.ProviderDefaults.FallbackOrder {
+					if name == "github-copilot" {
+						priority = i + 1
+						break
+					}
+				}
+				multiProvider.Register("github-copilot", copilotProvider, copilotCfg.Model, priority)
+				log.Info("Registered provider", "name", "github-copilot", "priority", priority)
+			}
 		}
 	}
 
@@ -1305,10 +1358,29 @@ func runOnboard(c *cli.Context) error {
 		} else {
 			model = config.DefaultModel
 		}
+		// Get provider from existing config or use default
+		if existingCfg != nil && len(existingCfg.Providers) > 0 {
+			for p := range existingCfg.Providers {
+				provider = p
+				break
+			}
+		}
+		if provider == "" {
+			provider = "openrouter"
+		}
+		var err error
+		apiKey, err = promptProviderAPIKey(provider, existingCfg)
+		if err != nil {
+			return err
+		}
 	} else {
 		// Interactive prompts - pass existing config for defaults
 		provider = selectProvider(existingCfg)
-		apiKey = promptProviderAPIKey(provider, existingCfg)
+		var err error
+		apiKey, err = promptProviderAPIKey(provider, existingCfg)
+		if err != nil {
+			return err
+		}
 		personalityChoice = selectPersonality(existingCfg)
 		soulContent = getPersonalitySoul(personalityChoice)
 		userName = promptUserName(existingCfg)
@@ -1407,7 +1479,7 @@ func selectProvider(existingCfg *config.Config) string {
 	fmt.Println("Choose your LLM provider:")
 
 	// Use provider registry for display names and descriptions
-	providerList := []string{"nvidia", "openrouter", "groq", "ollama"}
+	providerList := []string{"nvidia", "openrouter", "groq", "ollama", "github-copilot"}
 	for i, p := range providerList {
 		displayName := providers.GetProviderDisplayName(p)
 		desc := providers.GetProviderDescription(p)
@@ -1439,13 +1511,15 @@ func selectProvider(existingCfg *config.Config) string {
 		return "groq"
 	case "4":
 		return "ollama"
+	case "5":
+		return "github-copilot"
 	default:
 		return "nvidia"
 	}
 }
 
 // promptProviderAPIKey prompts for the API key based on the selected provider.
-func promptProviderAPIKey(provider string, existingCfg *config.Config) string {
+func promptProviderAPIKey(provider string, existingCfg *config.Config) (string, error) {
 	var keyURL, keyName string
 	switch provider {
 	case "nvidia":
@@ -1459,7 +1533,20 @@ func promptProviderAPIKey(provider string, existingCfg *config.Config) string {
 		keyName = "Groq API key"
 	case "ollama":
 		fmt.Println("\nOllama runs locally - no API key needed.")
-		return ""
+		return "", nil
+	case "github-copilot":
+		fmt.Println("\nGitHub Copilot uses OAuth authentication.")
+		fmt.Println("You will be shown a URL and code to authorize.")
+		fmt.Println()
+
+		ctx := context.Background()
+		if _, err := copilot.RunDeviceFlow(ctx); err != nil {
+			return "", fmt.Errorf("OAuth failed: %w", err)
+		}
+
+		fmt.Println("\nSuccessfully authenticated with GitHub Copilot!")
+		fmt.Println("Token saved to ~/.joshbot/auth.json")
+		return "", nil
 	}
 
 	fmt.Printf("\nGet your %s at: %s\n", keyName, keyURL)
@@ -1478,7 +1565,7 @@ func promptProviderAPIKey(provider string, existingCfg *config.Config) string {
 
 	var apiKey string
 	fmt.Scanln(&apiKey)
-	return strings.TrimSpace(apiKey)
+	return strings.TrimSpace(apiKey), nil
 }
 
 // selectPersonality prompts the user to choose a personality and returns the choice.
@@ -1995,7 +2082,7 @@ func listProviders(cfg *config.Config) error {
 	fmt.Println("╚═══════════════════════════════════════════╝")
 	fmt.Println()
 
-	providers := []string{"nvidia", "openrouter", "groq", "ollama"}
+	providers := []string{"nvidia", "openrouter", "groq", "ollama", "github-copilot"}
 	defaultProvider := cfg.ProviderDefaults.Default
 
 	for _, name := range providers {
@@ -2004,9 +2091,20 @@ func listProviders(cfg *config.Config) error {
 		statusIcon := "○"
 		statusText := "not configured"
 
-		if exists && p.APIKey != "" {
-			statusIcon = "✓"
-			statusText = "configured"
+		if exists && p.Enabled {
+			if name == "github-copilot" {
+				token, err := copilot.LoadToken(config.DefaultHome)
+				if err == nil && token != nil && token.AccessToken != "" {
+					statusIcon = "✓"
+					statusText = "authenticated"
+				} else {
+					statusIcon = "○"
+					statusText = "OAuth required"
+				}
+			} else if p.APIKey != "" {
+				statusIcon = "✓"
+				statusText = "configured"
+			}
 		}
 		if isDefault {
 			statusText += " (default)"
@@ -2021,7 +2119,7 @@ func listProviders(cfg *config.Config) error {
 
 // runConfigureWizard runs the interactive provider configuration wizard.
 func runConfigureWizard(cfg *config.Config) error {
-	providers := []string{"nvidia", "openrouter", "groq", "ollama"}
+	providers := []string{"nvidia", "openrouter", "groq", "ollama", "github-copilot"}
 
 	for {
 		// Display current state
@@ -2039,9 +2137,20 @@ func runConfigureWizard(cfg *config.Config) error {
 			icon := "○"
 			status := "not configured"
 
-			if exists && p.APIKey != "" {
-				icon = "✓"
-				status = "configured"
+			if exists && p.Enabled {
+				if name == "github-copilot" {
+					token, err := copilot.LoadToken(config.DefaultHome)
+					if err == nil && token != nil && token.AccessToken != "" {
+						icon = "✓"
+						status = "authenticated"
+					} else {
+						icon = "○"
+						status = "OAuth required"
+					}
+				} else if p.APIKey != "" {
+					icon = "✓"
+					status = "configured"
+				}
 			}
 			if isDefault {
 				status += " (default)"
@@ -2056,17 +2165,18 @@ func runConfigureWizard(cfg *config.Config) error {
 		fmt.Println("  2. Configure OpenRouter")
 		fmt.Println("  3. Configure Groq")
 		fmt.Println("  4. Configure Ollama")
-		fmt.Println("  5. Set default provider")
-		fmt.Println("  6. Configure fallback order")
-		fmt.Println("  7. Done")
+		fmt.Println("  5. Configure GitHub Copilot")
+		fmt.Println("  6. Set default provider")
+		fmt.Println("  7. Configure fallback order")
+		fmt.Println("  8. Done")
 		fmt.Println()
 
-		fmt.Print("Choice [7]: ")
+		fmt.Print("Choice [8]: ")
 
 		var choice string
 		fmt.Scanln(&choice)
 		if choice == "" {
-			choice = "7"
+			choice = "8"
 		}
 
 		switch choice {
@@ -2079,10 +2189,12 @@ func runConfigureWizard(cfg *config.Config) error {
 		case "4":
 			cfg = configureProvider(cfg, "ollama")
 		case "5":
-			cfg = setDefaultProvider(cfg)
+			cfg = configureProvider(cfg, "github-copilot")
 		case "6":
-			cfg = configureFallbackOrder(cfg)
+			cfg = setDefaultProvider(cfg)
 		case "7":
+			cfg = configureFallbackOrder(cfg)
+		case "8":
 			// Save and exit
 			if err := config.Save(cfg); err != nil {
 				return fmt.Errorf("failed to save config: %w", err)
@@ -2106,6 +2218,8 @@ func getProviderDisplayName(name string) string {
 		return "Groq"
 	case "ollama":
 		return "Ollama"
+	case "github-copilot":
+		return "GitHub Copilot"
 	default:
 		return name
 	}
@@ -2237,6 +2351,33 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 • List models: ollama list
 • Test model: ollama run <model-name>
 • Check GPU: ollama run llama3.2 (faster with GPU)`)
+	case "github-copilot":
+		fmt.Println("GitHub Copilot uses OAuth authentication.")
+		fmt.Println("You will be shown a URL and code to authorize.")
+		fmt.Println()
+
+		token, err := copilot.LoadToken(config.DefaultHome)
+		if err == nil && token != nil && token.AccessToken != "" {
+			fmt.Println("Already authenticated with GitHub Copilot.")
+			fmt.Println("Run 'joshbot auth github-copilot' to re-authenticate if needed.")
+		} else {
+			ctx := context.Background()
+			token, err = copilot.RunDeviceFlow(ctx)
+			if err != nil {
+				fmt.Printf("OAuth failed: %v\n", err)
+				return cfg
+			}
+
+			if err := copilot.SaveToken(config.DefaultHome, token); err != nil {
+				fmt.Printf("Failed to save token: %v\n", err)
+				return cfg
+			}
+
+			fmt.Println("\nSuccessfully authenticated with GitHub Copilot!")
+		}
+
+		fmt.Println("\nNote: GitHub Copilot is configured via OAuth.")
+		fmt.Println("The access token is stored securely in ~/.joshbot/auth.json")
 	}
 
 	// Validate credentials if API key was provided
@@ -2538,6 +2679,54 @@ func runServiceStatus(c *cli.Context) error {
 		fmt.Println("The service is currently running.")
 	} else {
 		fmt.Println("The service is not running.")
+	}
+
+	return nil
+}
+
+func runAuthCopilot(c *cli.Context) error {
+	homeDir := config.DefaultHome
+
+	token, err := copilot.LoadToken(homeDir)
+	if err == nil && token != nil && token.AccessToken != "" {
+		fmt.Println("Already authenticated with GitHub Copilot.")
+		fmt.Println("Run 'joshbot auth github-copilot' to re-authenticate.")
+		return nil
+	}
+
+	fmt.Println("Starting GitHub Copilot authentication...")
+	fmt.Println()
+
+	ctx := context.Background()
+	token, err = copilot.RunDeviceFlow(ctx)
+	if err != nil {
+		return fmt.Errorf("authentication failed: %w", err)
+	}
+
+	if err := copilot.SaveToken(homeDir, token); err != nil {
+		return fmt.Errorf("failed to save token: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Println("Successfully authenticated with GitHub Copilot!")
+	fmt.Println("You can now use 'joshbot agent' with GitHub Copilot.")
+	return nil
+}
+
+func runAuthStatus(c *cli.Context) error {
+	homeDir := config.DefaultHome
+
+	token, err := copilot.LoadToken(homeDir)
+
+	fmt.Println("Authentication Status:")
+	fmt.Println()
+	fmt.Printf("  GitHub Copilot: ")
+
+	if err != nil || token == nil || token.AccessToken == "" {
+		fmt.Println("not authenticated")
+		fmt.Println("    Run 'joshbot auth github-copilot' to authenticate")
+	} else {
+		fmt.Println("authenticated")
 	}
 
 	return nil

--- a/internal/copilot/auth.go
+++ b/internal/copilot/auth.go
@@ -1,0 +1,259 @@
+package copilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/bigknoxy/joshbot/internal/log"
+)
+
+const (
+	ClientID       = "Ov23li8tweQw6odWQebz"
+	DeviceCodeURL  = "https://github.com/login/device/code"
+	AccessTokenURL = "https://github.com/login/oauth/access_token"
+	CopilotAPIURL  = "https://api.githubcopilot.com/v1"
+)
+
+type DeviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	Interval        int    `json:"interval"`
+	ExpiresIn       int    `json:"expires_in"`
+}
+
+type TokenInfo struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresAt    int64  `json:"expires_at"`
+}
+
+type AuthData map[string]TokenInfo
+
+func InitiateDeviceFlow(ctx context.Context) (*DeviceCodeResponse, error) {
+	data := url.Values{}
+	data.Set("client_id", ClientID)
+	data.Set("scope", "read:user")
+
+	req, err := http.NewRequestWithContext(ctx, "POST", DeviceCodeURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initiate device flow: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("device flow initiation failed with status: %d", resp.StatusCode)
+	}
+
+	var result DeviceCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode device code response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func PollForToken(ctx context.Context, deviceCode string, intervalSec int) (*TokenInfo, error) {
+	if intervalSec < 5 {
+		intervalSec = 5
+	}
+
+	ticker := time.NewTicker(time.Duration(intervalSec) * time.Second)
+	defer ticker.Stop()
+
+	client := &http.Client{Timeout: 60 * time.Second}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			token, err := attemptTokenExchange(ctx, client, deviceCode)
+			if err != nil {
+				if isAuthError(err) {
+					return nil, err
+				}
+				log.Debug("token poll error, retrying: %v", err)
+				continue
+			}
+			if token != nil {
+				return token, nil
+			}
+		}
+	}
+}
+
+func attemptTokenExchange(ctx context.Context, client *http.Client, deviceCode string) (*TokenInfo, error) {
+	data := url.Values{}
+	data.Set("client_id", ClientID)
+	data.Set("device_code", deviceCode)
+	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+
+	req, err := http.NewRequestWithContext(ctx, "POST", AccessTokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token exchange request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+		Error        string `json:"error"`
+		ErrorDesc    string `json:"error_description"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	if result.Error != "" {
+		switch result.Error {
+		case "authorization_pending":
+			return nil, nil
+		case "slow_down":
+			return nil, nil
+		case "expired_token":
+			return nil, fmt.Errorf("authorization expired, please run auth again")
+		case "access_denied":
+			return nil, fmt.Errorf("authorization denied")
+		default:
+			return nil, fmt.Errorf("auth error: %s - %s", result.Error, result.ErrorDesc)
+		}
+	}
+
+	if result.AccessToken == "" {
+		return nil, nil
+	}
+
+	expiresAt := time.Now().Add(time.Duration(result.ExpiresIn) * time.Second).Unix()
+	return &TokenInfo{
+		AccessToken:  result.AccessToken,
+		RefreshToken: result.RefreshToken,
+		ExpiresAt:    expiresAt,
+	}, nil
+}
+
+func isAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "expired") ||
+		strings.Contains(errStr, "denied") ||
+		strings.Contains(errStr, "run auth again")
+}
+
+func LoadToken(homeDir string) (*TokenInfo, error) {
+	authFile := filepath.Join(homeDir, ".joshbot", "auth.json")
+
+	data, err := os.ReadFile(authFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read auth file: %w", err)
+	}
+
+	var authData AuthData
+	if err := json.Unmarshal(data, &authData); err != nil {
+		return nil, fmt.Errorf("failed to parse auth file: %w", err)
+	}
+
+	token, ok := authData["github-copilot"]
+	if !ok {
+		return nil, nil
+	}
+
+	if token.ExpiresAt > 0 && time.Now().Unix() > token.ExpiresAt {
+		return nil, fmt.Errorf("token expired, please re-authenticate")
+	}
+
+	return &token, nil
+}
+
+func SaveToken(homeDir string, info *TokenInfo) error {
+	authDir := filepath.Join(homeDir, ".joshbot")
+	if err := os.MkdirAll(authDir, 0700); err != nil {
+		return fmt.Errorf("failed to create auth directory: %w", err)
+	}
+
+	authFile := filepath.Join(authDir, "auth.json")
+
+	var authData AuthData
+	data, err := os.ReadFile(authFile)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read existing auth file: %w", err)
+	}
+	if err == nil {
+		if err := json.Unmarshal(data, &authData); err != nil {
+			return fmt.Errorf("failed to parse existing auth file: %w", err)
+		}
+	}
+
+	if authData == nil {
+		authData = make(AuthData)
+	}
+	authData["github-copilot"] = *info
+
+	newData, err := json.MarshalIndent(authData, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal auth data: %w", err)
+	}
+
+	if err := os.WriteFile(authFile, newData, 0600); err != nil {
+		return fmt.Errorf("failed to write auth file: %w", err)
+	}
+
+	return nil
+}
+
+func RunDeviceFlow(ctx context.Context) (*TokenInfo, error) {
+	deviceCode, err := InitiateDeviceFlow(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initiate device flow: %w", err)
+	}
+
+	fmt.Printf("\nPlease visit: %s\n", deviceCode.VerificationURI)
+	fmt.Printf("Enter code: %s\n\n", deviceCode.UserCode)
+	fmt.Println("Waiting for authorization...")
+
+	token, err := PollForToken(ctx, deviceCode.DeviceCode, deviceCode.Interval)
+	if err != nil {
+		return nil, fmt.Errorf("token polling failed: %w", err)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	if err := SaveToken(homeDir, token); err != nil {
+		return nil, fmt.Errorf("failed to save token: %w", err)
+	}
+
+	log.Info("GitHub Copilot authentication successful")
+	return token, nil
+}

--- a/internal/copilot/provider.go
+++ b/internal/copilot/provider.go
@@ -1,0 +1,149 @@
+package copilot
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/bigknoxy/joshbot/internal/providers"
+)
+
+func init() {
+	providers.RegisterProviderWithInfo("github-copilot", providers.ProviderInfo{
+		Factory: func(cfg providers.Config) (providers.Provider, error) {
+			if cfg.APIKey == "" {
+				return nil, fmt.Errorf("github-copilot requires authentication. Run: joshbot auth github-copilot")
+			}
+			return NewCopilotProvider(cfg, cfg.APIKey), nil
+		},
+		DefaultModel: "gpt-4o",
+		DisplayName:  "GitHub Copilot",
+		Description:  "GitHub Copilot (requires OAuth authentication)",
+	})
+}
+
+const copilotModel = "gpt-4o"
+
+type CopilotProvider struct {
+	cfg         providers.Config
+	accessToken string
+	client      *http.Client
+}
+
+func NewCopilotProvider(cfg providers.Config, accessToken string) *CopilotProvider {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 120 * time.Second
+	}
+	if cfg.Model == "" {
+		cfg.Model = copilotModel
+	}
+
+	return &CopilotProvider{
+		cfg:         cfg,
+		accessToken: accessToken,
+		client: &http.Client{
+			Timeout: cfg.Timeout,
+		},
+	}
+}
+
+func (p *CopilotProvider) Name() string {
+	return "github-copilot"
+}
+
+func (p *CopilotProvider) Config() providers.Config {
+	return p.cfg
+}
+
+func (p *CopilotProvider) Chat(ctx context.Context, req providers.ChatRequest) (*providers.ChatResponse, error) {
+	if req.Model == "" {
+		req.Model = p.cfg.Model
+	}
+
+	if req.MaxTokens == 0 && p.cfg.MaxTokens > 0 {
+		req.MaxTokens = p.cfg.MaxTokens
+	}
+	if req.Temperature == 0 && p.cfg.Temperature > 0 {
+		req.Temperature = p.cfg.Temperature
+	}
+
+	url := strings.TrimRight(CopilotAPIURL, "/") + "/chat/completions"
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+p.accessToken)
+	httpReq.Header.Set("Openai-Intent", "conversation-edits")
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.parseError(respBody, resp.StatusCode)
+	}
+
+	var chatResp providers.ChatResponse
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &chatResp, nil
+}
+
+func (p *CopilotProvider) ChatStream(ctx context.Context, req providers.ChatRequest) (<-chan providers.StreamChunk, error) {
+	return nil, fmt.Errorf("streaming not yet implemented")
+}
+
+func (p *CopilotProvider) Transcribe(ctx context.Context, audioData []byte, prompt string) (string, error) {
+	_ = ctx
+	_ = audioData
+	_ = prompt
+	return "", fmt.Errorf("transcribe not supported by GitHub Copilot")
+}
+
+func (p *CopilotProvider) parseError(body []byte, statusCode int) error {
+	if statusCode == http.StatusForbidden {
+		return fmt.Errorf("GitHub Copilot authentication expired. Run: joshbot auth github-copilot")
+	}
+
+	var errResp struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+
+	if err := json.Unmarshal(body, &errResp); err == nil {
+		if errResp.Error.Message != "" {
+			return fmt.Errorf("API error (%d): %s (type: %s, code: %s)",
+				statusCode, errResp.Error.Message, errResp.Error.Type, errResp.Error.Code)
+		}
+	}
+
+	return fmt.Errorf("API request failed with status %d: %s", statusCode, string(body))
+}
+
+var _ providers.Provider = (*CopilotProvider)(nil)


### PR DESCRIPTION
## Summary

Adds GitHub Copilot as a provider option, allowing users with Copilot subscriptions to use it as their LLM backend.

## Features

- **OAuth device flow authentication** via `joshbot auth github-copilot`
- **Secure token storage** in `~/.joshbot/auth.json` with 0600 permissions
- **Onboarding integration** - GitHub Copilot available as option 5
- **Auth status command** - `joshbot auth status` shows authentication state
- **Proper error handling** - 403 errors prompt re-authentication

## Implementation

| File | Purpose |
|------|---------|
| `internal/copilot/auth.go` | OAuth device flow and token management |
| `internal/copilot/provider.go` | Copilot API provider implementation |
| `cmd/joshbot/main.go` | auth command, onboarding integration |

## Usage

```bash
# Authenticate with GitHub Copilot
joshbot auth github-copilot

# Check authentication status
joshbot auth status

# Use during onboarding
joshbot onboard  # Select option 5
```

## Technical Details

- API endpoint: `https://api.githubcopilot.com/v1/chat/completions`
- Default model: `gpt-4o`
- Client ID: `Ov23li8tweQw6odWQebz` (GitHub Copilot OAuth app)

## Testing

- [x] Build passes (`go build ./...`)
- [x] Tests pass (`go test ./... -short`)
- [x] `joshbot auth --help` works
- [x] `joshbot auth status` shows correct status
- [x] `joshbot auth github-copilot` initiates OAuth flow
- [x] Code review completed by subagent