### PR TITLE
fix: configure provider updates agents.defaults.model when reconfiguring default provider

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -2729,6 +2729,7 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 	cfg.Providers[provider] = p
 
 	// If this is the first provider, set it as default with its model
+	// Otherwise, if this is the current default provider, update the model
 	if cfg.ProviderDefaults.Default == "" {
 		cfg.ProviderDefaults.Default = provider
 		if p.Model != "" {
@@ -2736,6 +2737,8 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 		} else {
 			cfg.Agents.Defaults.Model = providers.GetDefaultModel(provider)
 		}
+	} else if cfg.ProviderDefaults.Default == provider && p.Model != "" {
+		cfg.Agents.Defaults.Model = p.Model
 	}
 
 	fmt.Println()

--- a/internal/configure/configure.go
+++ b/internal/configure/configure.go
@@ -77,6 +77,8 @@ func (c *Configurator) ConfigureProvider(opts ProviderOptions) error {
 		} else {
 			c.cfg.Agents.Defaults.Model = providers.GetDefaultModel(opts.Name)
 		}
+	} else if c.cfg.ProviderDefaults.Default == opts.Name && p.Model != "" {
+		c.cfg.Agents.Defaults.Model = p.Model
 	}
 
 	return nil

--- a/internal/configure/configure_test.go
+++ b/internal/configure/configure_test.go
@@ -98,6 +98,72 @@ func TestConfigureProvider_SecondProvider_DoesNotOverrideDefault(t *testing.T) {
 	}
 }
 
+func TestConfigureProvider_ReconfigureDefault_UpdatesModel(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.Providers["nvidia"] = config.ProviderConfig{
+		APIKey:  "nvapi-old",
+		APIBase: "https://integrate.api.nvidia.com/v1",
+		Model:   "stepfun-ai/step-3.5-flash",
+		Enabled: true,
+	}
+	cfg.Providers["openrouter"] = config.ProviderConfig{
+		APIKey:  "sk-or-old",
+		Enabled: true,
+	}
+	cfg.ProviderDefaults.Default = "nvidia"
+	cfg.Agents.Defaults.Model = "stepfun-ai/step-3.5-flash"
+	c := New(cfg)
+
+	err := c.ConfigureProvider(ProviderOptions{
+		Name:   "nvidia",
+		APIKey: "nvapi-new",
+		Model:  "meta/llama-4-405b",
+	})
+	if err != nil {
+		t.Fatalf("ConfigureProvider on default provider failed: %v", err)
+	}
+
+	if c.cfg.Agents.Defaults.Model != "meta/llama-4-405b" {
+		t.Errorf("expected agents.defaults.model updated to 'meta/llama-4-405b', got %q", c.cfg.Agents.Defaults.Model)
+	}
+	if c.cfg.ProviderDefaults.Default != "nvidia" {
+		t.Errorf("expected default to remain 'nvidia', got %q", c.cfg.ProviderDefaults.Default)
+	}
+	p := c.cfg.Providers["nvidia"]
+	if p.Model != "meta/llama-4-405b" {
+		t.Errorf("expected per-provider model 'meta/llama-4-405b', got %q", p.Model)
+	}
+}
+
+func TestConfigureProvider_ReconfigureNonDefault_DoesNotChangeModel(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.Providers["nvidia"] = config.ProviderConfig{
+		APIKey:  "nvapi-key",
+		APIBase: "https://integrate.api.nvidia.com/v1",
+		Model:   "stepfun-ai/step-3.5-flash",
+		Enabled: true,
+	}
+	cfg.ProviderDefaults.Default = "nvidia"
+	cfg.Agents.Defaults.Model = "stepfun-ai/step-3.5-flash"
+	c := New(cfg)
+
+	err := c.ConfigureProvider(ProviderOptions{
+		Name:   "openrouter",
+		APIKey: "sk-or-new",
+		Model:  "some-other-model",
+	})
+	if err != nil {
+		t.Fatalf("ConfigureProvider on non-default provider failed: %v", err)
+	}
+
+	if c.cfg.Agents.Defaults.Model != "stepfun-ai/step-3.5-flash" {
+		t.Errorf("expected agents.defaults.model unchanged, got %q", c.cfg.Agents.Defaults.Model)
+	}
+	if c.cfg.ProviderDefaults.Default != "nvidia" {
+		t.Errorf("expected default to remain 'nvidia', got %q", c.cfg.ProviderDefaults.Default)
+	}
+}
+
 func TestConfigureProvider_ExistingProvider_UpdatesFields(t *testing.T) {
 	cfg := newTestConfig(t)
 	cfg.Providers["openrouter"] = config.ProviderConfig{


### PR DESCRIPTION
## Problem

When a user configures OpenRouter first (which becomes the default provider), then adds NVIDIA with a different model like `stepfun-ai/step-3.5-flash`, the `agents.defaults.model` field is never updated to reflect the NVIDIA model. This causes the agent to use the wrong model at runtime.

## Root Cause

Both `configureProvider()` in `cmd/joshbot/main.go:2732` and `ConfigureProvider()` in `internal/configure/configure.go:73` only update `agents.defaults.model` when `ProviderDefaults.Default == ""` (i.e., on the very first provider configured). On subsequent provider additions, the model field is silently skipped even if the new provider becomes the intended default.

## Fix

Added an `else if` branch in both code paths: if the provider being configured is the current default provider, update `agents.defaults.model` with its model.

## Verification

- ✅ Reconfigure default provider with new model → `agents.defaults.Model` updates
- ✅ Add non-default provider → `agents.defaults.Model` unchanged
- ✅ All existing tests pass
- ✅ New tests added for both scenarios
- ✅ `gofmt -l .` clean
- ✅ `go vet ./...` clean
- ✅ `go test -race ./...` passes