### PR TITLE
fix: replace retired Go Report Card badge with pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/bigknoxy/joshbot/actions/workflows/ci.yml/badge.svg)](https://github.com/bigknoxy/joshbot/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/bigknoxy/joshbot/branch/main/graph/badge.svg)](https://codecov.io/gh/bigknoxy/joshbot)
-[![Go Report Card](https://goreportcard.com/badge/github.com/bigknoxy/joshbot)](https://goreportcard.com/report/github.com/bigknoxy/joshbot)
+[![Go Reference](https://pkg.go.dev/badge/github.com/bigknoxy/joshbot.svg)](https://pkg.go.dev/github.com/bigknoxy/joshbot)
 [![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?logo=go)](https://go.dev/dl/)
 [![GitHub release](https://img.shields.io/github/v/release/bigknoxy/joshbot?include_prereleases)](https://github.com/bigknoxy/joshbot/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
## Summary

Replaces the retired Go Report Card badge with a pkg.go.dev badge.

## Issue

 service was shut down and the badge shows 'retired'. Replaced with  badge which provides up-to-date Go package documentation reference.

## Badge Status

| Badge | Status |
|-------|--------|
| CI | ✅ Working |
| Coverage | ⚠️ Shows 'unknown' (repo needs to be registered on Codecov.io) |
| Go Reference | ✅ Working (new) |
| Go Version | ✅ Working |
| GitHub release | ✅ Working |
| License: MIT | ✅ Working |