### PR TITLE
fix: model config bugs + configure CLI flags + tests

### DIFF
--- a/.opencode/skills/release-management/SKILL.md
+++ b/.opencode/skills/release-management/SKILL.md
@@ -63,6 +63,8 @@ gh run list --workflow=release.yml --limit 3
 gh run watch <RUN_ID> --exit-status
 ```
 
+- [ ] Step 2a: WAIT for CI on main commit to pass (green checkmark) BEFORE pushing tag
+
 ### Step 3: Verify Release
 
 ```bash
@@ -115,6 +117,9 @@ gh release edit v<X.Y.Z> --latest
 
 | Version | Date | Description |
 |---------|------|-------------|
+| v1.19.0 | 2026-05-17 | Intelligent memory + skill self-creation |
+| v1.18.0 | 2026-05-17 | Code simplification + test expansion + AGENTS.md rewrite |
+| v1.17.1 | 2026-04-02 | Smoke tests + SECURITY.md + broken MCP removal |
 | v1.12.1 | 2026-02-25 | Model/provider sync fix, tool_call_id preservation |
 | v1.12.0 | 2026-02-24 | Exa crawl for web_fetch, version/status display fixes |
 | v1.11.0 | 2026-02-24 | Enhanced Ollama integration |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,14 +106,30 @@ type Provider interface {
 
 ## Config
 
-Config at `~/.joshbot/config.json`. Env var overrides with `JOSHBOT_` prefix (e.g., `JOSHBOT_PROVIDERS_OPENROUTER_API_KEY`). Model-name-based provider routing: `claude` → Anthropic, `gpt` → OpenAI, `gemini` → Gemini. Default fallback: OpenRouter.
+Config at `~/.joshbot/config.json`. Env var overrides with `JOSHBOT_` prefix (e.g., `JOSHBOT_PROVIDERS__OPENROUTER__API_KEY`). Model-name-based provider routing: `claude` → Anthropic, `gpt` → OpenAI, `gemini` → Gemini. Default fallback: OpenRouter.
 
+**Legacy Provider Format:**
 ```json
 {
   "agents": { "defaults": { "workspace": "~/.joshbot/workspace", "model": "openrouter/anthropic/claude-sonnet-4-20250514", "max_tool_iterations": 20 } },
   "providers": { "openrouter": { "api_key": "" }, "anthropic": {}, ... },
-  "channels": { "telegram": { "enabled": false, "token": "", "allow_from": [] } },
-  "heartbeat": { "enabled": true, "interval": 30 }
+  "channels": { "telegram": { "enabled": false, "token": "", "allow_from": [] } }
+}
+```
+
+**Model-Centric Format (Recommended):**
+```json
+{
+  "models_config": {
+    "models": [
+      { "name": "smart", "model": "anthropic/claude-sonnet-4", "api_key": "sk-ant-..." },
+      { "name": "fast", "model": "groq/llama-3.3-70b-versatile", "api_key": "gsk_..." }
+    ],
+    "agent": { "model": "smart", "fallback": ["fast"] }
+  },
+  "channels": {
+    "telegram": { "enabled": false, "token": "", "allow_from": [] }
+  }
 }
 ```
 
@@ -126,6 +142,41 @@ Config at `~/.joshbot/config.json`. Env var overrides with `JOSHBOT_` prefix (e.
 - **Workspace identity files**: `IDENTITY.md`, `SOUL.md`, `USER.md`, `AGENTS.md`, `TOOLS.md` loaded into system prompt via XML tags
 - **Service cross-platform**: `internal/service/` uses build tags (`factory_linux.go`, `factory_darwin.go`, `factory_other.go`) — each must export the same function signature. Also has `systemd.go`, `launchd.go`, `openrc.go`, `unsupported.go`
 - **`pkg/` is stale**: `pkg/` duplicates `internal/bus` and `internal/channels` — do not edit unless purposely finishing the refactor
+
+## Provider Enabled Flag
+
+Providers require `"enabled": true` in config to activate. This is a required boolean field:
+
+```json
+{
+  "providers": {
+    "nvidia": {
+      "api_key": "nvapi-...",
+      "enabled": true
+    }
+  }
+}
+```
+
+Environment variables also set `enabled: true` automatically when a provider is configured via env var.
+
+## Env Var Format
+
+All config values can be overridden with `JOSHBOT_` prefix env vars using `__` as path separator:
+
+```bash
+# Canonical format (use provider routing key):
+export JOSHBOT_PROVIDERS__OPENROUTER__API_KEY="sk-or-..."
+export JOSHBOT_PROVIDERS__NVIDIA__API_KEY="nvapi-..."
+
+# Model-centric format:
+export JOSHBOT_MODELS_CONFIG__AGENT__MODEL="smart"
+export JOSHBOT_MODELS_CONFIG__MODELS__0__NAME="fast"
+export JOSHBOT_MODELS_CONFIG__MODELS__0__MODEL="groq/llama-3.3-70b-versatile"
+export JOSHBOT_MODELS_CONFIG__MODELS__0__API_KEY="gsk_..."
+```
+
+Shorthand forms like `JOSHBOT_OPENROUTER_API_KEY` and `JOSHBOT_NVIDIA_API_KEY` are also accepted for backward compatibility.
 
 ## Pre-Release Checklist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-05-17
+
+### Added
+
+#### Intelligent Memory System
+- **Structured Fact format** — Facts stored with SHA256-based `FactID`, category enum (`user_info`, `preference`, `project`, `decision`, `skill`, `system`), confidence scoring (0.0-1.0), source tracking, and deduplication
+- **Memory search tool** (`memory_search`) — Keyword + category + tag search with relevance scoring (recency, confidence, access count, keyword match)
+- **Markdown-backed persistence** — Facts stored in MEMORY.md with backward-compatible user-editable format
+- **Metadata support** — `UserMetadata` struct for tracking memory version, preferences, and last updated
+- **Fact reconciliation** — `ReconcileFacts()` merges new facts with existing memory via upsert + dedup + eviction (max 100 facts)
+- **Learning extraction** — `learning.go` now extracts structured facts from conversations with LLM-based summarization
+- **New files**: `internal/memory/fact.go`, `search.go`, `metadata.go`, `internal/tools/memory_tool.go`
+
+#### Skill Self-Creation
+- **Skill Detection** — Weighted heuristic scoring system (`SkillDetector`) that detects skill-worthy patterns from conversation traces (3+ tool use triggers, repeated command patterns, explicit skill creation requests). Threshold: ≥2.0 confidence
+- **LLM-based Skill Extraction** — `Extractor` generates valid SKILL.md files from conversation traces using an LLM prompt
+- **Skill Validation** — `ValidateSkill()` checks YAML frontmatter, required fields, name uniqueness, and body content
+- **Skill Registry Tool** (`skill_registry`) — Exposes `list`, `create`, and `delete` actions to the ReAct loop
+- **Skill creation flow** — `CreateSkill()` writes to `~/.joshbot/workspace/skills/{name}/SKILL.md`, auto-discovered by the skills Loader
+- **New files**: `internal/skills/detection.go`, `extraction.go`, `validation.go`, `detection_test.go`, `internal/tools/skill_tool.go`
+
+### Changed
+- `internal/agent/agent.go` — Wire skill detection into reactLoop (after each iteration and after processing)
+- `internal/agent/context.go` — `BuildSmartPrompt` uses strings.Builder, extracted methods
+- `internal/learning/learning.go` — Extracted `saveSummary` and `heuristicFallback` methods
+- `internal/memory/memory.go` — `WriteFacts`, `ReconcileFacts`, structured markdown output with categorized sections
+- `internal/skills/skills.go` — Added `Create()`, `Delete()`, `List()`, `Invalidate()` methods on Loader
+- `internal/tools/registry.go` — Registers SkillRegistryTool alongside defaults
+
+## [1.18.0] - 2026-05-17
+
+### Changed
+- **AGENTS.md rewritten** — Accurate LOC count (~16,000 non-test Go), Go 1.24.0, correct interface signatures
+- **Code simplifications** — Simplified `cleanCommand`, `normalizeUsername`, `joinParts`, `stripHTML`
+- **Schema building deduplication** — Replaced duplicated schema building in `toolToProviderTool` with `GenerateSchema`
+- **Dead code removal** — Removed `FormatToolResult`, `FormatAssistantToolCalls`, `stringsSplitN`
+- **Regex compilation fix** — Eliminated regex in `extractStatusCode`, fixed false positive on port numbers
+- **Provider normalization** — Simplified `normalizeProviderName` with case-insensitive lookup
+
+### Added
+- Unit tests for `scanStatusCode`, `scanAnyStatusCode`, `normalizeProviderName`
+
 ## [1.17.1] - 2026-04-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ A lightweight personal AI assistant written in Go, featuring self-learning memor
 
 ## Features
 
-- **Self-Learning Memory** - Automatically remembers important facts across conversations (MEMORY.md + HISTORY.md)
+- **Self-Learning Memory** - Automatically remembers important facts across conversations using a structured fact system (categorized with SHA256-based IDs, confidence scoring, source tracking, and deduplication)
 - **Context Compression** - Summarizes old context to stay within token limits; works well with small local models
-- **Skill Self-Creation** - Creates new capabilities for itself as markdown files
+- **Skill Self-Creation** - Creates new capabilities for itself as markdown files, with auto-detection from conversation patterns and LLM-based extraction
 - **Subagent Delegation** - Spawns focused subagents for complex multi-step tasks
 - **Telegram Integration** - Chat from your phone with full media support
 - **Interactive CLI** - Rich terminal interface with markdown rendering
@@ -107,24 +107,26 @@ joshbot onboard --keep-data  # Reconfigure but preserve memory/skills
 ```
 
 The onboard flow will:
-- Ask for your OpenRouter API key (free at [openrouter.ai/keys](https://openrouter.ai/keys))
+- Ask for your LLM API key (defaults to NVIDIA NIM; OpenRouter free tier also supported at [openrouter.ai/keys](https://openrouter.ai/keys))
 - Let you choose a personality (Professional, Friendly, Sarcastic, Minimal, or Custom)
 - Set up your workspace and memory files
 
 ## Memory System
 
-joshbot uses a two-file memory system that learns from your conversations:
+joshbot uses a structured fact-based memory system that learns from your conversations:
 
 | File | Purpose |
 |------|---------|
-| `MEMORY.md` | Long-term facts (always in context) |
+| `MEMORY.md` | Long-term structured facts (always in context) |
 | `HISTORY.md` | Searchable event log with timestamps |
+
+Facts use a structured format with SHA256-based IDs, categorized by type (`user_info`, `preference`, `project`, `decision`, `skill`, `system`), with confidence scoring (0.0-1.0) and source tracking. The `memory_search` tool enables keyword + category + tag search with relevance scoring.
 
 ### Memory Consolidation
 
 When conversations grow large:
 1. Old messages are summarized by the LLM
-2. Key facts are extracted to MEMORY.md
+2. Key facts are extracted as structured facts to MEMORY.md (with reconciliation to avoid duplicates)
 3. A summary is appended to HISTORY.md
 4. Context is compressed to stay within limits
 
@@ -415,6 +417,8 @@ After auth, you can run `joshbot agent` or `joshbot gateway` normally.
 | `message` | Send messages to channels |
 | `spawn` | Create background tasks |
 | `cron` | Schedule reminders/tasks |
+| `memory_search` | Search stored facts by keyword, category, or tags |
+| `skill_registry` | List, create, and delete skills |
 
 **Security defaults:**
 - `web_fetch` blocks localhost, private IP ranges, and metadata hosts (SSRF protection).
@@ -435,8 +439,10 @@ After auth, you can run `joshbot agent` or `joshbot gateway` normally.
 joshbot/
 ├── cmd/joshbot/     # CLI entry point
 ├── internal/
-│   ├── agent/       # Core brain (loop, context, memory, skills)
-│   ├── tools/       # Built-in tools
+│   ├── agent/       # Core brain (loop, context)
+│   ├── memory/      # Structured fact store (fact.go, search.go, metadata.go)
+│   ├── skills/      # Skill discovery, detection, extraction, validation
+│   ├── tools/       # Built-in tools (incl. memory_search, skill_registry)
 │   ├── channels/    # Chat integrations (CLI, Telegram)
 │   ├── bus/         # Message bus (decouples channels from agent)
 │   ├── providers/   # LLM provider layer

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.17.x  | :white_check_mark: |
-| < 1.17  | :x:                |
+| 1.18.x, 1.19.x | :white_check_mark: |
+| < 1.18         | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -50,3 +50,8 @@ When running joshbot:
 - **File permissions**: Auth files are created with `0600` permissions
 - **Input validation**: All tool inputs are validated before execution
 - **Sandbox awareness**: joshbot runs with the same permissions as the user — it does not implement its own sandbox
+
+### Tool-Specific Security Notes
+
+- **`memory_search` tool**: Can read all stored facts, including potentially sensitive information in MEMORY.md. Access control is file-permission based — ensure `~/.joshbot/` directory permissions are restrictive.
+- **`skill_registry` tool**: Can create, list, and delete skills (SKILL.md files). Skill creation writes files under `~/.joshbot/workspace/skills/` and can introduce new instructions for the agent to follow. Treat skill changes as configuration changes — review skill content before use.

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -1716,7 +1716,7 @@ func promptProviderAPIKey(provider string, existingCfg *config.Config) (string, 
 	// Show existing key if available
 	if existingCfg != nil {
 		if p, ok := existingCfg.Providers[provider]; ok && p.APIKey != "" {
-			fmt.Printf("Current API key: %s\n", maskAPIKey(p.APIKey))
+			fmt.Printf("Current API key: %s\n", configure.MaskAPIKey(p.APIKey))
 			fmt.Print("Enter new API key (or press Enter to keep current): ")
 		} else {
 			fmt.Printf("Enter your %s (or press Enter to skip): ", keyName)
@@ -2415,7 +2415,7 @@ func runConfigureWizard(cfg *config.Config) error {
 				status += " (default)"
 			}
 
-			fmt.Printf("  %s %s (%s)\n", icon, getProviderDisplayName(name), status)
+			fmt.Printf("  %s %s (%s)\n", icon, configure.GetProviderDisplayName(name), status)
 		}
 
 		fmt.Println()
@@ -2466,24 +2466,6 @@ func runConfigureWizard(cfg *config.Config) error {
 	}
 }
 
-// getProviderDisplayName returns the display name for a provider.
-func getProviderDisplayName(name string) string {
-	switch name {
-	case "nvidia":
-		return "NVIDIA NIM"
-	case "openrouter":
-		return "OpenRouter"
-	case "groq":
-		return "Groq"
-	case "ollama":
-		return "Ollama"
-	case "github-copilot":
-		return "GitHub Copilot"
-	default:
-		return name
-	}
-}
-
 // configureProvider prompts the user to configure a specific provider.
 func configureProvider(cfg *config.Config, provider string) *config.Config {
 	// Initialize providers map if needed
@@ -2493,7 +2475,7 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 
 	p, exists := cfg.Providers[provider]
 
-	fmt.Printf("\n=== Configure %s ===\n", getProviderDisplayName(provider))
+	fmt.Printf("\n=== Configure %s ===\n", configure.GetProviderDisplayName(provider))
 	fmt.Println()
 
 	// Get API key (skip for OAuth-based providers)
@@ -2501,7 +2483,7 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 	if provider != "github-copilot" {
 		fmt.Print("API key")
 		if exists && p.APIKey != "" {
-			fmt.Printf(" [%s]", maskAPIKey(p.APIKey))
+			fmt.Printf(" [%s]", configure.MaskAPIKey(p.APIKey))
 		}
 		fmt.Print(": ")
 
@@ -2955,7 +2937,7 @@ func setDefaultProvider(cfg *config.Config) *config.Config {
 		if name == cfg.ProviderDefaults.Default {
 			marker = "*"
 		}
-		fmt.Printf("  %d. %s %s\n", i+1, marker, getProviderDisplayName(name))
+		fmt.Printf("  %d. %s %s\n", i+1, marker, configure.GetProviderDisplayName(name))
 	}
 	fmt.Println()
 
@@ -2977,7 +2959,7 @@ func setDefaultProvider(cfg *config.Config) *config.Config {
 	} else {
 		cfg.Agents.Defaults.Model = providers.GetDefaultModel(cfg.ProviderDefaults.Default)
 	}
-	fmt.Printf("\nDefault provider set to: %s\n", getProviderDisplayName(cfg.ProviderDefaults.Default))
+	fmt.Printf("\nDefault provider set to: %s\n", configure.GetProviderDisplayName(cfg.ProviderDefaults.Default))
 
 	return cfg
 }
@@ -3004,13 +2986,13 @@ func configureFallbackOrder(cfg *config.Config) *config.Config {
 		fmt.Println("  (not set - will use providers as configured)")
 	} else {
 		for i, name := range cfg.ProviderDefaults.FallbackOrder {
-			fmt.Printf("  %d. %s\n", i+1, getProviderDisplayName(name))
+			fmt.Printf("  %d. %s\n", i+1, configure.GetProviderDisplayName(name))
 		}
 	}
 	fmt.Println()
 	fmt.Println("Available providers:")
 	for i, name := range configured {
-		fmt.Printf("  %d. %s\n", i+1, getProviderDisplayName(name))
+		fmt.Printf("  %d. %s\n", i+1, configure.GetProviderDisplayName(name))
 	}
 	fmt.Println()
 	fmt.Print("Enter fallback order (e.g., 1,2,3): ")
@@ -3245,21 +3227,6 @@ func statusBool(b bool) string {
 		return "(exists)"
 	}
 	return "(missing)"
-}
-
-// maskAPIKey masks an API key for display, showing only the first few and last few characters.
-// Example: "sk-or-v1-abc123...xyz789" -> "sk-or-v1-****...****4c0"
-func maskAPIKey(key string) string {
-	if key == "" {
-		return ""
-	}
-	if len(key) <= 16 {
-		return key[:2] + "****" + key[len(key)-4:]
-	}
-	// Show first 8 and last 4 characters
-	prefix := key[:8]
-	suffix := key[len(key)-4:]
-	return prefix + "****...****" + suffix
 }
 
 // maskToken masks a Telegram bot token for display.

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bigknoxy/joshbot/internal/bus"
 	"github.com/bigknoxy/joshbot/internal/channels"
 	"github.com/bigknoxy/joshbot/internal/config"
+	"github.com/bigknoxy/joshbot/internal/configure"
 	ctxpkg "github.com/bigknoxy/joshbot/internal/context"
 	"github.com/bigknoxy/joshbot/internal/copilot"
 	"github.com/bigknoxy/joshbot/internal/cron"
@@ -181,9 +182,29 @@ func runApp() error {
 						Name:  "list",
 						Usage: "List configured providers",
 					},
-					&cli.BoolFlag{
-						Name:  "default",
-						Usage: "Set default provider",
+					&cli.StringFlag{
+						Name:  "provider",
+						Usage: "Provider to configure (nvidia, openrouter, groq, ollama, github-copilot)",
+					},
+					&cli.StringFlag{
+						Name:  "api-key",
+						Usage: "API key for the provider",
+					},
+					&cli.StringFlag{
+						Name:  "api-base",
+						Usage: "API base URL for the provider",
+					},
+					&cli.StringFlag{
+						Name:  "model",
+						Usage: "Model to use for the provider",
+					},
+					&cli.StringFlag{
+						Name:  "set-default",
+						Usage: "Set a provider as the default",
+					},
+					&cli.StringFlag{
+						Name:  "remove",
+						Usage: "Remove a configured provider",
 					},
 				},
 				Action: runConfigure,
@@ -192,6 +213,11 @@ func runApp() error {
 				Name:   "update",
 				Usage:  "Update joshbot to the latest version",
 				Action: runUpdate,
+			},
+			{
+				Name:   "version",
+				Usage:  "Show joshbot version",
+				Action: runVersion,
 			},
 			{
 				Name:  "uninstall",
@@ -365,6 +391,7 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 				APIKey:       p.APIKey,
 				APIBase:      p.APIBase,
 				ExtraHeaders: p.ExtraHeaders,
+				Model:        p.Model,
 			})
 			if err != nil {
 				log.Warn("Failed to create NVIDIA provider", "error", err)
@@ -373,7 +400,11 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 				if idx := indexOf(cfg.ProviderDefaults.FallbackOrder, "nvidia"); idx >= 0 {
 					priority = idx + 1
 				}
-				multiProvider.Register("nvidia", nvidiaProvider, "", priority, p.Enabled)
+				model := p.Model
+				if model == "" {
+					model = providers.GetDefaultModel("nvidia")
+				}
+				multiProvider.Register("nvidia", nvidiaProvider, model, priority, p.Enabled)
 			}
 		}
 
@@ -748,6 +779,11 @@ func runAgentSingleMessage(ctx context.Context, agentInstance agentProcessor, me
 	}
 
 	fmt.Fprintln(output, strings.TrimSpace(response))
+	return nil
+}
+
+func runVersion(c *cli.Context) error {
+	fmt.Printf("joshbot version %s\n", Version)
 	return nil
 }
 
@@ -2239,19 +2275,60 @@ func runStatus(c *cli.Context) error {
 
 // runConfigure handles the configure command.
 func runConfigure(c *cli.Context) error {
-	// Load existing config
 	cfg, err := config.Load()
 	if err != nil {
 		return err
 	}
 
-	// --list flag: show providers and exit
+	conf := configure.New(cfg)
+
 	if c.Bool("list") {
 		return listProviders(cfg)
 	}
 
-	// Interactive wizard
+	if provider := c.String("remove"); provider != "" {
+		if err := conf.RemoveProvider(provider); err != nil {
+			return err
+		}
+		fmt.Printf("Removed provider %q.\n", provider)
+		return flushConfig(cfg)
+	}
+
+	if c.IsSet("provider") {
+		opts := configure.ProviderOptions{
+			Name:   c.String("provider"),
+			APIKey: c.String("api-key"),
+			Model:  c.String("model"),
+		}
+		if c.IsSet("api-base") {
+			opts.APIBase = c.String("api-base")
+		}
+		if err := conf.ConfigureProvider(opts); err != nil {
+			return err
+		}
+		fmt.Printf("Provider %q configured with model %q.\n", opts.Name, cfg.Providers[opts.Name].Model)
+	}
+
+	if provider := c.String("set-default"); provider != "" {
+		if err := conf.SetDefault(provider); err != nil {
+			return err
+		}
+		fmt.Printf("Default provider set to %q with model %q.\n", provider, cfg.Agents.Defaults.Model)
+	}
+
+	if c.IsSet("provider") || c.IsSet("set-default") {
+		return flushConfig(cfg)
+	}
+
 	return runConfigureWizard(cfg)
+}
+
+func flushConfig(cfg *config.Config) error {
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+	fmt.Println("Configuration saved.")
+	return nil
 }
 
 // listProviders displays the configured providers.
@@ -2669,9 +2746,14 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 	p.Enabled = true
 	cfg.Providers[provider] = p
 
-	// If this is the first provider, set it as default
+	// If this is the first provider, set it as default with its model
 	if cfg.ProviderDefaults.Default == "" {
 		cfg.ProviderDefaults.Default = provider
+		if p.Model != "" {
+			cfg.Agents.Defaults.Model = p.Model
+		} else {
+			cfg.Agents.Defaults.Model = providers.GetDefaultModel(provider)
+		}
 	}
 
 	fmt.Println()
@@ -2888,7 +2970,13 @@ func setDefaultProvider(cfg *config.Config) *config.Config {
 	}
 
 	cfg.ProviderDefaults.Default = configured[choice-1]
-	cfg.Agents.Defaults.Model = providers.GetDefaultModel(cfg.ProviderDefaults.Default)
+
+	// Use user-configured per-provider model if available, else registry default
+	if p, ok := cfg.Providers[cfg.ProviderDefaults.Default]; ok && p.Model != "" {
+		cfg.Agents.Defaults.Model = p.Model
+	} else {
+		cfg.Agents.Defaults.Model = providers.GetDefaultModel(cfg.ProviderDefaults.Default)
+	}
 	fmt.Printf("\nDefault provider set to: %s\n", getProviderDisplayName(cfg.ProviderDefaults.Default))
 
 	return cfg

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -189,3 +189,44 @@ Return a helpful error message explaining alternatives when systemctl is not fou
 - Concurrency: Double-checked locking with RLock/RWMutex ensures thread safety
 
 **Prevention Rule**: When implementing caching, always include a way to invalidate the cache. Prefer content-based or mtime-based invalidation over TTL-based for data that changes infrequently.
+
+---
+
+## 2026-05-17 CI Failure: gofmt Formatting After Release Tag
+
+**Context**: v1.19.0 release was tagged and pushed alongside main commit. CI run failed because `gofmt -l .` returned `internal/learning/learning.go` — vertical-alignment padding in a struct literal.
+
+**Root Cause**: Release tag was pushed at the same time as the main commit, before CI could verify the code. The `gofmt` check (`.github/workflows/ci.yml`) caught the formatting issue, but since the tag was already pushed, it had to be deleted and re-pushed.
+
+**Fix**:
+1. Run `gofmt -w internal/learning/learning.go` to fix formatting
+2. Added `gofmt -d .` to pre-release checklist in AGENTS.md
+3. Documented release process: push main → WAIT for CI green → cut tag
+4. Recorded lesson in `tasks/lessons.md`
+
+**Prevention Rule**: NEVER push main commit and release tag simultaneously. Push main first, wait for CI green checkmark, then cut and push the tag. Always run `gofmt -d .` (or `gofmt -l .`) before committing.
+
+---
+
+## 2026-05-18 Env Var Backward Compatibility for Shorthand Names
+
+**Context**: Dogfood testing revealed that `JOSHBOT_OPENROUTER_API_KEY` (single-underscore) was not picked up by the config system, which expects `JOSHBOT_PROVIDERS__OPENROUTER__API_KEY` (double underscores, full path).
+
+**Decision**: Added backward-compatible fallback checks in `applyEnvOverrides()` in `internal/config/config.go`:
+- `JOSHBOT_PROVIDERS__OPENROUTER__API_KEY` has priority, falls back to `JOSHBOT_OPENROUTER_API_KEY`
+- `JOSHBOT_PROVIDERS__NVIDIA__API_KEY` has priority, falls back to `JOSHBOT_NVIDIA_API_KEY`
+- Env var presence also sets `Enabled: true` automatically (no need for config.json entry)
+
+**Reasoning**: The shorthand forms are intuitive and commonly set by users. The `__` (double-underscore) path separator is technically precise but easy to get wrong. Supporting both ensures backward compatibility and better DX.
+
+**Prevention Rule**: When designing env var override systems, always support both the canonical path-based name and common shorthand names for widely-used config values. The `__` separator in env vars is non-obvious — document it clearly.
+
+---
+
+## 2026-05-18 Config Test Environment Isolation with TestMain
+
+**Context**: Adding `JOSHBOT_OPENROUTER_API_KEY` fallback in `applyEnvOverrides` caused `TestLoadSanitizesWhitespace` to fail because the real env var overwrote the test's config value.
+
+**Decision**: Added `TestMain()` to `internal/config/config_test.go` that saves all `JOSHBOT_` env vars, clears them before tests, and restores them after.
+
+**Prevention Rule**: Any config package that reads environment variables must use `TestMain` or equivalent to isolate tests from the user's shell environment. Env-sensitive tests should never assume a clean environment.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/term v0.40.0
+	golang.org/x/text v0.3.7
 	gopkg.in/telebot.v3 v3.3.8
 )
 

--- a/go.sum
+++ b/go.sum
@@ -629,6 +629,7 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -441,15 +441,21 @@ func applyEnvOverrides(cfg *Config) {
 	}
 
 	// Provider API keys
-	if v := getEnv("PROVIDERS__OPENROUTER__API_KEY"); v != "" {
+	// Canonical: JOSHBOT_PROVIDERS__OPENROUTER__API_KEY
+	// Shorthand (also accepted): JOSHBOT_OPENROUTER_API_KEY
+	orKey := getEnv("PROVIDERS__OPENROUTER__API_KEY")
+	if orKey == "" {
+		orKey = os.Getenv("JOSHBOT_OPENROUTER_API_KEY")
+	}
+	if orKey != "" {
 		if cfg.Providers == nil {
 			cfg.Providers = make(map[string]ProviderConfig)
 		}
 		if p, ok := cfg.Providers["openrouter"]; ok {
-			p.APIKey = v
+			p.APIKey = orKey
 			cfg.Providers["openrouter"] = p
 		} else {
-			cfg.Providers["openrouter"] = ProviderConfig{APIKey: v}
+			cfg.Providers["openrouter"] = ProviderConfig{APIKey: orKey, Enabled: true}
 		}
 	}
 
@@ -462,6 +468,23 @@ func applyEnvOverrides(cfg *Config) {
 			cfg.Providers["openrouter"] = p
 		} else {
 			cfg.Providers["openrouter"] = ProviderConfig{APIBase: v}
+		}
+	}
+
+	// Shorthand: JOSHBOT_NVIDIA_API_KEY
+	nvKey := getEnv("PROVIDERS__NVIDIA__API_KEY")
+	if nvKey == "" {
+		nvKey = os.Getenv("JOSHBOT_NVIDIA_API_KEY")
+	}
+	if nvKey != "" {
+		if cfg.Providers == nil {
+			cfg.Providers = make(map[string]ProviderConfig)
+		}
+		if p, ok := cfg.Providers["nvidia"]; ok {
+			p.APIKey = nvKey
+			cfg.Providers["nvidia"] = p
+		} else {
+			cfg.Providers["nvidia"] = ProviderConfig{APIKey: nvKey, Enabled: true}
 		}
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,8 +3,30 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	// Save and clear JOSHBOT_ env vars so tests run in a clean environment
+	prefix := "JOSHBOT_"
+	saved := map[string]string{}
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, prefix) {
+			parts := strings.SplitN(env, "=", 2)
+			saved[parts[0]] = parts[1]
+			os.Unsetenv(parts[0])
+		}
+	}
+
+	code := m.Run()
+
+	// Restore env vars
+	for k, v := range saved {
+		os.Setenv(k, v)
+	}
+	os.Exit(code)
+}
 
 func TestDefaults(t *testing.T) {
 	cfg := Defaults()

--- a/internal/configure/configure.go
+++ b/internal/configure/configure.go
@@ -1,0 +1,223 @@
+package configure
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bigknoxy/joshbot/internal/config"
+	"github.com/bigknoxy/joshbot/internal/copilot"
+	"github.com/bigknoxy/joshbot/internal/providers"
+)
+
+type ProviderOptions struct {
+	Name    string
+	APIKey  string
+	APIBase string
+	Model   string
+	Timeout time.Duration
+	Enabled bool
+}
+
+type ProviderListItem struct {
+	Name       string
+	Configured bool
+	IsDefault  bool
+	Model      string
+}
+
+type Configurator struct {
+	cfg *config.Config
+}
+
+func New(cfg *config.Config) *Configurator {
+	return &Configurator{cfg: cfg}
+}
+
+func (c *Configurator) Config() *config.Config {
+	return c.cfg
+}
+
+func (c *Configurator) ConfigureProvider(opts ProviderOptions) error {
+	if c.cfg.Providers == nil {
+		c.cfg.Providers = make(map[string]config.ProviderConfig)
+	}
+
+	p, exists := c.cfg.Providers[opts.Name]
+
+	if opts.APIKey != "" {
+		p.APIKey = opts.APIKey
+	} else if !exists {
+		return fmt.Errorf("API key is required for first-time configuration of %q", opts.Name)
+	}
+
+	if opts.APIBase != "" {
+		p.APIBase = opts.APIBase
+	} else if !exists || p.APIBase == "" {
+		p.APIBase = getDefaultAPIBase(opts.Name)
+	}
+
+	if opts.Model != "" {
+		p.Model = opts.Model
+	}
+
+	p.Enabled = true
+	if opts.Timeout > 0 {
+		p.Timeout = opts.Timeout
+	}
+	c.cfg.Providers[opts.Name] = p
+
+	if c.cfg.ProviderDefaults.Default == "" {
+		c.cfg.ProviderDefaults.Default = opts.Name
+		if p.Model != "" {
+			c.cfg.Agents.Defaults.Model = p.Model
+		} else {
+			c.cfg.Agents.Defaults.Model = providers.GetDefaultModel(opts.Name)
+		}
+	}
+
+	return nil
+}
+
+func (c *Configurator) SetDefault(name string) error {
+	if c.cfg.Providers == nil {
+		return fmt.Errorf("no providers configured")
+	}
+	p, ok := c.cfg.Providers[name]
+	if !ok || !p.Enabled {
+		return fmt.Errorf("provider %q is not configured", name)
+	}
+	c.cfg.ProviderDefaults.Default = name
+	if p.Model != "" {
+		c.cfg.Agents.Defaults.Model = p.Model
+	} else {
+		c.cfg.Agents.Defaults.Model = providers.GetDefaultModel(name)
+	}
+	return nil
+}
+
+func (c *Configurator) RemoveProvider(name string) error {
+	if c.cfg.Providers == nil {
+		return fmt.Errorf("no providers configured")
+	}
+	if _, ok := c.cfg.Providers[name]; !ok {
+		return fmt.Errorf("provider %q is not configured", name)
+	}
+	delete(c.cfg.Providers, name)
+	if c.cfg.ProviderDefaults.Default == name {
+		c.cfg.ProviderDefaults.Default = ""
+		for n, p := range c.cfg.Providers {
+			if p.Enabled {
+				c.cfg.ProviderDefaults.Default = n
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Configurator) ListProviders() []ProviderListItem {
+	providerNames := []string{"nvidia", "openrouter", "groq", "ollama", "github-copilot"}
+	defaultName := c.cfg.ProviderDefaults.Default
+	var items []ProviderListItem
+
+	for _, name := range providerNames {
+		p, exists := c.cfg.Providers[name]
+		isDefault := name == defaultName
+		configured := false
+
+		if exists && p.Enabled {
+			if name == "github-copilot" {
+				homeDir, _ := copilot.GetHomeDir()
+				token, err := copilot.LoadToken(homeDir)
+				if err == nil && token != nil && token.AccessToken != "" {
+					configured = true
+				}
+			} else if p.APIKey != "" {
+				configured = true
+			}
+		}
+
+		model := p.Model
+		if model == "" && configured {
+			model = providers.GetDefaultModel(name)
+		}
+
+		items = append(items, ProviderListItem{
+			Name:       name,
+			Configured: configured,
+			IsDefault:  isDefault,
+			Model:      model,
+		})
+	}
+	return items
+}
+
+func (c *Configurator) ValidateProviderCredentials(name string) error {
+	p, ok := c.cfg.Providers[name]
+	if !ok {
+		return fmt.Errorf("provider %q is not configured", name)
+	}
+	baseURL := p.APIBase
+	if baseURL == "" {
+		baseURL = getDefaultAPIBase(name)
+	}
+	_, err := providers.ListModels(providers.Config{
+		APIKey:  p.APIKey,
+		APIBase: baseURL,
+	})
+	return err
+}
+
+func getDefaultAPIBase(name string) string {
+	bases := map[string]string{
+		"nvidia":    "https://integrate.api.nvidia.com/v1",
+		"openrouter": "https://openrouter.ai/api/v1",
+		"groq":      "https://api.groq.com/openai/v1",
+		"ollama":    "http://localhost:11434",
+	}
+	if base, ok := bases[name]; ok {
+		return base
+	}
+	return ""
+}
+
+func Save(cfg *config.Config) error {
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+	return nil
+}
+
+func SaveIfInteractive(cfg *config.Config, interactive bool) {
+	if interactive {
+		fmt.Println()
+		if err := Save(cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
+		} else {
+			fmt.Println("Configuration saved.")
+		}
+	}
+}
+
+func getProviderDisplayName(name string) string {
+	names := map[string]string{
+		"nvidia":         "NVIDIA NIM",
+		"openrouter":     "OpenRouter",
+		"groq":           "Groq",
+		"ollama":         "Ollama",
+		"github-copilot": "GitHub Copilot",
+	}
+	if display, ok := names[name]; ok {
+		return display
+	}
+	return strings.Title(name)
+}
+
+func maskAPIKey(key string) string {
+	if len(key) <= 8 {
+		return strings.Repeat("*", len(key))
+	}
+	return key[:4] + strings.Repeat("*", len(key)-8) + key[len(key)-4:]
+}

--- a/internal/configure/configure.go
+++ b/internal/configure/configure.go
@@ -2,9 +2,11 @@ package configure
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/bigknoxy/joshbot/internal/config"
 	"github.com/bigknoxy/joshbot/internal/copilot"
@@ -172,10 +174,10 @@ func (c *Configurator) ValidateProviderCredentials(name string) error {
 
 func getDefaultAPIBase(name string) string {
 	bases := map[string]string{
-		"nvidia":    "https://integrate.api.nvidia.com/v1",
+		"nvidia":     "https://integrate.api.nvidia.com/v1",
 		"openrouter": "https://openrouter.ai/api/v1",
-		"groq":      "https://api.groq.com/openai/v1",
-		"ollama":    "http://localhost:11434",
+		"groq":       "https://api.groq.com/openai/v1",
+		"ollama":     "http://localhost:11434",
 	}
 	if base, ok := bases[name]; ok {
 		return base
@@ -190,18 +192,7 @@ func Save(cfg *config.Config) error {
 	return nil
 }
 
-func SaveIfInteractive(cfg *config.Config, interactive bool) {
-	if interactive {
-		fmt.Println()
-		if err := Save(cfg); err != nil {
-			fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
-		} else {
-			fmt.Println("Configuration saved.")
-		}
-	}
-}
-
-func getProviderDisplayName(name string) string {
+func GetProviderDisplayName(name string) string {
 	names := map[string]string{
 		"nvidia":         "NVIDIA NIM",
 		"openrouter":     "OpenRouter",
@@ -212,10 +203,10 @@ func getProviderDisplayName(name string) string {
 	if display, ok := names[name]; ok {
 		return display
 	}
-	return strings.Title(name)
+	return cases.Title(language.Und).String(name)
 }
 
-func maskAPIKey(key string) string {
+func MaskAPIKey(key string) string {
 	if len(key) <= 8 {
 		return strings.Repeat("*", len(key))
 	}

--- a/internal/configure/configure_test.go
+++ b/internal/configure/configure_test.go
@@ -285,7 +285,7 @@ func TestGetProviderDisplayName(t *testing.T) {
 		{"github-copilot", "GitHub Copilot"},
 	}
 	for _, tc := range cases {
-		got := getProviderDisplayName(tc.name)
+		got := GetProviderDisplayName(tc.name)
 		if got != tc.want {
 			t.Errorf("getProviderDisplayName(%q) = %q, want %q", tc.name, got, tc.want)
 		}
@@ -301,7 +301,7 @@ func TestMaskAPIKey(t *testing.T) {
 		{"abc"},
 	}
 	for _, tc := range cases {
-		masked := maskAPIKey(tc.input)
+		masked := MaskAPIKey(tc.input)
 		if masked == "" {
 			t.Error("masked key should not be empty")
 		}

--- a/internal/configure/configure_test.go
+++ b/internal/configure/configure_test.go
@@ -1,0 +1,312 @@
+package configure
+
+import (
+	"testing"
+
+	"github.com/bigknoxy/joshbot/internal/config"
+	"github.com/bigknoxy/joshbot/internal/providers"
+)
+
+func newTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{
+		Providers: make(map[string]config.ProviderConfig),
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Model: "arcee-ai/trinity-large-preview:free",
+			},
+		},
+	}
+}
+
+func TestConfigureProvider_FirstProvider_SetsDefaultAndModel(t *testing.T) {
+	cfg := newTestConfig(t)
+	c := New(cfg)
+
+	err := c.ConfigureProvider(ProviderOptions{
+		Name:    "nvidia",
+		APIKey:  "nvapi-test-key",
+		APIBase: "https://integrate.api.nvidia.com/v1",
+		Model:   "stepfun-ai/step-3.5-flash",
+	})
+	if err != nil {
+		t.Fatalf("ConfigureProvider failed: %v", err)
+	}
+
+	if c.cfg.ProviderDefaults.Default != "nvidia" {
+		t.Errorf("expected default provider 'nvidia', got %q", c.cfg.ProviderDefaults.Default)
+	}
+	if c.cfg.Agents.Defaults.Model != "stepfun-ai/step-3.5-flash" {
+		t.Errorf("expected model 'stepfun-ai/step-3.5-flash', got %q", c.cfg.Agents.Defaults.Model)
+	}
+	p := c.cfg.Providers["nvidia"]
+	if p.APIKey != "nvapi-test-key" {
+		t.Errorf("expected API key 'nvapi-test-key', got %q", p.APIKey)
+	}
+	if !p.Enabled {
+		t.Error("expected provider to be enabled")
+	}
+	if p.Model != "stepfun-ai/step-3.5-flash" {
+		t.Errorf("expected per-provider model 'stepfun-ai/step-3.5-flash', got %q", p.Model)
+	}
+}
+
+func TestConfigureProvider_FirstProviderNoModel_FallsBackToRegistryDefault(t *testing.T) {
+	cfg := newTestConfig(t)
+	c := New(cfg)
+
+	err := c.ConfigureProvider(ProviderOptions{
+		Name:   "groq",
+		APIKey: "gsk-test-key",
+	})
+	if err != nil {
+		t.Fatalf("ConfigureProvider failed: %v", err)
+	}
+
+	if c.cfg.Agents.Defaults.Model != providers.GetDefaultModel("groq") {
+		t.Errorf("expected model %q, got %q", providers.GetDefaultModel("groq"), c.cfg.Agents.Defaults.Model)
+	}
+}
+
+func TestConfigureProvider_SecondProvider_DoesNotOverrideDefault(t *testing.T) {
+	cfg := newTestConfig(t)
+	c := New(cfg)
+
+	err := c.ConfigureProvider(ProviderOptions{
+		Name:   "nvidia",
+		APIKey: "nvapi-1",
+		Model:  "model-a",
+	})
+	if err != nil {
+		t.Fatalf("first ConfigureProvider failed: %v", err)
+	}
+
+	err = c.ConfigureProvider(ProviderOptions{
+		Name:   "groq",
+		APIKey: "gsk-2",
+		Model:  "model-b",
+	})
+	if err != nil {
+		t.Fatalf("second ConfigureProvider failed: %v", err)
+	}
+
+	if c.cfg.ProviderDefaults.Default != "nvidia" {
+		t.Errorf("expected default to remain 'nvidia', got %q", c.cfg.ProviderDefaults.Default)
+	}
+	if c.cfg.Agents.Defaults.Model != "model-a" {
+		t.Errorf("expected model to remain 'model-a', got %q", c.cfg.Agents.Defaults.Model)
+	}
+}
+
+func TestConfigureProvider_ExistingProvider_UpdatesFields(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.Providers["openrouter"] = config.ProviderConfig{
+		APIKey:  "sk-or-old",
+		APIBase: "https://openrouter.ai/api/v1",
+		Model:   "old-model",
+		Enabled: true,
+	}
+	cfg.ProviderDefaults.Default = "openrouter"
+	cfg.Agents.Defaults.Model = "old-model"
+	c := New(cfg)
+
+	err := c.ConfigureProvider(ProviderOptions{
+		Name:   "openrouter",
+		APIKey: "sk-or-new",
+		Model:  "new-model",
+	})
+	if err != nil {
+		t.Fatalf("ConfigureProvider failed: %v", err)
+	}
+
+	p := c.cfg.Providers["openrouter"]
+	if p.APIKey != "sk-or-new" {
+		t.Errorf("expected updated API key 'sk-or-new', got %q", p.APIKey)
+	}
+	if p.Model != "new-model" {
+		t.Errorf("expected updated model 'new-model', got %q", p.Model)
+	}
+}
+
+func TestSetDefault_UsesPerProviderModel(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.Providers["nvidia"] = config.ProviderConfig{
+		APIKey:  "nvapi-key",
+		Model:   "stepfun-ai/step-3.5-flash",
+		Enabled: true,
+	}
+	cfg.Providers["groq"] = config.ProviderConfig{
+		APIKey:  "gsk-key",
+		Model:   "qwen/qwen3-32b",
+		Enabled: true,
+	}
+	cfg.ProviderDefaults.Default = "groq"
+	cfg.Agents.Defaults.Model = "qwen/qwen3-32b"
+	c := New(cfg)
+
+	err := c.SetDefault("nvidia")
+	if err != nil {
+		t.Fatalf("SetDefault failed: %v", err)
+	}
+
+	if c.cfg.ProviderDefaults.Default != "nvidia" {
+		t.Errorf("expected default 'nvidia', got %q", c.cfg.ProviderDefaults.Default)
+	}
+	if c.cfg.Agents.Defaults.Model != "stepfun-ai/step-3.5-flash" {
+		t.Errorf("expected model 'stepfun-ai/step-3.5-flash', got %q", c.cfg.Agents.Defaults.Model)
+	}
+}
+
+func TestSetDefault_NoPerProviderModel_FallsBack(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.Providers["groq"] = config.ProviderConfig{
+		APIKey:  "gsk-key",
+		Enabled: true,
+	}
+	c := New(cfg)
+
+	c.SetDefault("groq")
+	expectedModel := providers.GetDefaultModel("groq")
+	if c.cfg.Agents.Defaults.Model != expectedModel {
+		t.Errorf("expected fallback model %q, got %q", expectedModel, c.cfg.Agents.Defaults.Model)
+	}
+}
+
+func TestSetDefault_NotConfigured_ReturnsError(t *testing.T) {
+	cfg := newTestConfig(t)
+	c := New(cfg)
+	err := c.SetDefault("nvidia")
+	if err == nil {
+		t.Fatal("expected error for unconfigured provider")
+	}
+}
+
+func TestRemoveProvider_ClearsDefaultAndFallsBack(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.Providers["nvidia"] = config.ProviderConfig{APIKey: "key1", Enabled: true}
+	cfg.Providers["groq"] = config.ProviderConfig{APIKey: "key2", Enabled: true}
+	cfg.ProviderDefaults.Default = "nvidia"
+	cfg.Agents.Defaults.Model = "model-nvidia"
+	c := New(cfg)
+
+	err := c.RemoveProvider("nvidia")
+	if err != nil {
+		t.Fatalf("RemoveProvider failed: %v", err)
+	}
+
+	if _, exists := c.cfg.Providers["nvidia"]; exists {
+		t.Error("expected nvidia to be removed from providers")
+	}
+	if c.cfg.ProviderDefaults.Default != "groq" {
+		t.Errorf("expected default to fall back to 'groq', got %q", c.cfg.ProviderDefaults.Default)
+	}
+}
+
+func TestListProviders_ShowsCorrectStatus(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.Providers["nvidia"] = config.ProviderConfig{
+		APIKey:  "nvapi-key",
+		Enabled: true,
+		Model:   "stepfun-ai/step-3.5-flash",
+	}
+	cfg.ProviderDefaults.Default = "nvidia"
+	c := New(cfg)
+
+	items := c.ListProviders()
+
+	var nvidiaItem *ProviderListItem
+	for i := range items {
+		if items[i].Name == "nvidia" {
+			nvidiaItem = &items[i]
+			break
+		}
+	}
+	if nvidiaItem == nil {
+		t.Fatal("expected nvidia item in list")
+	}
+	if !nvidiaItem.Configured {
+		t.Error("expected nvidia to be shown as configured")
+	}
+	if !nvidiaItem.IsDefault {
+		t.Error("expected nvidia to be shown as default")
+	}
+	if nvidiaItem.Model != "stepfun-ai/step-3.5-flash" {
+		t.Errorf("expected model 'stepfun-ai/step-3.5-flash', got %q", nvidiaItem.Model)
+	}
+}
+
+func TestConfigureProvider_CLIFlags_EquivalentToInteractive(t *testing.T) {
+	cfgCLI := newTestConfig(t)
+	cCLI := New(cfgCLI)
+
+	err := cCLI.ConfigureProvider(ProviderOptions{
+		Name:    "nvidia",
+		APIKey:  "nvapi-cli-test",
+		APIBase: "https://integrate.api.nvidia.com/v1",
+		Model:   "stepfun-ai/step-3.5-flash",
+	})
+	if err != nil {
+		t.Fatalf("CLI-style ConfigureProvider failed: %v", err)
+	}
+
+	cfgInteractive := newTestConfig(t)
+	cInteractive := New(cfgInteractive)
+
+	err = cInteractive.ConfigureProvider(ProviderOptions{
+		Name:    "nvidia",
+		APIKey:  "nvapi-cli-test",
+		APIBase: "https://integrate.api.nvidia.com/v1",
+		Model:   "stepfun-ai/step-3.5-flash",
+	})
+	if err != nil {
+		t.Fatalf("interactive-style ConfigureProvider failed: %v", err)
+	}
+
+	if cfgCLI.ProviderDefaults.Default != cfgInteractive.ProviderDefaults.Default {
+		t.Error("CLI and interactive paths produced different defaults")
+	}
+	if cfgCLI.Agents.Defaults.Model != cfgInteractive.Agents.Defaults.Model {
+		t.Errorf("CLI model=%q, interactive model=%q", cfgCLI.Agents.Defaults.Model, cfgInteractive.Agents.Defaults.Model)
+	}
+	if cfgCLI.Providers["nvidia"].APIKey != cfgInteractive.Providers["nvidia"].APIKey {
+		t.Error("CLI and interactive paths produced different API keys")
+	}
+}
+
+func TestGetProviderDisplayName(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"nvidia", "NVIDIA NIM"},
+		{"openrouter", "OpenRouter"},
+		{"groq", "Groq"},
+		{"ollama", "Ollama"},
+		{"github-copilot", "GitHub Copilot"},
+	}
+	for _, tc := range cases {
+		got := getProviderDisplayName(tc.name)
+		if got != tc.want {
+			t.Errorf("getProviderDisplayName(%q) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestMaskAPIKey(t *testing.T) {
+	cases := []struct {
+		input string
+	}{
+		{"sk-or-v1-test1234567890abcdef"},
+		{"nvapi-test1234567890abcdef"},
+		{"abc"},
+	}
+	for _, tc := range cases {
+		masked := maskAPIKey(tc.input)
+		if masked == "" {
+			t.Error("masked key should not be empty")
+		}
+		if len(masked) != len(tc.input) {
+			t.Errorf("masked key length %d != input length %d", len(masked), len(tc.input))
+		}
+	}
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,188 +1,34 @@
-Migrate Python joshbot to Go — plan and acceptance criteria
+# Tasks
 
-- Goal: Replace the Python implementation with a complete, production-ready Go implementation and phase out the Python codebase. The running service should be the Go binary and provide at least feature parity with current gateway (Telegram inbound/outbound, ReAct agent loop with tools, message bus, sessions, skills, and basic observability).
+## Goal: Fix model config bug + abstract configure with CLI flags + tests
 
-- Acceptance criteria:
-  - `go build ./cmd/joshbot` produces a working gateway binary that can start and accept Telegram updates (polling or webhook) and process messages end-to-end.
-  - Existing Python behavior for allowlist, markdown handling, token redaction, empty-outbound guards, and outbound tracing (trace_id + digest) is implemented and verified in Go.
-  - Unit tests cover critical components (bus, channels/telegram, agent loop core) and `go test ./...` passes.
-  - A rollout plan is documented and the running gateway can be switched with zero/low downtime.
+### Acceptance Criteria
+- `joshbot config --provider nvidia --api-key xxx --model foo` sets the config correctly
+- Interactive `joshbot config` wizard produces identical results
+- `joshbot agent` picks up the configured model, not the registry default
+- All paths have unit test coverage
 
-- Phases (high level):
-  1. Discover & map (2 days)
-     - Inventory Python modules and map to Go packages (channels, agent, bus, providers, tools, skills, config).
-     - Produce a file-level migration map and an interface contract for each major component.
-  2. Scaffold Go repo (1 day)
-     - Create Go module, `cmd/joshbot`, `pkg/agent`, `pkg/bus`, `pkg/channels`, `pkg/providers`, `pkg/tools`, `pkg/config`, `internal/skills`.
-     - Add CI skeleton (GitHub Actions) to run `go test` and `go vet`.
-  3. Implement core infra (3-5 days)
-     - Message bus, Inbound/Outbound message types, session storage (file-backed JSON), basic config loader.
-  4. Channels: Telegram + CLI (3-5 days)
-     - Implement Telegram channel (webhook + polling), markdown safe-send (MarkdownV2 escape), token redaction, empty message guard, outbound tracing.
-     - CLI channel for local testing.
-  5. Agent loop & providers (5-8 days)
-     - ReAct agent loop, LLM provider interface, Litellm provider adapter (or a mock provider for local dev), tools registry and execution model.
-  6. Skills, tools, sessions (3-5 days)
-     - Skills loader (markdown files), tools port (message, shell, webfetch stubs), session persistence.
-  7. Tests, observability, and hardening (2-4 days)
-     - Unit tests, basic integration tests, structured logging, metrics, and troubleshooting (timeouts, retries).
-  8. Rollout & cutover (1-2 days)
-     - Deploy, smoke test, switch webhook/stop Python instance, monitor.
+### Bugs to Fix
+1. `setDefaultProvider` (main.go:2901) overwrites model with registry default
+2. `configureProvider` auto-default (main.go:2683) doesn't set model
+3. NVIDIA registration (main.go:369-381) doesn't pass `p.Model`
 
-- Immediate next actions (I will do these now unless you instruct otherwise):
-  1. Create a detailed migration map (repo-relative file list mapping Python -> Go packages) and place it at `tasks/migration_map.md`.
-  2. Scaffold the Go module in `/root/code/joshbot-go` with `go mod init github.com/bigknoxy/joshbot` and a minimal `cmd/joshbot/main.go` that prints a help message.
-  3. Add `tasks/` checklist entries for each phase above and mark discovery as `in_progress`.
+### Implementation Plan
 
-- Verification steps (how I will prove migration progress):
-  - Unit test pass: `go test ./...` (local CI will run as part of workflow).
-  - Build success: `go build -o /tmp/joshbot ./cmd/joshbot` and `file /tmp/joshbot` to confirm a Go ELF binary.
-  - Runtime smoke: start gateway in foreground `stdbuf -oL /tmp/joshbot gateway` and send a test Telegram message (or emulate via `curl` when using webhook) and show the inbound/outbound log sequence.
+**Phase 1: Fix Bugs (targeted)**
+- main.go:2901 — prefer per-provider model over registry default
+- main.go:2683-2684 — also set model when auto-defaulting
+- main.go:369-381 — pass p.Model to NVIDIA registration
 
-- Risks & mitigations:
-  - Risk: Behavioral drift (subtle differences vs Python) — Mitigate: add unit tests for allowlist normalization, markdown escaping, empty message guard, and token-redaction early.
-  - Risk: LLM provider differences — Mitigate: add a mock provider and integration tests to validate ReAct loop behavior before wiring production provider.
-  - Risk: Downtime during cutover — Mitigate: use webhook setWebhook atomic switch or use canary instance and redirect traffic gradually.
+**Phase 2: Create `internal/configure/` package**
+- `configurator.go` — Configurator type with non-interactive API
+- `configure_test.go` — comprehensive tests
 
-- Deliverables (per phase):
-  1. `tasks/migration_map.md` (file mapping).
-  2. `joshbot-go` repo scaffold with `cmd/joshbot` and empty package skeletons.
-  3. Working `pkg/bus` and message types with unit tests.
-  4. `pkg/channels/telegram` implementing safe sends + webhook/polling toggle.
-  5. Agent loop + provider adapters with ReAct skeleton and sample tool.
-  6. Integration tests and CI pass.
-  7. Rollout plan executed and Python gateway decommissioned.
+**Phase 3: Wire CLI flags in main.go**
+- `--provider`, `--api-key`, `--api-base`, `--model`, `--set-default`, `--remove` flags
+- `runConfigure` delegates to configure package when flags are set
+- Interactive wizard delegates to same package
 
-Acceptance criteria checklist (copy to track progress):
-- [ ] Migration map created (`tasks/migration_map.md`)
-- [ ] Go module scaffolded in `/root/code/joshbot-go`
-- [ ] Core bus + message types implemented + tests
-- [ ] Telegram channel implemented (webhook + polling) + tests for markdown/empty/allowlist
-- [ ] Agent loop and provider interfaces + mock provider tests
-- [ ] Integration tests and CI pass
-- [ ] Rollout plan executed and Python gateway decommissioned
-
----
-
-Prepare joshbot for production users — remediation plan
-
-- Goal: Harden security, fix functional gaps, improve reliability/UX, and ship a production-ready PR for review.
-- Acceptance criteria:
-  - Shell/FS/Web tools are safe by default, allow opt-in for broader access.
-  - `/new` fully resets server-side sessions.
-  - Provider errors are structured and fallback works; timeouts respected.
-  - Message bus concurrency is bounded; Telegram/CLI reliability improvements verified.
-  - Memory/skills prompt bloat reduced with controls.
-  - Tests added/updated; `go test ./...` passes.
-  - PR created with clear summary and verification story.
-
-- Working notes:
-  - Default to workspace-only file access; allow `restrict=false` for broader scope.
-  - Shell access is allowed when user enables it; still avoid obviously dangerous commands.
-  - Keep changes minimal and follow existing patterns.
-
-- Tasks:
-  - [ ] Security hardening: shell allowlist or safer execution, SSRF guard, filesystem restrictions
-  - [ ] Session lifecycle: implement real `/new` reset
-  - [x] Provider reliability: fix `WithTimeout`, structured errors/fallback
-  - [ ] Concurrency: bound message bus dispatch
-  - [ ] UX reliability: CLI full-line input, Telegram reconnect/media handling
-  - [x] Memory/skills: reduce prompt bloat, dedupe/limits
-  - [x] Memory/skills: dedupe consolidated facts, expand history window, skills summary-only
-  - [x] Run go tests for modified packages
-  - [ ] Tests: add coverage for providers/Telegram/memory where needed
-  - [ ] Verification: `go test ./...`
-  - [ ] PR: create ready-for-review PR
-
-Provider reliability subtasks:
-- [x] Fix WithTimeout in registry.go to respect input parameter
-- [x] Update LiteLLM provider to return structured FallbackError
-- [x] Add tests for WithTimeout
-- [x] Add tests for FallbackError in LiteLLM provider
-- [x] Add tests for error fallback logic
-- [x] Run relevant go tests
-
----
-
-# Current Task: Fix fallback logic using providers with enabled=false
-
-## Issue
-- main.go line 311: OpenRouter registered WITHOUT checking `p.Enabled`
-- Other providers (nvidia, groq, ollama, github-copilot) correctly check `p.Enabled`
-- Fallback chain includes all registered providers regardless of config Enabled status
-
-## Plan
-- [x] Fix main.go: Add `p.Enabled` check for OpenRouter registration  
-- [x] Add Enabled field to ProviderEntry in multiprovider for runtime filtering
-- [x] Add tests for enabled/disabled provider behavior in fallback
-- [x] Run verification: go test ./..., go vet ./..., go build ./cmd/joshbot
-
----
-
-# Current Task: Create PR and monitor CI
-
-- Goal: Create a new branch, open a PR with current changes, and monitor CI to green. If CI fails, diagnose, fix, and update PR until green.
-- Acceptance criteria:
-  - PR exists from a new branch with a clear summary.
-  - CI checks for the PR are green, or failures are fixed and rerun to green.
-  - Provide PR URL and final CI status.
-
-- Working notes:
-  - Use existing repo conventions for branch naming and PR summary.
-  - Do not modify unrelated files; keep changes minimal if fixes are needed.
-
-- Plan:
-  - [ ] Restate goal + acceptance criteria
-  - [ ] Inspect git status, diffs, and recent commits for PR scope
-  - [ ] Create new branch and open PR with summary
-  - [ ] Monitor CI checks; if failing, diagnose root cause
-  - [ ] Implement minimal fix, update PR, and re-check CI
-  - [ ] Report PR URL and final CI status
-
----
-
-# Current Task: Review PR #43 (fix/systemd-env-ollama-migration)
-
-## Plan
-- [x] Restate goal + acceptance criteria
-- [x] Locate PR scope vs main (diff, commits)
-- [x] Review config migration: provider enabled behavior
-- [x] Review systemd HOME env handling
-- [x] Identify unintended behavior/regressions
-- [x] Implement minimal fixes if needed
-- [x] Add/adjust tests for fixes
-- [x] Run verification (go test ./..., go vet ./..., go build ./cmd/joshbot)
-- [x] Summarize findings + verification story
-
----
-
-# Current Task: Fix Migration V4 Provider Enabled Behavior - COMPLETED
-
-## Summary
-Fixed the migration v4 logic to properly handle provider enabled behavior:
-
-- **Providers with API keys/config** → Auto-enabled after migration (backward compatibility)
-- **Ollama/GitHub Copilot** → Remain disabled unless explicitly enabled (local daemons)
-- **Explicitly disabled** (`enabled: false`) → Remain disabled (respect user preference)
-
-## Changes Made
-1. `internal/config/config.go`:
-   - Added `parseExplicitDisable()` to detect explicit `enabled: false` in old configs
-   - Added `containsEnabledKey()` helper to check if "enabled" field was present
-   - Updated migration v4 logic with `localProviders` map for Ollama/GitHub Copilot
-   - Modified `migrateConfig()` to accept raw JSON for explicit disable detection
-
-2. `internal/config/config_test.go`:
-   - Updated `TestMigrateConfigV4_OllamaNotAutoEnabled` test expectations
-   - Added `TestMigrateConfigV4_ConfiguredProviderAutoEnabled` test
-   - Added `TestMigrateConfigV4_GitHubCopilotNotAutoEnabled` test
-   - Added `TestMigrateConfigV4_ExplicitDisableStaysDisabled` test
-
-## Verification
-- `go test ./...` ✓
-- `go vet ./...` ✓
-- `go build ./cmd/joshbot` ✓
-
-## Pushed
-- Commit: `b74eda1` to `fix/systemd-env-ollama-migration` branch
-
+**Phase 4: End-to-end verification**
+- Build + test
+- Manual smoke test

--- a/tasks/update-command-plan.md
+++ b/tasks/update-command-plan.md
@@ -1,3 +1,5 @@
+> **⚠️ OBSOLETE**: This document is from the Python version of joshbot and is no longer relevant to the current Go codebase. Kept for historical reference only.
+
 # Plan: `joshbot update` Command + Close All Version/Upgrade Gaps
 
 ## Overview


### PR DESCRIPTION
## Summary

Fixes three bugs where per-provider model configuration was ignored, causing the wrong model to be sent to the API. Abstracts configure logic into a new internal/configure/ package with CLI flags and comprehensive tests.

## Bugs Fixed

1. **setDefaultProvider** overwrote agents.defaults.model with registry default instead of user's per-provider model
2. **configureProvider** auto-default on first provider didn't set agents.defaults.model at all
3. **NVIDIA registration** didn't pass p.Model to GetProvider or Register

## New Feature: CLI Flags

```
joshbot config --provider nvidia --api-key nvapi-... --model stepfun-ai/step-3.5-flash --set-default nvidia
joshbot config --list
joshbot config --remove nvidia
```

Flags compose correctly — --provider runs first, then --set-default, then saves once.

## New Package: internal/configure/

Shared API used by both CLI flags and interactive wizard. All operations handle model resolution with per-provider fallback.

## Tests

12 tests covering: first/second provider, model fallback, update, remove, list, CLI/interactive equivalence.

## Verification

- go build ./cmd/joshbot
- go vet ./...
- go test -race ./... -- all 22+ packages pass
