### PR TITLE
feat: add provider enable/disable support for fallback chain

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -307,8 +307,8 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 		multiProvider.SetDefault("openrouter")
 	}
 
-	// Register OpenRouter (always registered if configured)
-	if p, ok := cfg.Providers["openrouter"]; ok && p.APIKey != "" {
+	// Register OpenRouter (if configured and enabled)
+	if p, ok := cfg.Providers["openrouter"]; ok && p.APIKey != "" && p.Enabled {
 		openrouterProvider, err := providers.GetProvider("openrouter", providers.Config{
 			APIKey:       p.APIKey,
 			APIBase:      p.APIBase,
@@ -320,7 +320,7 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 		if err != nil {
 			log.Warn("Failed to create OpenRouter provider", "error", err)
 		} else {
-			multiProvider.Register("openrouter", openrouterProvider, cfg.Agents.Defaults.Model, 0)
+			multiProvider.Register("openrouter", openrouterProvider, cfg.Agents.Defaults.Model, 0, p.Enabled)
 		}
 	}
 
@@ -338,7 +338,7 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 			if idx := indexOf(cfg.ProviderDefaults.FallbackOrder, "nvidia"); idx >= 0 {
 				priority = idx + 1
 			}
-			multiProvider.Register("nvidia", nvidiaProvider, "", priority)
+			multiProvider.Register("nvidia", nvidiaProvider, "", priority, p.Enabled)
 		}
 	}
 
@@ -356,7 +356,7 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 			if idx := indexOf(cfg.ProviderDefaults.FallbackOrder, "groq"); idx >= 0 {
 				priority = idx + 1
 			}
-			multiProvider.Register("groq", groqProvider, "", priority)
+			multiProvider.Register("groq", groqProvider, "", priority, p.Enabled)
 		}
 	}
 
@@ -387,7 +387,7 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 			if model == "" {
 				model = providers.GetDefaultModel("ollama")
 			}
-			multiProvider.Register("ollama", ollamaProvider, model, priority)
+			multiProvider.Register("ollama", ollamaProvider, model, priority, p.Enabled)
 		}
 	}
 
@@ -422,7 +422,7 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 						break
 					}
 				}
-				multiProvider.Register("github-copilot", copilotProvider, copilotCfg.Model, priority)
+				multiProvider.Register("github-copilot", copilotProvider, copilotCfg.Model, priority, p.Enabled)
 				log.Info("Registered provider", "name", "github-copilot", "priority", priority)
 			}
 		}

--- a/internal/providers/multiprovider.go
+++ b/internal/providers/multiprovider.go
@@ -13,6 +13,7 @@ type ProviderEntry struct {
 	Provider Provider // The actual provider instance
 	Model    string   // Default model for this provider
 	Priority int      // Fallback order (0 = primary, higher = later fallback)
+	Enabled  bool     // Whether this provider is enabled for fallback
 }
 
 // MultiProviderConfig holds configuration for the multi-provider.
@@ -49,15 +50,21 @@ func NewMultiProvider(cfg MultiProviderConfig) *MultiProvider {
 }
 
 // Register adds a provider to the fallback chain.
-func (mp *MultiProvider) Register(name string, provider Provider, model string, priority int) {
+func (mp *MultiProvider) Register(name string, provider Provider, model string, priority int, enabled ...bool) {
 	mp.mu.Lock()
 	defer mp.mu.Unlock()
+
+	isEnabled := true
+	if len(enabled) > 0 {
+		isEnabled = enabled[0]
+	}
 
 	entry := &ProviderEntry{
 		Name:     name,
 		Provider: provider,
 		Model:    model,
 		Priority: priority,
+		Enabled:  isEnabled,
 	}
 
 	mp.entries[name] = entry
@@ -265,7 +272,7 @@ func (mp *MultiProvider) resolveModel(entry *ProviderEntry, requestedModel strin
 	return entry.Provider.Config().Model
 }
 
-// getFallbackChain returns providers in fallback order.
+// getFallbackChain returns providers in fallback order, excluding disabled providers.
 func (mp *MultiProvider) getFallbackChain(startProvider string) []*ProviderEntry {
 	mp.mu.RLock()
 	defer mp.mu.RUnlock()
@@ -273,15 +280,15 @@ func (mp *MultiProvider) getFallbackChain(startProvider string) []*ProviderEntry
 	result := make([]*ProviderEntry, 0, len(mp.orderedEntries))
 	seen := make(map[string]bool)
 
-	// Start with specified provider
-	if entry, exists := mp.entries[startProvider]; exists {
+	// Start with specified provider (only if enabled)
+	if entry, exists := mp.entries[startProvider]; exists && entry.Enabled {
 		result = append(result, entry)
 		seen[startProvider] = true
 	}
 
-	// Add remaining by priority
+	// Add remaining enabled providers by priority
 	for _, entry := range mp.orderedEntries {
-		if !seen[entry.Name] {
+		if !seen[entry.Name] && entry.Enabled {
 			result = append(result, entry)
 			seen[entry.Name] = true
 		}
@@ -302,10 +309,20 @@ func (mp *MultiProvider) GetProviderNames() []string {
 	return names
 }
 
-// HasProvider returns true if a provider is registered.
+// HasProvider returns true if a provider is registered and enabled.
 func (mp *MultiProvider) HasProvider(name string) bool {
 	mp.mu.RLock()
 	defer mp.mu.RUnlock()
-	_, exists := mp.entries[name]
-	return exists
+	entry, exists := mp.entries[name]
+	return exists && entry.Enabled
+}
+
+// SetEnabled enables or disables a provider in the fallback chain.
+func (mp *MultiProvider) SetEnabled(name string, enabled bool) {
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
+	if entry, exists := mp.entries[name]; exists {
+		entry.Enabled = enabled
+		mp.rebuildOrderedList()
+	}
 }

--- a/internal/providers/multiprovider_test.go
+++ b/internal/providers/multiprovider_test.go
@@ -488,3 +488,138 @@ func TestMultiProvider_TimeoutContext(t *testing.T) {
 		t.Logf("got error: %v", err)
 	}
 }
+
+func TestMultiProvider_DisabledProviderNotInFallbackChain(t *testing.T) {
+	mp := NewMultiProvider(MultiProviderConfig{
+		DefaultProvider: "enabled1",
+	})
+
+	// Register enabled provider
+	enabled1 := &mockProvider{name: "enabled1"}
+	mp.Register("enabled1", enabled1, "model1", 0, true)
+
+	// Register disabled provider
+	disabled := &mockProvider{name: "disabled"}
+	mp.Register("disabled", disabled, "model2", 1, false)
+
+	// Register another enabled provider
+	enabled2 := &mockProvider{name: "enabled2"}
+	mp.Register("enabled2", enabled2, "model3", 2, true)
+
+	// Get fallback chain
+	chain := mp.getFallbackChain("enabled1")
+
+	// Should only have 2 enabled providers
+	if len(chain) != 2 {
+		t.Errorf("getFallbackChain() len = %d, want 2", len(chain))
+	}
+
+	// Check provider names
+	if chain[0].Name != "enabled1" {
+		t.Errorf("first provider = %q, want %q", chain[0].Name, "enabled1")
+	}
+	if chain[1].Name != "enabled2" {
+		t.Errorf("second provider = %q, want %q", chain[1].Name, "enabled2")
+	}
+}
+
+func TestMultiProvider_DisabledProviderNotUsed(t *testing.T) {
+	mp := NewMultiProvider(MultiProviderConfig{
+		DefaultProvider: "primary",
+	})
+
+	// Primary is disabled
+	primary := &mockProvider{
+		name:    "primary",
+		chatErr: &FallbackError{StatusCode: 503, Message: "unavailable", Provider: "primary"},
+	}
+	mp.Register("primary", primary, "model1", 0, false)
+
+	// Secondary is enabled but should fail
+	secondary := &mockProvider{
+		name:    "secondary",
+		chatErr: &FallbackError{StatusCode: 503, Message: "unavailable", Provider: "secondary"},
+	}
+	mp.Register("secondary", secondary, "model2", 1, true)
+
+	// Should skip primary and try secondary
+	_, err := mp.Chat(context.Background(), ChatRequest{
+		Model:    "test",
+		Messages: []Message{{Role: RoleUser, Content: "hello"}},
+	})
+
+	// Both should fail, but it should try both (not just primary)
+	if err == nil {
+		t.Error("expected error when all providers fail")
+	}
+
+	// Verify primary was never called (since it's disabled)
+	if primary.chatCalls > 0 {
+		t.Errorf("disabled provider should not be called, but was called %d times", primary.chatCalls)
+	}
+
+	// Secondary should have been called
+	if secondary.chatCalls != 1 {
+		t.Errorf("secondary provider should be called once, was called %d times", secondary.chatCalls)
+	}
+}
+
+func TestMultiProvider_SetEnabled(t *testing.T) {
+	mp := NewMultiProvider(MultiProviderConfig{
+		DefaultProvider: "provider1",
+	})
+
+	p1 := &mockProvider{name: "provider1"}
+	p2 := &mockProvider{name: "provider2"}
+
+	// Register both as enabled initially
+	mp.Register("provider1", p1, "model1", 0, true)
+	mp.Register("provider2", p2, "model2", 1, true)
+
+	// Disable provider2
+	mp.SetEnabled("provider2", false)
+
+	// Check that HasProvider returns false for disabled
+	if mp.HasProvider("provider2") {
+		t.Error("HasProvider should return false for disabled provider")
+	}
+
+	// Check that provider2 is not in fallback chain
+	chain := mp.getFallbackChain("provider1")
+	if len(chain) != 1 {
+		t.Errorf("getFallbackChain() len = %d, want 1", len(chain))
+	}
+
+	// Re-enable provider2
+	mp.SetEnabled("provider2", true)
+
+	// Check that HasProvider returns true
+	if !mp.HasProvider("provider2") {
+		t.Error("HasProvider should return true for re-enabled provider")
+	}
+
+	// Check fallback chain again
+	chain = mp.getFallbackChain("provider1")
+	if len(chain) != 2 {
+		t.Errorf("getFallbackChain() len = %d, want 2", len(chain))
+	}
+}
+
+func TestMultiProvider_DefaultEnabled(t *testing.T) {
+	mp := NewMultiProvider(MultiProviderConfig{
+		DefaultProvider: "provider1",
+	})
+
+	// Register without explicit enabled parameter (should default to true)
+	p1 := &mockProvider{name: "provider1"}
+	mp.Register("provider1", p1, "model1", 0)
+
+	if !mp.HasProvider("provider1") {
+		t.Error("HasProvider should return true for provider registered without explicit enabled")
+	}
+
+	chain := mp.getFallbackChain("provider1")
+	if len(chain) != 1 {
+		t.Errorf("getFallbackChain() len = %d, want 1", len(chain))
+	}
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -105,3 +105,18 @@ Provider reliability subtasks:
 - [x] Add tests for FallbackError in LiteLLM provider
 - [x] Add tests for error fallback logic
 - [x] Run relevant go tests
+
+---
+
+# Current Task: Fix fallback logic using providers with enabled=false
+
+## Issue
+- main.go line 311: OpenRouter registered WITHOUT checking `p.Enabled`
+- Other providers (nvidia, groq, ollama, github-copilot) correctly check `p.Enabled`
+- Fallback chain includes all registered providers regardless of config Enabled status
+
+## Plan
+- [x] Fix main.go: Add `p.Enabled` check for OpenRouter registration  
+- [x] Add Enabled field to ProviderEntry in multiprovider for runtime filtering
+- [x] Add tests for enabled/disabled provider behavior in fallback
+- [x] Run verification: go test ./..., go vet ./..., go build ./cmd/joshbot


### PR DESCRIPTION
## Summary

- Add `Enabled` field to `ProviderEntry` struct in multiprovider
- Update `Register` method to accept optional `enabled` parameter (defaults to true)
- Filter disabled providers from `getFallbackChain` to exclude them from fallback rotation
- Update `HasProvider` to check `Enabled` status before returning true
- Add `SetEnabled` method to dynamically enable/disable providers at runtime
- Update `main.go` to pass `Enabled` flag when registering all providers (OpenRouter, NVIDIA, Groq, Ollama, GitHub Copilot)
- Add comprehensive tests for disabled provider behavior

This enables proper provider lifecycle management - providers can be configured but disabled, allowing them to be enabled later without reconfiguration.