### PR TITLE
fix: add User-Agent header to GitHub OAuth requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
             EXTENSION=".exe"
           fi
           OUTPUT_NAME="joshbot_${{ steps.version.outputs.version }}_${GOOS}_${GOARCH}${EXTENSION}"
-          go build -ldflags="-s -w -X main.Version=${{ steps.version.outputs.version }}" \
+          go build -ldflags="-s -w -X main.Version=${{ steps.version.outputs.version }} -X github.com/bigknoxy/joshbot/internal/copilot.Version=${{ steps.version.outputs.version }}" \
             -trimpath \
             -o "$OUTPUT_NAME" \
             ./cmd/joshbot

--- a/internal/copilot/auth.go
+++ b/internal/copilot/auth.go
@@ -21,6 +21,8 @@ const (
 	CopilotAPIURL  = "https://api.githubcopilot.com/v1"
 )
 
+var Version = "dev"
+
 type DeviceCodeResponse struct {
 	DeviceCode      string `json:"device_code"`
 	UserCode        string `json:"user_code"`
@@ -48,6 +50,7 @@ func InitiateDeviceFlow(ctx context.Context) (*DeviceCodeResponse, error) {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "joshbot/"+Version)
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
@@ -122,6 +125,7 @@ func attemptTokenExchange(ctx context.Context, client *http.Client, deviceCode s
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "joshbot/"+Version)
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

Add `User-Agent: joshbot/1.13.1` header to GitHub OAuth device flow requests to fix authentication hanging issue.

## Problem

When using `joshbot config` → option 5 (GitHub Copilot), after successfully authorizing on GitHub's website (`github.com/login/device/success`), the console still shows "Waiting for authorization..." indefinitely.

## Root Cause

GitHub's OAuth API requires a `User-Agent` header for proper request handling. Without it, requests may be silently rejected or delayed.

## Fix

Add `User-Agent: joshbot/1.13.1` header to:
- `InitiateDeviceFlow` - device code request
- `attemptTokenExchange` - token polling request

## Testing

1. Build: `go build ./...` ✅
2. Tests: `go test ./... -short` ✅
3. Manual test needed: `joshbot config` → option 5 → complete OAuth flow

## Changes

| File | Change |
|------|--------|
| `internal/copilot/auth.go` | Add User-Agent header to OAuth requests |