### PR TITLE
fix: replace defunct default model with openrouter/free, fix migration typo, add 410 to fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.2] - 2026-05-31
+
+### Fixed
+- **HTTP 410 error on LLM calls** — Default model `arcee-ai/trinity-large-preview:free` was removed from OpenRouter, causing all API calls to fail with `API error (410)`. Changed default to `openrouter/free` (auto-routes to best available free model), updated all references in config, provider registry, context budget, docs, and tests.
+- **Migration typo** — Config migration from v0→v1 wrote misspelled model name `arcee-ai/tranny-large-preview:free` (typo: "tranny") instead of the correct model. Fixed to migrate to `openrouter/free`. Hardenend migration test to assert exact expected model.
+- **410 not triggering fallback** — `isFallbackStatusCode()` did not include 410 (Gone), so a deprecated model caused immediate failure instead of triggering fallback to another provider. Added 410 to the fallback status code list.
+
 ## [1.20.0] - 2026-05-19
 
 ### Added

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -1556,7 +1556,7 @@ func runOnboard(c *cli.Context) error {
 		// Get provider's default model as fallback
 		defaultModel := providers.GetDefaultModel(provider)
 		if defaultModel == "" {
-			defaultModel = "arcee-ai/trinity-large-preview:free"
+			defaultModel = "openrouter/free"
 		}
 		// Use selected model, or fall back to provider default
 		if model == "" {

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -169,7 +169,7 @@ The wizard will guide you through:
    ```
 
 3. **Model Selection**
-   - Default: `openai/gpt-4` (or use `arcee-ai/trinity-large-preview:free` for free via OpenRouter)
+   - Default: `openai/gpt-4` (or use `openrouter/free` for free via OpenRouter)
    - You can specify any model supported by your provider
 
 ### Onboarding Options
@@ -485,7 +485,7 @@ Choose an LLM model based on your needs:
 
 | Use Case | Recommended Model | Notes |
 |----------|-------------------|-------|
-| Free tier | `arcee-ai/trinity-large-preview:free` | No cost via OpenRouter, good for testing |
+| Free tier | `openrouter/free` | No cost via OpenRouter, auto-routes to best free model |
 | Better quality | `anthropic/claude-sonnet-4` | Requires Anthropic or OpenRouter credits |
 | Fast responses | `groq/llama-3.3-70b-versatile` | Requires Groq API key |
 | Local | `ollama/llama3.2` | No API key needed, runs locally |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,7 @@ func SetLogger(l Logger) {
 
 const (
 	// DefaultModel is the default LLM model.
-	DefaultModel = "arcee-ai/trinity-large-preview:free"
+	DefaultModel = "openrouter/free"
 	// DefaultExecTimeout is the default shell execution timeout in seconds.
 	DefaultExecTimeout = 60
 	// DefaultGatewayHost is the default gateway host.
@@ -977,8 +977,8 @@ func migrateConfig(cfg *Config, rawJSON []byte) error {
 	if cfg.SchemaVersion < 1 {
 		// Update defunct model if present
 		if cfg.Agents.Defaults.Model == "google/gemma-2-9b-it:free" {
-			cfg.Agents.Defaults.Model = "arcee-ai/tranny-large-preview:free"
-			logger.Info("Migrated model from google/gemma-2-9b-it:free to arcee-ai/tranny-large-preview:free")
+			cfg.Agents.Defaults.Model = "openrouter/free"
+			logger.Info("Migrated model from google/gemma-2-9b-it:free to openrouter/free")
 		}
 		cfg.SchemaVersion = 1
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -377,7 +377,7 @@ func TestConfigString(t *testing.T) {
 	cfg := Defaults()
 	str := cfg.String()
 
-	expected := "Config{SchemaVersion: 4, Model: arcee-ai/trinity-large-preview:free, LogLevel: info, Gateway: 0.0.0.0:18790}"
+	expected := "Config{SchemaVersion: 4, Model: openrouter/free, LogLevel: info, Gateway: 0.0.0.0:18790}"
 	if str != expected {
 		t.Errorf("String() = %v, want %v", str, expected)
 	}
@@ -580,9 +580,9 @@ func TestMigrateConfig(t *testing.T) {
 		t.Errorf("expected schema version %d after migration, got %d", CurrentSchemaVersion, cfg.SchemaVersion)
 	}
 
-	// Model should be migrated
-	if cfg.Agents.Defaults.Model == "google/gemma-2-9b-it:free" {
-		t.Error("model should have been migrated")
+	// Model should be migrated to the current default
+	if cfg.Agents.Defaults.Model != DefaultModel {
+		t.Errorf("model should have been migrated to %q, got %q", DefaultModel, cfg.Agents.Defaults.Model)
 	}
 }
 

--- a/internal/configure/configure_test.go
+++ b/internal/configure/configure_test.go
@@ -13,7 +13,7 @@ func newTestConfig(t *testing.T) *config.Config {
 		Providers: make(map[string]config.ProviderConfig),
 		Agents: config.AgentsConfig{
 			Defaults: config.AgentDefaults{
-				Model: "arcee-ai/trinity-large-preview:free",
+				Model: config.DefaultModel,
 			},
 		},
 	}

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -35,7 +35,7 @@ func NewRegistry() *Registry {
 		"z-ai/glm-4.5-air:free":            8192,
 		"openai/llama3.2":                  8192,
 		"meta-llama/llama-3.2-3b-instruct": 8192,
-		"arcee-ai/trinity-large-preview":   131072,
+		"openrouter/free":                  131072,
 	}}
 }
 

--- a/internal/providers/errors.go
+++ b/internal/providers/errors.go
@@ -129,6 +129,8 @@ func IsFallbackError(err error, providerName string) bool {
 // isFallbackStatusCode returns true for status codes that should trigger fallback.
 func isFallbackStatusCode(statusCode int) bool {
 	switch statusCode {
+	case 410: // Gone (deprecated/removed model)
+		return true
 	case 429: // Rate limit
 		return true
 	case 500, 502, 503, 504: // Server errors

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -161,7 +161,7 @@ func init() {
 			}
 			return NewLiteLLMProvider(cfg), nil
 		},
-		DefaultModel: "arcee-ai/trinity-large-preview:free",
+		DefaultModel: "openrouter/free",
 		DisplayName:  "OpenRouter",
 		Description:  "Many models, one API key",
 	})


### PR DESCRIPTION
## What changed

### Root cause
OpenRouter removed `arcee-ai/trinity-large-preview:free` — the default model since v1.0.0. This caused HTTP 410 on every LLM call, producing `API error (410): unknown error` for all users (including Telegram).

### Fixes
1. **Default model** → `openrouter/free` (auto-routes to best available free model, future-proof)
2. **Config migration typo** — v0→v1 migration wrote misspelled `arcee-ai/tranny-large-preview:free` (`tranny` vs `trinity`). Fixed to `openrouter/free`.
3. **410 now triggers provider fallback** — Added HTTP 410 to `isFallbackStatusCode()` so deprecated models trigger fallback to the next provider instead of failing immediately.
4. **Hardened migration test** — Now asserts exact expected model instead of just checking it changed.
5. **Updated all references** — config.go, registry.go, context.go, main.go, INSTALL.md, all tests.

### Verification
- `go test -race ./...` — all 23 packages pass
- `gofmt -d .` — empty (clean)
- `go vet ./...` — empty (clean)
- `go build ./cmd/joshbot` — builds clean
- Dogfood: binary runs, agent responds correctly
- Dogfood: config test with old schema_version=0 and old model migrates correctly

### Release
After merge: `v1.20.2`