### PR TITLE
feat: add model selection UX with filtering during provider configuration

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/bigknoxy/joshbot/internal/session"
 	"github.com/bigknoxy/joshbot/internal/skills"
 	"github.com/bigknoxy/joshbot/internal/tools"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/urfave/cli/v2"
 )
 
@@ -2093,8 +2094,8 @@ func listProviders(cfg *config.Config) error {
 
 		if exists && p.Enabled {
 			if name == "github-copilot" {
-				token, err := copilot.LoadToken(config.DefaultHome)
-				if err == nil && token != nil && token.AccessToken != "" {
+				copilotToken, copilotErr := copilot.LoadToken(config.DefaultHome)
+				if copilotErr == nil && copilotToken != nil && copilotToken.AccessToken != "" {
 					statusIcon = "✓"
 					statusText = "authenticated"
 				} else {
@@ -2273,6 +2274,31 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 			}
 		}
 		p.APIBase = strings.TrimSpace(apiBase)
+
+		defaultModel := providers.GetDefaultModel("openrouter")
+		if exists && p.Model != "" {
+			defaultModel = p.Model
+		}
+		models, err := providers.ListModels(providers.Config{
+			APIKey:  p.APIKey,
+			APIBase: p.APIBase,
+		})
+		if err != nil {
+			fmt.Printf("\nCould not fetch models: %v\n", err)
+			fmt.Printf("Model (default: %s): ", defaultModel)
+		} else if len(models) > 0 {
+			selected := promptModelSelection(models, defaultModel)
+			p.Model = selected
+		} else {
+			fmt.Printf("Model (default: %s): ", defaultModel)
+		}
+		var modelInput string
+		fmt.Scanln(&modelInput)
+		if modelInput == "" && p.Model == "" {
+			p.Model = defaultModel
+		} else if modelInput != "" {
+			p.Model = strings.TrimSpace(modelInput)
+		}
 	case "nvidia":
 		if exists && p.APIBase != "" {
 			fmt.Printf("API base URL [%s]: ", p.APIBase)
@@ -2288,6 +2314,20 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 			}
 		}
 		p.APIBase = strings.TrimSpace(apiBase)
+
+		fmt.Println("\nNote: NVIDIA NIM does not support model listing via API.")
+		fmt.Printf("Available models: https://docs.nvidia.com/nim/large-language-models/1.15.0/models.html\n")
+		defaultModel := providers.GetDefaultModel("nvidia")
+		if exists && p.Model != "" {
+			defaultModel = p.Model
+		}
+		fmt.Printf("Model (default: %s): ", defaultModel)
+		var modelInput string
+		fmt.Scanln(&modelInput)
+		if modelInput == "" {
+			modelInput = defaultModel
+		}
+		p.Model = strings.TrimSpace(modelInput)
 	case "groq":
 		if exists && p.APIBase != "" {
 			fmt.Printf("API base URL [%s]: ", p.APIBase)
@@ -2303,6 +2343,31 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 			}
 		}
 		p.APIBase = strings.TrimSpace(apiBase)
+
+		defaultModel := providers.GetDefaultModel("groq")
+		if exists && p.Model != "" {
+			defaultModel = p.Model
+		}
+		models, err := providers.ListModels(providers.Config{
+			APIKey:  p.APIKey,
+			APIBase: p.APIBase,
+		})
+		if err != nil {
+			fmt.Printf("\nCould not fetch models: %v\n", err)
+			fmt.Printf("Model (default: %s): ", defaultModel)
+		} else if len(models) > 0 {
+			selected := promptModelSelection(models, defaultModel)
+			p.Model = selected
+		} else {
+			fmt.Printf("Model (default: %s): ", defaultModel)
+		}
+		var modelInput string
+		fmt.Scanln(&modelInput)
+		if modelInput == "" && p.Model == "" {
+			p.Model = defaultModel
+		} else if modelInput != "" {
+			p.Model = strings.TrimSpace(modelInput)
+		}
 	case "ollama":
 		if exists && p.APIBase != "" {
 			fmt.Printf("Ollama base URL [%s]: ", p.APIBase)
@@ -2375,6 +2440,32 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 
 		fmt.Println("\nNote: GitHub Copilot is configured via OAuth.")
 		fmt.Println("The access token is stored securely in ~/.joshbot/auth.json")
+
+		token, err = copilot.LoadToken(config.DefaultHome)
+		if err == nil && token != nil && token.AccessToken != "" {
+			defaultModel := providers.GetDefaultModel("github-copilot")
+			if exists && p.Model != "" {
+				defaultModel = p.Model
+			}
+			var models []string
+			models, err = copilot.ListModels(token.AccessToken)
+			if err != nil {
+				fmt.Printf("\nCould not fetch models: %v\n", err)
+				fmt.Printf("Model (default: %s): ", defaultModel)
+			} else if len(models) > 0 {
+				selected := promptModelSelection(models, defaultModel)
+				p.Model = selected
+			} else {
+				fmt.Printf("Model (default: %s): ", defaultModel)
+			}
+			var modelInput string
+			fmt.Scanln(&modelInput)
+			if modelInput == "" && p.Model == "" {
+				p.Model = defaultModel
+			} else if modelInput != "" {
+				p.Model = strings.TrimSpace(modelInput)
+			}
+		}
 	}
 
 	// Validate credentials if API key was provided
@@ -2446,6 +2537,94 @@ func promptOllamaModelSelection(models []providers.ModelInfo) string {
 	return input
 }
 
+var modelListStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("86"))
+var selectedModelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("212")).Bold(true)
+var helpStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+
+func promptModelSelection(models []string, defaultModel string) string {
+	if len(models) == 0 {
+		return defaultModel
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+
+	filtered := models
+	filter := ""
+
+	for {
+		fmt.Println()
+		fmt.Printf("Available models (default: %s):\n", defaultModel)
+		if filter != "" {
+			fmt.Printf("  Filter: %s (%d matches)\n", filter, len(filtered))
+		}
+		fmt.Println(helpStyle.Render("  Type number to select, or text to filter (Enter for default):"))
+		fmt.Println()
+
+		maxShow := 15
+		if len(filtered) > maxShow {
+			for i, m := range filtered[:maxShow] {
+				if m == defaultModel {
+					fmt.Printf("  %d. %s %s\n", i+1, selectedModelStyle.Render(m), helpStyle.Render("(default)"))
+				} else {
+					fmt.Printf("  %d. %s\n", i+1, modelListStyle.Render(m))
+				}
+			}
+			fmt.Printf("\n  ... and %d more (type more to filter, or number to select)\n", len(filtered)-maxShow)
+		} else {
+			for i, m := range filtered {
+				if m == defaultModel {
+					fmt.Printf("  %d. %s %s\n", i+1, selectedModelStyle.Render(m), helpStyle.Render("(default)"))
+				} else {
+					fmt.Printf("  %d. %s\n", i+1, modelListStyle.Render(m))
+				}
+			}
+		}
+
+		fmt.Println()
+		fmt.Print("> ")
+
+		input, _ := reader.ReadString('\n')
+		input = strings.TrimSpace(input)
+
+		if input == "" {
+			return defaultModel
+		}
+
+		if num, err := strconv.Atoi(input); err == nil && num >= 1 && num <= len(filtered) {
+			return filtered[num-1]
+		}
+
+		newFilter := input
+		if newFilter == filter {
+			if len(filtered) == 1 {
+				return filtered[0]
+			}
+			fmt.Println(helpStyle.Render("  Press Enter for default or type a number"))
+			continue
+		}
+
+		filtered = filterModels(models, newFilter)
+		filter = newFilter
+
+		if len(filtered) == 0 {
+			fmt.Printf("\n  No models match '%s', showing all\n\n", filter)
+			filtered = models
+			filter = ""
+		}
+	}
+}
+
+func filterModels(models []string, filter string) []string {
+	filterLower := strings.ToLower(filter)
+	var result []string
+	for _, m := range models {
+		if strings.Contains(strings.ToLower(m), filterLower) {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
 // validateProviderCredentials tests the API credentials for a provider.
 func validateProviderCredentials(provider, apiKey, apiBase string) error {
 	switch provider {
@@ -2487,7 +2666,13 @@ func setDefaultProvider(cfg *config.Config) *config.Config {
 	// Find configured providers
 	var configured []string
 	for name, p := range cfg.Providers {
-		if p.APIKey != "" {
+		if name == "github-copilot" {
+			// Check for OAuth token
+			token, err := copilot.LoadToken(config.DefaultHome)
+			if err == nil && token != nil && token.AccessToken != "" {
+				configured = append(configured, name)
+			}
+		} else if p.APIKey != "" {
 			configured = append(configured, name)
 		}
 	}
@@ -2706,6 +2891,42 @@ func runAuthCopilot(c *cli.Context) error {
 
 	fmt.Println()
 	fmt.Println("Successfully authenticated with GitHub Copilot!")
+
+	fmt.Println("\nFetching available models...")
+	models, err := copilot.ListModels(token.AccessToken)
+	if err != nil {
+		fmt.Printf("Could not fetch models: %v\n", err)
+		fmt.Println("You can configure models later with 'joshbot configure'.")
+		return nil
+	}
+
+	if len(models) == 0 {
+		fmt.Println("No models available.")
+		return nil
+	}
+
+	defaultModel := providers.GetDefaultModel("github-copilot")
+	fmt.Println("\nSelect a model:")
+	selected := promptModelSelection(models, defaultModel)
+
+	cfg, _ := loadConfig("")
+	if cfg == nil {
+		cfg = &config.Config{Providers: make(map[string]config.ProviderConfig)}
+	}
+	if cfg.Providers == nil {
+		cfg.Providers = make(map[string]config.ProviderConfig)
+	}
+	cfg.Providers["github-copilot"] = config.ProviderConfig{
+		Enabled: true,
+		Model:   selected,
+	}
+
+	if err := config.Save(cfg); err != nil {
+		fmt.Printf("Warning: Could not save config: %v\n", err)
+	} else {
+		fmt.Printf("\nModel '%s' saved to config.\n", selected)
+	}
+
 	fmt.Println("You can now use 'joshbot agent' with GitHub Copilot.")
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/lipgloss v0.10.0
+	github.com/charmbracelet/lipgloss v0.13.0
 	github.com/charmbracelet/log v0.4.0
 )
 
@@ -16,13 +16,13 @@ require (
 )
 
 require (
+	github.com/charmbracelet/x/ansi v0.2.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,10 +78,12 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/charmbracelet/lipgloss v0.10.0 h1:KWeXFSexGcfahHX+54URiZGkBFazf70JNMtwg/AFW3s=
-github.com/charmbracelet/lipgloss v0.10.0/go.mod h1:Wig9DSfvANsxqkRsqj6x87irdy123SR4dOXlKa91ciE=
+github.com/charmbracelet/lipgloss v0.13.0 h1:4X3PPeoWEDCMvzDvGmTajSyYPcZM4+y8sCA/SsA3cjw=
+github.com/charmbracelet/lipgloss v0.13.0/go.mod h1:nw4zy0SBX/F/eAO1cWdcvy6qnkDUxr8Lw7dvFrAIbbY=
 github.com/charmbracelet/log v0.4.0 h1:G9bQAcx8rWA2T3pWvx7YtPTPwgqpk7D68BX21IRW8ZM=
 github.com/charmbracelet/log v0.4.0/go.mod h1:63bXt/djrizTec0l11H20t8FDSvA4CRZJ1KH22MdptM=
+github.com/charmbracelet/x/ansi v0.2.3 h1:VfFN0NUpcjBRd4DnKfRaIRo53KRgey/nhOoEqosGDEY=
+github.com/charmbracelet/x/ansi v0.2.3/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -296,9 +298,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
-github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
@@ -314,8 +315,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
-github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -351,7 +350,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/copilot/provider.go
+++ b/internal/copilot/provider.go
@@ -147,4 +147,55 @@ func (p *CopilotProvider) parseError(body []byte, statusCode int) error {
 	return fmt.Errorf("API request failed with status %d: %s", statusCode, string(body))
 }
 
+const copilotCatalogURL = "https://models.github.ai/catalog/models"
+
+type copilotCatalogModel struct {
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Publisher    string   `json:"publisher"`
+	Summary      string   `json:"summary"`
+	Capabilities []string `json:"capabilities"`
+}
+
+func ListModels(accessToken string) ([]string, error) {
+	httpReq, err := http.NewRequest(http.MethodGet, copilotCatalogURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+accessToken)
+	httpReq.Header.Set("Accept", "application/vnd.github+json")
+	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	httpReq.Header.Set("User-Agent", "joshbot/"+Version)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var models []copilotCatalogModel
+	if err := json.Unmarshal(body, &models); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	result := make([]string, len(models))
+	for i, m := range models {
+		result[i] = m.ID
+	}
+
+	return result, nil
+}
+
 var _ providers.Provider = (*CopilotProvider)(nil)

--- a/internal/providers/litellm.go
+++ b/internal/providers/litellm.go
@@ -320,6 +320,63 @@ func (p *LiteLLMProvider) parseError(body []byte, statusCode int) error {
 	return fmt.Errorf("API request failed with status %d: %s", statusCode, string(body))
 }
 
+// ListModels fetches available models from an OpenAI-compatible API.
+func ListModels(cfg Config) ([]string, error) {
+	apiBase := cfg.APIBase
+	if apiBase == "" {
+		apiBase = "https://openrouter.ai/api/v1"
+	}
+	url := strings.TrimRight(apiBase, "/") + "/models"
+
+	httpReq, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	if cfg.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+
+	for k, v := range cfg.ExtraHeaders {
+		httpReq.Header.Set(k, v)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var result struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	models := make([]string, len(result.Data))
+	for i, m := range result.Data {
+		models[i] = m.ID
+	}
+
+	return models, nil
+}
+
 // LiteLLMProviderWithTools extends LiteLLMProvider with tool execution capabilities.
 type LiteLLMProviderWithTools struct {
 	*LiteLLMProvider

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -195,7 +195,7 @@ func init() {
 			}
 			return NewLiteLLMProvider(cfg), nil
 		},
-		DefaultModel: "meta/llama-3.3-70b-instruct",
+		DefaultModel: "moonshotai/kimi-k2-thinking",
 		DisplayName:  "NVIDIA NIM",
 		Description:  "Free tier available",
 	})


### PR DESCRIPTION
## Summary

- Change NVIDIA default model to `moonshotai/kimi-k2-thinking`
- Add generic `ListModels()` to LiteLLMProvider for OpenAI-compatible APIs
- Add Copilot `ListModels()` for GitHub Copilot model catalog
- Add interactive model selection with text filtering
- Fix setDefaultProvider to check Copilot OAuth tokens
- Populate Copilot model in config after OAuth authentication

## Changes

### Provider Model Selection
- **NVIDIA**: Shows docs link, uses default model (no model listing API available)
- **OpenRouter**: Fetches available models from API, interactive selection
- **Groq**: Fetches available models from API, interactive selection  
- **GitHub Copilot**: Fetches from catalog, model selection after OAuth

### UX Features
- Type to filter models in real-time
- Number to select specific model
- Enter to accept default (highlighted)
- Shows default model prominently

### Config Normalization
- All providers now store `model` in config under `providers.{name}.model`
- Agent defaults remain unchanged (fallback behavior)

## Testing
- Build: ✅
- Unit tests: ✅
- Vet: ✅