### PR TITLE
feat: config tool, model routing fix, identity rewrite

### DIFF
--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -571,13 +571,63 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 		skillsLoader,
 	)
 
+	// Create function to reload providers from config (for config tool hot-reload)
+	reloadProviders := func() error {
+		multiProvider.Clear()
+		if cfg.UseModelsConfig() {
+			resolvedModels := cfg.GetAllModelConfigs()
+			for i, resolved := range resolvedModels {
+				llmProvider := providers.NewProviderFromResolvedModel(resolved, &providers.DefaultLogger{})
+				var provider providers.Provider = llmProvider
+				if len(resolved.APIKeys) > 1 {
+					pool := providers.NewAPIKeyPool(resolved.APIKeys, 24*time.Hour, 3)
+					provider = providers.NewKeyRotatingProvider(llmProvider, pool)
+				}
+				multiProvider.Register(resolved.Name, provider, resolved.ModelID, i, true)
+			}
+		} else {
+			if p, ok := cfg.Providers["openrouter"]; ok && p.APIKey != "" && p.Enabled {
+				openrouterProvider, err := providers.GetProvider("openrouter", providers.Config{
+					APIKey: p.APIKey, APIBase: p.APIBase, ExtraHeaders: p.ExtraHeaders,
+					Model: cfg.Agents.Defaults.Model, MaxTokens: cfg.Agents.Defaults.MaxTokens,
+					Temperature: cfg.Agents.Defaults.Temperature,
+				})
+				if err != nil {
+					log.Warn("Failed to create OpenRouter provider", "error", err)
+				} else {
+					multiProvider.Register("openrouter", openrouterProvider, cfg.Agents.Defaults.Model, 0, p.Enabled)
+				}
+			}
+			if p, ok := cfg.Providers["nvidia"]; ok && p.APIKey != "" && p.Enabled {
+				nvidiaProvider, err := providers.GetProvider("nvidia", providers.Config{
+					APIKey: p.APIKey, APIBase: p.APIBase, ExtraHeaders: p.ExtraHeaders, Model: p.Model,
+				})
+				if err != nil {
+					log.Warn("Failed to create NVIDIA provider", "error", err)
+				} else {
+					model := p.Model
+					if model == "" { model = cfg.Agents.Defaults.Model }
+					multiProvider.Register("nvidia", nvidiaProvider, model, 1, p.Enabled)
+				}
+			}
+		}
+		return nil
+	}
+
+	// Register config tool
+	toolsRegistry.Register(tools.NewConfigureTool(cfg, reloadProviders))
+
 	// Create async callback channel and start processor for background task notifications
 	asyncCallbackCh := make(chan tools.AsyncResult, 100)
 	toolsRegistry.SetAsyncCallback(asyncCallbackCh)
 	toolsRegistry.Register(tools.NewMemorySearchTool(memoryManager))
 
 	// Create subagent runner for parallel and chain execution tools
-	subagentRunner := subagent.NewRunner(multiProvider, cfg.Agents.Defaults.Model, 4096, 0.3, 60*time.Second)
+	agentModel := cfg.Agents.Defaults.Model
+	if cfg.UseModelsConfig() {
+		agentModel = cfg.ModelsConfig.Agent.Model
+	}
+	subagentRunner := subagent.NewRunner(multiProvider, agentModel, 4096, 0.3, 60*time.Second)
 	toolsRegistry.Register(tools.NewParallelSubagentTool(subagentRunner))
 	toolsRegistry.Register(tools.NewChainExecutionTool(subagentRunner))
 
@@ -617,7 +667,7 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 
 	// Create skill self-creation components (Milestone 2)
 	skillDetector := skills.NewSkillDetector()
-	skillExtractor := skills.NewExtractor(multiProvider, cfg.Agents.Defaults.Model)
+	skillExtractor := skills.NewExtractor(multiProvider, agentModel)
 
 	// Enable async support in the registry
 	toolsRegistry.SetAsyncCallback(asyncCallbackCh)

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -606,7 +606,9 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 					log.Warn("Failed to create NVIDIA provider", "error", err)
 				} else {
 					model := p.Model
-					if model == "" { model = cfg.Agents.Defaults.Model }
+					if model == "" {
+						model = cfg.Agents.Defaults.Model
+					}
 					multiProvider.Register("nvidia", nvidiaProvider, model, 1, p.Enabled)
 				}
 			}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -348,8 +348,8 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 		if len(assistantMsg.ToolCalls) == 0 {
 			content := assistantMsg.Content
 			if content == "" {
-a.logger.Warn("Empty content from LLM - triggering fallback message",
-				"model", a.getModelName(),
+				a.logger.Warn("Empty content from LLM - triggering fallback message",
+					"model", a.getModelName(),
 					"iteration", iteration+1,
 				)
 				content = "I've processed your request."

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -72,6 +72,17 @@ type Agent struct {
 	skillDetector *skills.SkillDetector
 	extractor     *skills.Extractor
 	skillLoader   *skills.Loader
+	modelName     string
+}
+
+func (a *Agent) getModelName() string {
+	if a.modelName != "" {
+		return a.modelName
+	}
+	if a.cfg.UseModelsConfig() {
+		return a.cfg.ModelsConfig.Agent.Model
+	}
+	return a.cfg.Agents.Defaults.Model
 }
 
 // Option is a functional option for configuring Agent.
@@ -304,7 +315,7 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 
 		// Call LLM
 		req := providers.ChatRequest{
-			Model:       a.cfg.Agents.Defaults.Model,
+			Model:       a.getModelName(),
 			Messages:    messages,
 			Temperature: a.cfg.Agents.Defaults.Temperature,
 			MaxTokens:   a.cfg.Agents.Defaults.MaxTokens,
@@ -337,8 +348,8 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 		if len(assistantMsg.ToolCalls) == 0 {
 			content := assistantMsg.Content
 			if content == "" {
-				a.logger.Warn("Empty content from LLM - triggering fallback message",
-					"model", a.cfg.Agents.Defaults.Model,
+a.logger.Warn("Empty content from LLM - triggering fallback message",
+				"model", a.getModelName(),
 					"iteration", iteration+1,
 				)
 				content = "I've processed your request."
@@ -530,7 +541,7 @@ func (a *Agent) checkAndCompactContext(messages []providers.Message, sess *sessi
 		threshold = 0.7 // default fallback
 	}
 
-	model := a.cfg.Agents.Defaults.Model
+	model := a.getModelName()
 	maxCompletion := a.cfg.Agents.Defaults.MaxTokens
 	budget := a.budget.ComputeBudget(model, maxCompletion)
 	thresholdBudget := int(float64(budget) * threshold)
@@ -621,7 +632,7 @@ func (a *Agent) buildMessages(systemPrompt string, sess *session.Session) []prov
 
 	// If we have a budget manager and compressor, consider compressing older messages
 	if a.budget != nil && a.compressor != nil {
-		model := a.cfg.Agents.Defaults.Model
+		model := a.getModelName()
 		maxCompletion := a.cfg.Agents.Defaults.MaxTokens
 		budget := a.budget.ComputeBudget(model, maxCompletion)
 		budget -= ctxpkg.TokenEstimator(systemPrompt)
@@ -749,7 +760,7 @@ Tools: %d registered
 Memory window: %d
 
 Just type normally to chat with me!`,
-			a.cfg.Agents.Defaults.Model,
+			a.getModelName(),
 			toolCount,
 			a.cfg.Agents.Defaults.MemoryWindow,
 		)
@@ -771,7 +782,7 @@ Just type normally to chat with me!`
   Tools: %d registered
   Memory window: %d
   Max iterations: %d`,
-			a.cfg.Agents.Defaults.Model,
+			a.getModelName(),
 			toolCount,
 			a.cfg.Agents.Defaults.MemoryWindow,
 			a.cfg.Agents.Defaults.MaxToolIterations,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -225,6 +225,54 @@ func TestNewAgent(t *testing.T) {
 	}
 }
 
+func TestGetModelName(t *testing.T) {
+	t.Run("model-centric mode uses agent model name", func(t *testing.T) {
+		cfg := &config.Config{
+			ModelsConfig: config.ModelsConfig{
+				Models: []config.ModelConfig{
+					{Name: "smart", Model: "nvidia/stepfun-ai/step-3.5-flash"},
+				},
+				Agent: config.AgentModelConfig{Model: "smart"},
+			},
+			Agents: config.AgentsConfig{Defaults: config.AgentDefaults{Model: "nvidia/stepfun-ai/step-3.5-flash"}},
+		}
+		agent := NewAgent(cfg, &mockProvider{}, &mockToolExecutor{}, newMockSessionManager(), newMockLogger())
+		got := agent.getModelName()
+		if got != "smart" {
+			t.Errorf("expected %q, got %q", "smart", got)
+		}
+	})
+
+	t.Run("explicit modelName overrides config", func(t *testing.T) {
+		cfg := &config.Config{
+			ModelsConfig: config.ModelsConfig{
+				Models: []config.ModelConfig{
+					{Name: "smart", Model: "nvidia/stepfun-ai/step-3.5-flash"},
+				},
+				Agent: config.AgentModelConfig{Model: "smart"},
+			},
+			Agents: config.AgentsConfig{Defaults: config.AgentDefaults{Model: "nvidia/stepfun-ai/step-3.5-flash"}},
+		}
+		agent := NewAgent(cfg, &mockProvider{}, &mockToolExecutor{}, newMockSessionManager(), newMockLogger())
+		agent.modelName = "custom-name"
+		got := agent.getModelName()
+		if got != "custom-name" {
+			t.Errorf("expected %q, got %q", "custom-name", got)
+		}
+	})
+
+	t.Run("legacy mode uses agents.defaults.model", func(t *testing.T) {
+		cfg := &config.Config{
+			Agents: config.AgentsConfig{Defaults: config.AgentDefaults{Model: "nvidia/stepfun-ai/step-3.5-flash"}},
+		}
+		agent := NewAgent(cfg, &mockProvider{}, &mockToolExecutor{}, newMockSessionManager(), newMockLogger())
+		got := agent.getModelName()
+		if got != "nvidia/stepfun-ai/step-3.5-flash" {
+			t.Errorf("expected %q, got %q", "nvidia/stepfun-ai/step-3.5-flash", got)
+		}
+	})
+}
+
 func TestNewAgentWithOptions(t *testing.T) {
 	cfg := config.Defaults()
 	provider := &mockProvider{}

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -215,30 +215,29 @@ func BuildSmartPrompt(workspace string, skills SkillsLoader, mem MemoryLoader, u
 
 // buildCoreIdentity returns the core identity prompt.
 func buildCoreIdentity() string {
-	return `You are joshbot, a personal AI assistant. You are helpful, capable, and proactive.
+	return `You are joshbot. A personal AI assistant built by someone who wanted a bot that actually works.
 
-You have access to tools that let you interact with the filesystem, run shell commands, search the web, and manage your own memory and skills.
+You have tools — filesystem, shell, web, memory, skills, subagents. Use them. Do not just answer questions if tools would produce a better answer.
 
-Key behaviors:
-- Use your tools proactively to help the user
-- Remember important information by updating your memory files
-- When you learn something new or develop a useful capability, consider creating a skill for it
-- Search your HISTORY.md when the user references past conversations
-- Be concise but thorough in your responses
-- If you're unsure about something, say so and suggest ways to find out
+How you work:
+- Read before write. Always.
+- Batch operations when it makes sense. Do not call three tools if one covers it.
+- If you are unsure, say so. Then figure it out — search, grep, fetch, whatever it takes.
+- Learn from being wrong. Correcting you is not a bug, it is how you improve.
+- Create skills when you see a pattern repeat. Offer them, do not force them.
 
-Tool selection guidelines:
-- Prefer built-in tools (web_search, web_fetch, read_file) over shell commands - they are faster and more reliable
-- Use web_search for finding information, web_fetch for fetching specific URLs
-- Plan ahead to minimize tool calls - batch operations when possible
-- Shell command outputs are truncated to prevent context overflow
-- Tool outputs are automatically truncated to stay within context limits
+Tool use:
+- web_search and web_fetch for internet lookups. They are faster and more reliable than curl.
+- shell for real work — builds, tests, git, running code. Safety guards are active, you cannot shoot yourself in the foot.
+- read_file and write_file for files. Prefer reading full files or targeted ranges; grep to find what you need.
+- parallel_subagent when you need to research multiple independent things at once.
+- chain_execution when you need a multi-step pipeline (research → outline → draft → polish).
 
-Memory system:
-- MEMORY.md contains long-term facts about the user and context (always loaded)
-- HISTORY.md is an append-only log of conversation summaries (searchable via grep)
-- Use read_file and write_file to manage these files
-- When conversations are consolidated, key facts go to MEMORY.md and summaries to HISTORY.md
+Memory:
+- MEMORY.md is always in your context at session start. It contains long-term facts about the user and context.
+- HISTORY.md is an append-only log. The learning system reads it periodically to distill facts back into MEMORY.md.
+- If you learn something important about the user, update MEMORY.md.
+- If a conversation covers something meaningful, append a summary to HISTORY.md.
 
 `
 }

--- a/internal/providers/multiprovider.go
+++ b/internal/providers/multiprovider.go
@@ -80,6 +80,14 @@ func (mp *MultiProvider) Unregister(name string) {
 	mp.rebuildOrderedList()
 }
 
+// Clear removes all registered providers.
+func (mp *MultiProvider) Clear() {
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
+	mp.entries = make(map[string]*ProviderEntry)
+	mp.orderedEntries = nil
+}
+
 // SetDefault sets the default provider.
 func (mp *MultiProvider) SetDefault(name string) {
 	mp.mu.Lock()
@@ -239,12 +247,14 @@ func (mp *MultiProvider) Transcribe(ctx context.Context, audioData []byte, promp
 	return entry.Provider.Transcribe(ctx, audioData, prompt)
 }
 
-// parseModel parses "provider:model" format.
+// parseModel resolves a model specification to a provider name and model name.
+// It handles "provider:model" format and direct provider name lookups.
 func (mp *MultiProvider) parseModel(modelSpec string) (providerName, modelName string) {
 	if modelSpec == "" {
 		return mp.defaultProvider, ""
 	}
 
+	// Check for "provider:model" format
 	if idx := strings.Index(modelSpec, ":"); idx > 0 {
 		potentialProvider := modelSpec[:idx]
 		potentialModel := modelSpec[idx+1:]
@@ -256,6 +266,14 @@ func (mp *MultiProvider) parseModel(modelSpec string) (providerName, modelName s
 		if exists {
 			return potentialProvider, potentialModel
 		}
+	}
+
+	// Check if modelSpec is itself a registered provider name (e.g., "smart")
+	mp.mu.RLock()
+	_, exists := mp.entries[modelSpec]
+	mp.mu.RUnlock()
+	if exists {
+		return modelSpec, ""
 	}
 
 	return mp.defaultProvider, modelSpec

--- a/internal/tools/configure.go
+++ b/internal/tools/configure.go
@@ -1,0 +1,264 @@
+package tools
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bigknoxy/joshbot/internal/config"
+	"github.com/bigknoxy/joshbot/internal/log"
+)
+
+type ReloadProvidersFunc func() error
+
+type ConfigureTool struct {
+	cfg            *config.Config
+	reloadProviders ReloadProvidersFunc
+}
+
+func NewConfigureTool(cfg *config.Config, reload ReloadProvidersFunc) *ConfigureTool {
+	return &ConfigureTool{cfg: cfg, reloadProviders: reload}
+}
+
+func (t *ConfigureTool) Name() string {
+	return "joshbot_config"
+}
+
+func (t *ConfigureTool) Description() string {
+	return "Read and modify joshbot's configuration. Use this to list available models and settings, switch the active model, adjust settings like temperature and max_tokens, or view the current active configuration."
+}
+
+func (t *ConfigureTool) Parameters() []Parameter {
+	return []Parameter{
+		{
+			Name:        "operation",
+			Type:        ParamString,
+			Description: "Operation to perform: 'list_models' (list available models), 'status' (show current active config), 'switch_model' (switch active model by name), 'set' (change a setting), 'get' (get a config value).",
+			Required:    true,
+			Enum:        []string{"list_models", "status", "switch_model", "set", "get"},
+		},
+		{
+			Name:        "model",
+			Type:        ParamString,
+			Description: "Model name (required for 'switch_model' operation). Example: 'smart', 'fast'. Use 'list_models' to see available names.",
+		},
+		{
+			Name:        "setting",
+			Type:        ParamString,
+			Description: "Setting name for 'get' or 'set' operations. Examples: 'temperature', 'max_tokens', 'model'.",
+		},
+		{
+			Name:        "value",
+			Type:        ParamString,
+			Description: "Value for the setting (required for 'set' operation). For temperature use a decimal like '0.7'. For model use a model name.",
+		},
+	}
+}
+
+func (t *ConfigureTool) Execute(ctx interface{}, args map[string]any) ToolResult {
+	if t.cfg == nil {
+		return ToolResult{Error: fmt.Errorf("config not available")}
+	}
+
+	operation, _ := args["operation"].(string)
+	if operation == "" {
+		return ToolResult{Error: fmt.Errorf("'operation' is required")}
+	}
+
+	switch operation {
+	case "list_models":
+		return t.handleListModels()
+	case "status":
+		return t.handleStatus()
+	case "switch_model":
+		return t.handleSwitchModel(args)
+	case "get":
+		return t.handleGet(args)
+	case "set":
+		return t.handleSet(args)
+	default:
+		return ToolResult{Error: fmt.Errorf("unknown operation: %s (valid: list_models, status, switch_model, get, set)", operation)}
+	}
+}
+
+func (t *ConfigureTool) handleListModels() ToolResult {
+	if !t.cfg.UseModelsConfig() {
+		return ToolResult{Output: "Using legacy provider config. Run 'joshbot onboard' or configure manually to set up model-centric config."}
+	}
+
+	models := t.cfg.ModelsConfig.Models
+	if len(models) == 0 {
+		return ToolResult{Output: "No models configured."}
+	}
+
+	activeName := ""
+	if t.cfg.UseModelsConfig() {
+		activeName = t.cfg.ModelsConfig.Agent.Model
+	}
+
+	sort.Slice(models, func(i, j int) bool {
+		return models[i].Name < models[j].Name
+	})
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("## Available Models (%d)\n\n", len(models)))
+	for _, m := range models {
+		active := ""
+		if m.Name == activeName {
+			active = " ← active"
+		}
+		status := ""
+		if m.Disabled {
+			status = " [disabled]"
+		}
+		sb.WriteString(fmt.Sprintf("- **%s**%s%s: `%s`\n", m.Name, active, status, m.Model))
+	}
+	sb.WriteString("\nUse `switch_model` with the model name to change the active model.")
+	return ToolResult{Output: sb.String()}
+}
+
+func (t *ConfigureTool) handleStatus() ToolResult {
+	var sb strings.Builder
+	sb.WriteString("## Current Configuration\n\n")
+
+	if t.cfg.UseModelsConfig() {
+		activeName := t.cfg.ModelsConfig.Agent.Model
+		sb.WriteString(fmt.Sprintf("**Config format:** model-centric\n"))
+		sb.WriteString(fmt.Sprintf("**Active model:** %s\n", activeName))
+
+		if m, ok := t.cfg.GetModel(activeName); ok {
+			sb.WriteString(fmt.Sprintf("**Model ID:** `%s`\n", m.Model))
+			sb.WriteString(fmt.Sprintf("**Max tokens:** %d\n", m.MaxTokens))
+			sb.WriteString(fmt.Sprintf("**API base:** %s\n", m.APIBase))
+			if len(m.APIKey) > 8 {
+				sb.WriteString(fmt.Sprintf("**API key:** %s...%s\n", m.APIKey[:4], m.APIKey[len(m.APIKey)-4:]))
+			} else {
+				sb.WriteString("**API key:** configured\n")
+			}
+		}
+
+		if len(t.cfg.ModelsConfig.Agent.Fallback) > 0 {
+			sb.WriteString(fmt.Sprintf("**Fallback:** %s\n", strings.Join(t.cfg.ModelsConfig.Agent.Fallback, ", ")))
+		}
+
+		sb.WriteString(fmt.Sprintf("\n**Temperature:** %.1f\n", t.cfg.Agents.Defaults.Temperature))
+		sb.WriteString(fmt.Sprintf("**Max tool iterations:** %d\n", t.cfg.Agents.Defaults.MaxToolIterations))
+		sb.WriteString(fmt.Sprintf("**Workspace:** %s\n", t.cfg.Agents.Defaults.Workspace))
+	} else {
+		sb.WriteString("**Config format:** legacy provider-based\n")
+		sb.WriteString(fmt.Sprintf("**Default provider:** %s\n", t.cfg.ProviderDefaults.Default))
+		sb.WriteString(fmt.Sprintf("**Model:** %s\n", t.cfg.Agents.Defaults.Model))
+	}
+
+	return ToolResult{Output: sb.String()}
+}
+
+func (t *ConfigureTool) handleSwitchModel(args map[string]any) ToolResult {
+	if !t.cfg.UseModelsConfig() {
+		return ToolResult{Error: fmt.Errorf("model switching requires model-centric config. Run 'joshbot onboard' first")}
+	}
+
+	modelName, _ := args["model"].(string)
+	if modelName == "" {
+		return ToolResult{Error: fmt.Errorf("'model' is required for 'switch_model'")}
+	}
+
+	if _, ok := t.cfg.GetModel(modelName); !ok {
+		return ToolResult{Error: fmt.Errorf("model %q not found. Use 'list_models' to see available models", modelName)}
+	}
+
+	prev := t.cfg.ModelsConfig.Agent.Model
+	t.cfg.ModelsConfig.Agent.Model = modelName
+
+	if err := config.Save(t.cfg); err != nil {
+		// Restore on failure
+		t.cfg.ModelsConfig.Agent.Model = prev
+		return ToolResult{Error: fmt.Errorf("failed to save config: %w", err)}
+	}
+
+	if t.reloadProviders != nil {
+		if err := t.reloadProviders(); err != nil {
+			log.Warn("Config saved but provider reload failed", "error", err)
+			return ToolResult{Output: fmt.Sprintf("Switched from %q to %q. Config saved but provider reload failed: %s. Changes will apply on restart.", prev, modelName, err)}
+		}
+	}
+
+	log.Info("Switched active model", "from", prev, "to", modelName)
+	return ToolResult{Output: fmt.Sprintf("Switched active model from **%s** to **%s**. The change is active now.", prev, modelName)}
+}
+
+func (t *ConfigureTool) handleGet(args map[string]any) ToolResult {
+	setting, _ := args["setting"].(string)
+	if setting == "" {
+		return ToolResult{Error: fmt.Errorf("'setting' is required for 'get'")}
+	}
+
+	switch setting {
+	case "model":
+		if t.cfg.UseModelsConfig() {
+			return ToolResult{Output: fmt.Sprintf("Active model: **%s**", t.cfg.ModelsConfig.Agent.Model)}
+		}
+		return ToolResult{Output: fmt.Sprintf("Default model: `%s`", t.cfg.Agents.Defaults.Model)}
+	case "temperature":
+		return ToolResult{Output: fmt.Sprintf("Temperature: **%.1f**", t.cfg.Agents.Defaults.Temperature)}
+	case "max_tokens":
+		return ToolResult{Output: fmt.Sprintf("Max tokens: **%d**", t.cfg.Agents.Defaults.MaxTokens)}
+	case "workspace":
+		return ToolResult{Output: fmt.Sprintf("Workspace: `%s`", t.cfg.Agents.Defaults.Workspace)}
+	default:
+		return ToolResult{Error: fmt.Errorf("unknown setting: %s (valid: model, temperature, max_tokens, workspace)", setting)}
+	}
+}
+
+func (t *ConfigureTool) handleSet(args map[string]any) ToolResult {
+	setting, _ := args["setting"].(string)
+	if setting == "" {
+		return ToolResult{Error: fmt.Errorf("'setting' is required for 'set'")}
+	}
+
+	value, _ := args["value"].(string)
+	if value == "" && setting != "" {
+		return ToolResult{Error: fmt.Errorf("'value' is required for 'set'")}
+	}
+
+	switch setting {
+	case "temperature":
+		return t.setFloat(&t.cfg.Agents.Defaults.Temperature, value, "temperature")
+	case "max_tokens":
+		return t.setInt(&t.cfg.Agents.Defaults.MaxTokens, value, "max tokens")
+	case "model":
+		return t.handleSwitchModel(args)
+	default:
+		return ToolResult{Error: fmt.Errorf("unknown setting: %s (valid: model, temperature, max_tokens)", setting)}
+	}
+}
+
+func (t *ConfigureTool) setFloat(target *float64, value, name string) ToolResult {
+	var v float64
+	if _, err := fmt.Sscanf(value, "%f", &v); err != nil {
+		return ToolResult{Error: fmt.Errorf("invalid %s value: %q (use decimal like 0.7)", name, value)}
+	}
+	prev := *target
+	*target = v
+	if err := config.Save(t.cfg); err != nil {
+		*target = prev
+		return ToolResult{Error: fmt.Errorf("failed to save config: %w", err)}
+	}
+	log.Info("Updated setting", "name", name, "from", prev, "to", v)
+	return ToolResult{Output: fmt.Sprintf("Set %s from **%.2f** to **%.2f**. Saved to config.", name, prev, v)}
+}
+
+func (t *ConfigureTool) setInt(target *int, value, name string) ToolResult {
+	var v int
+	if _, err := fmt.Sscanf(value, "%d", &v); err != nil {
+		return ToolResult{Error: fmt.Errorf("invalid %s value: %q (use integer like 4096)", name, value)}
+	}
+	prev := *target
+	*target = v
+	if err := config.Save(t.cfg); err != nil {
+		*target = prev
+		return ToolResult{Error: fmt.Errorf("failed to save config: %w", err)}
+	}
+	log.Info("Updated setting", "name", name, "from", prev, "to", v)
+	return ToolResult{Output: fmt.Sprintf("Set %s from **%d** to **%d**. Saved to config.", name, prev, v)}
+}

--- a/internal/tools/configure.go
+++ b/internal/tools/configure.go
@@ -12,7 +12,7 @@ import (
 type ReloadProvidersFunc func() error
 
 type ConfigureTool struct {
-	cfg            *config.Config
+	cfg             *config.Config
 	reloadProviders ReloadProvidersFunc
 }
 


### PR DESCRIPTION
## Summary

Adds an in-chat config tool, fixes model-centric routing, and rewrites identity files for personality.

## Changes

- **ConfigureTool** (`internal/tools/configure.go`): New tool with operations `list_models`, `status`, `switch_model`, `get`, `set`. Change temperature, model, max_tokens via chat. Saves config to disk and reloads providers live.
- **Model routing fix** (`internal/agent/agent.go`, `internal/providers/multiprovider.go`): Agent now calls `getModelName()` which returns the model name (`"smart"`) in model-centric mode instead of the raw model string (`"nvidia/stepfun-ai/step-3.5-flash"`). Added `Clear()` method to MultiProvider for live reload.
- **Identity rewrite** (`internal/agent/context.go`): Rewrote SOUL.md, IDENTITY.md, AGENTS.md for direct, self-aware voice with dry humor.
- **Tests**: Added `TestGetModelName` with 3 subtests (model-centric, explicit override, legacy mode).

## Verification
- `go build ./cmd/joshbot` — clean
- `go test -race ./...` — all pass
- Dogfooded: list_models + status (worked), set temperature to 0.5 (saved to disk, reverted)

Closes the model routing 404 issue and adds the config tool for UX improvements.