### PR TITLE
docs: refresh CLAUDE.md with verified stats, commands, and gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,13 @@
 # joshbot — Architect's Guide
 
-joshbot is a self-hosted Go personal AI assistant (~19.6K LOC non-test, 597 test functions in 48 files). Single binary, zero runtime deps.
+joshbot is a self-hosted Go personal AI assistant (~19.6K LOC non-test, ~850 test functions across 55 files). Single binary, zero runtime deps.
+
+**`AGENTS.md` (repo root) is the full agent guide** — key interfaces, code style, naming, concurrency and logging patterns, complete gotchas list. Read it before non-trivial work. This file is the quick index.
 
 ## Key facts
 
 - **Go 1.24.0**, module `github.com/bigknoxy/joshbot`
-- **~16MB binary**, ~30ms startup
+- **~17MB binary**, ~30ms startup
 - **Architecture**: goroutine message bus → ReAct agent loop → multi-provider LLM
 - **Channels**: CLI (readline) + Telegram (long-polling, telebot)
 - **Providers**: openrouter, openai, nvidia, groq, ollama, anthropic, poolside, azure, custom, litellm
@@ -17,11 +19,36 @@ joshbot is a self-hosted Go personal AI assistant (~19.6K LOC non-test, 597 test
 - **Cron**: Scheduled jobs via cron.yml in workspace
 - **Heartbeat**: Unchecked task scanner via HEARTBEAT.md
 
+## Commands
+
+No Makefile — standard Go tooling.
+
+```bash
+go build -o joshbot ./cmd/joshbot
+go run ./cmd/joshbot agent -m "hello"        # single-message, non-interactive
+go test ./...                                # all tests
+go test -v ./internal/tools -run TestShell   # single test
+go vet ./... && gofmt -l .                   # CI gates on both
+./scripts/verify-local.sh                    # build + onboard + smoke-test heartbeat
+```
+
+## Layout
+
+`cmd/joshbot` entrypoint. Under `internal/`: `agent` (ReAct loop), `bus` (message bus),
+`channels` (cli.go, telegram.go), `providers` (registry.go = provider routing keys),
+`tools`, `memory`, `skills`, `session`, `context`, `config`, `cron`, `heartbeat`,
+`subagent`, `service` (build-tagged per-OS), `learning`, `integration`.
+
 ## Important gotchas
 
 - `internal/` is the source of truth. `pkg/` is a stale incomplete refactor — do not edit.
 - All CLI commands work non-interactively (agent -m, onboard --force, configure --provider --api-key, uninstall --force, etc.)
 - ExtraBody support for providers needing custom JSON body fields (poolside chat_template_kwargs, etc.)
+- Providers need `"enabled": true` in config to activate — omitting it silently disables them.
+- Env var nesting uses `__`: `JOSHBOT_PROVIDERS__OPENROUTER__API_KEY`. Shorthand `JOSHBOT_OPENROUTER_API_KEY` still works.
+- Session key is computed from `Channel:SenderID` — there is no `SessionKey` field.
+- `internal/service/` is build-tagged (`factory_linux.go` / `factory_darwin.go` / `factory_other.go`) — all must export the same signature.
+- Telegram hard-fails over 4096 chars; joshbot does not split messages.
 
 ## Website (site/)
 
@@ -35,6 +62,13 @@ Two pages in `site/`:
 
 ```bash
 go build ./cmd/joshbot
+go vet ./...        # CI gates on this
 gofmt -d .          # MUST be empty
 go test -race ./... # MUST pass
+# CI also fails if total coverage drops below 45%
 ```
+
+## PR & release
+
+See `.github/PR_RULES.md`. Branch from main (never commit directly), conventional commits,
+squash & merge. Releases: push to main → **wait for CI green** → then `git tag vX.Y.Z && git push origin vX.Y.Z`.


### PR DESCRIPTION
## Description

CLAUDE.md had drifted from the codebase and duplicated a small slice of `AGENTS.md` without referencing it — so Claude Code sessions never saw the 16.5KB full agent guide.

Changes (each verified against the repo, not assumed):

- **Corrected stale stats** — was "597 test functions in 48 files", actual is ~850 across 55 files; binary is 17MB not ~16MB. (LOC ~19.6K and Go 1.24.0 were already correct.)
- **Added `AGENTS.md` pointer** at the top, so the full guide is discoverable.
- **New `## Commands` section** — build, single-message run, single-test invocation, vet/gofmt, `scripts/verify-local.sh`.
- **New `## Layout` section** — one-paragraph map of the 20 packages under `internal/`.
- **Five gotchas added** — provider `"enabled": true` requirement, `__` env var nesting, computed session key (no `SessionKey` field), `internal/service/` build tags, Telegram 4096-char hard limit.
- **Pre-release checklist aligned with CI** — added `go vet` and a note about the 45% coverage gate, both of which CI enforces but the checklist omitted.
- **New `## PR & release` section** pointing at `.github/PR_RULES.md`, including the push → wait for CI green → tag ordering.

Net: 1.9KB → 3.7KB, +37/-3 lines. Docs only; no code touched.

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor

## Checklist

- [ ] Tests added/updated <!-- N/A: docs-only change -->
- [x] Documentation updated
- [x] `go vet` passes
- [x] `gofmt` passes
- [x] Tests pass

## Related Issues

None.

## Screenshots

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)