### PR TITLE
feat: behavioural eval harness for the ReAct loop (+ two context bugs it found)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,33 @@ go test -v ./internal/tools -run TestShell             # Single test
 
 Tests colocated with `_test.go` suffix. Integration tests in `tests/` plus `internal/integration/`. Python test scripts in `tests/` (legacy from migration).
 
+### Behavioural eval harness (`internal/agent`)
+
+`evalharness_test.go` runs the **real ReAct loop** against a scripted provider that
+replays a fixed sequence of model turns and records every request. No network, no
+API key, no clock dependence — it runs in normal CI.
+
+```bash
+go test ./internal/agent -run 'TestEval_' -v
+```
+
+Add a scenario by declaring a `trajectoryScenario` (scripted turns, tool outputs,
+seeded history, budget/window knobs) and passing it to `runTrajectoryEval`. Assert
+on the **trajectory** — `res.requests` (what was sent to the model), `res.invocations`
+(what was dispatched), `res.sess` (what was persisted) — not on the reply text.
+
+Always call `assertProtocolInvariants(t, res)`. It enforces the wire-format rules an
+OpenAI-compatible provider rejects with a 400: every tool message carries a
+`tool_call_id`, every id answers a call announced by an earlier assistant message, and
+every announced call receives a result. Two shipped bugs were found this way, both of
+which broke only long conversations. Keep this call in every new scenario so evals
+added later inherit the checks.
+
+Do not confuse this with `prompt_eval_test.go`, `prompt_optimizer_test.go` and
+`prompt_variants_test.go` — those are a **prompt lint**. They score the system prompt
+string with `strings.Contains` and never invoke the agent, a model, or a tool. They
+cannot catch behavioural regressions.
+
 ## Linting & Formatting
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Long conversations were rejected by the LLM provider** — Once a conversation grew past the token budget, context reduction rebuilt older messages without their tool-call linkage, so joshbot sent `tool` messages carrying no `tool_call_id`. OpenAI-compatible endpoints reject that request with a 400, meaning long sessions failed while short ones worked. The memory window could orphan a tool result the same way by cutting between an assistant tool call and its result.
+
+### Added
+- **Behavioural eval harness for the ReAct loop** (`internal/agent/evalharness_test.go`) — Runs the real loop against a scripted provider that records every request, so tests assert the trajectory (what was sent, dispatched and persisted) rather than the reply text. Runs in CI with no network or API key. `assertProtocolInvariants` enforces provider wire-format rules on every scenario. Validated by mutation testing: 9 of 9 deliberately introduced regressions were caught. `internal/agent` coverage 63.5% → 75.3%.
+
 ## [1.35.0] - 2026-07-25
 
 ### Security

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -668,6 +668,7 @@ func (a *Agent) buildMessages(systemPrompt string, sess *session.Session) []prov
 	window := a.cfg.Agents.Defaults.MemoryWindow
 	if window > 0 && len(providerMsgs) > window {
 		providerMsgs = providerMsgs[len(providerMsgs)-window:]
+		providerMsgs = dropOrphanedToolResults(providerMsgs)
 	}
 
 	// If we have a budget manager and compressor, consider compressing older messages
@@ -713,6 +714,18 @@ func (a *Agent) buildMessages(systemPrompt string, sess *session.Session) []prov
 	return msgs
 }
 
+// dropOrphanedToolResults removes tool messages at the head of a truncated
+// history whose announcing assistant message was cut away. Sending a tool
+// result that answers nothing makes an OpenAI-compatible provider reject the
+// whole request with a 400.
+func dropOrphanedToolResults(messages []providers.Message) []providers.Message {
+	start := 0
+	for start < len(messages) && messages[start].Role == providers.RoleTool {
+		start++
+	}
+	return messages[start:]
+}
+
 // applyObservationMasking reduces context by stripping tool result content from older messages
 // while keeping the last 3 exchanges (user+assistant pairs) fully intact.
 // Tool outputs are replaced with "[Tool output truncated]" to save tokens.
@@ -741,14 +754,16 @@ func (a *Agent) applyObservationMasking(messages []providers.Message, budget int
 		result[i] = messages[i]
 	}
 
-	// Mask tool result content in older messages
+	// Mask tool result content in older messages. Only the content is
+	// replaced: ToolCalls and ToolCallID must survive, because an
+	// OpenAI-compatible provider rejects a tool message with no tool_call_id,
+	// or an announced tool call with no answering result, with a 400.
 	for i := 0; i < verbatimStart; i++ {
 		m := messages[i]
 		if m.Role == providers.RoleTool || m.Role == providers.RoleAssistant {
-			result[i] = providers.Message{
-				Role:    m.Role,
-				Content: truncateSummary(m.Content),
-			}
+			masked := m
+			masked.Content = truncateSummary(m.Content)
+			result[i] = masked
 		} else {
 			result[i] = m
 		}

--- a/internal/agent/eval_trajectory_test.go
+++ b/internal/agent/eval_trajectory_test.go
@@ -1,0 +1,299 @@
+package agent
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bigknoxy/joshbot/internal/providers"
+	"github.com/bigknoxy/joshbot/internal/session"
+)
+
+// Behavioural evals for the ReAct loop. Each drives the real loop through a
+// scripted model and asserts on the trajectory — what the loop sent, what it
+// dispatched, what it persisted — rather than on the final string.
+//
+// Every eval ends with assertProtocolInvariants so that the wire-format rules
+// are enforced on every scenario, present and future.
+
+func TestEval_SingleToolRoundTrip(t *testing.T) {
+	res := runTrajectoryEval(t, trajectoryScenario{
+		name:        "single tool round trip",
+		userMessage: "list the files",
+		turns: []scriptedTurn{
+			{toolCalls: []providers.ToolCall{toolCall("call_a", "shell", `{"command":"ls"}`)}},
+			{content: "There are three files."},
+		},
+		toolOutputs: map[string]string{"shell": "a.go b.go c.go"},
+	})
+	assertProtocolInvariants(t, res)
+
+	if res.err != nil {
+		t.Fatalf("Process returned %v", res.err)
+	}
+	if len(res.requests) != 2 {
+		t.Fatalf("expected 2 model calls, got %d", len(res.requests))
+	}
+
+	// The tool must actually be dispatched, with the arguments parsed out of
+	// the model's JSON rather than passed through raw.
+	inv := res.invocations
+	if len(inv) != 1 {
+		t.Fatalf("expected 1 tool invocation, got %d", len(inv))
+	}
+	if inv[0].name != "shell" {
+		t.Errorf("tool name = %q, want shell", inv[0].name)
+	}
+	if got := inv[0].args["command"]; got != "ls" {
+		t.Errorf("command arg = %v, want ls", got)
+	}
+
+	// The whole point of the loop: the tool's output has to reach the model on
+	// the next turn. If this regresses the agent still replies, just blindly.
+	second := res.requestMessages(1)
+	result, ok := toolResultFor(second, "call_a")
+	if !ok {
+		t.Fatal("second model call carried no result for call_a")
+	}
+	if !strings.Contains(result, "a.go b.go c.go") {
+		t.Errorf("tool output did not reach the model; got %q", result)
+	}
+
+	if res.final != "There are three files." {
+		t.Errorf("final = %q", res.final)
+	}
+}
+
+func TestEval_ParallelToolCallsAllAnswered(t *testing.T) {
+	res := runTrajectoryEval(t, trajectoryScenario{
+		name: "two tool calls in one turn",
+		turns: []scriptedTurn{
+			{toolCalls: []providers.ToolCall{
+				toolCall("call_1", "shell", `{"command":"date"}`),
+				toolCall("call_2", "filesystem", `{"path":"/tmp"}`),
+			}},
+			{content: "done"},
+		},
+		toolOutputs: map[string]string{"shell": "Tuesday", "filesystem": "empty"},
+	})
+	assertProtocolInvariants(t, res)
+
+	if len(res.invocations) != 2 {
+		t.Fatalf("expected both tools to be dispatched, got %d", len(res.invocations))
+	}
+
+	second := res.requestMessages(1)
+	for _, id := range []string{"call_1", "call_2"} {
+		if _, ok := toolResultFor(second, id); !ok {
+			t.Errorf("no result returned for %s", id)
+		}
+	}
+	if n := countRole(second, providers.RoleTool); n != 2 {
+		t.Errorf("expected 2 tool messages in the follow-up request, got %d", n)
+	}
+}
+
+func TestEval_MalformedToolArgumentsAreReportedNotDispatched(t *testing.T) {
+	res := runTrajectoryEval(t, trajectoryScenario{
+		name: "model emits invalid JSON arguments",
+		turns: []scriptedTurn{
+			{toolCalls: []providers.ToolCall{toolCall("call_bad", "shell", `{"command": `)}},
+			{content: "I could not parse that."},
+		},
+	})
+	assertProtocolInvariants(t, res)
+
+	if res.err != nil {
+		t.Fatalf("malformed arguments should not fail the run, got %v", res.err)
+	}
+	// A tool must not run on arguments that did not parse.
+	if len(res.invocations) != 0 {
+		t.Errorf("expected no tool dispatch, got %v", res.invocations)
+	}
+
+	// The model has to be told, otherwise it retries the same broken call.
+	second := res.requestMessages(1)
+	result, ok := toolResultFor(second, "call_bad")
+	if !ok {
+		t.Fatal("no tool message answered the malformed call")
+	}
+	if !strings.Contains(strings.ToLower(result), "invalid arguments") {
+		t.Errorf("model was not told the arguments were invalid; got %q", result)
+	}
+}
+
+func TestEval_ToolErrorReachesModel(t *testing.T) {
+	res := runTrajectoryEval(t, trajectoryScenario{
+		name: "tool returns an error",
+		turns: []scriptedTurn{
+			{toolCalls: []providers.ToolCall{toolCall("call_e", "shell", `{"command":"rm -rf /"}`)}},
+			{content: "That was blocked."},
+		},
+		toolErrors: map[string]error{"shell": errors.New("command denied: dangerous pattern")},
+	})
+	assertProtocolInvariants(t, res)
+
+	second := res.requestMessages(1)
+	result, ok := toolResultFor(second, "call_e")
+	if !ok {
+		t.Fatal("no tool message answered the failing call")
+	}
+	// The reason has to survive, not be flattened to a generic failure. A
+	// denied command the model cannot see the reason for gets retried forever.
+	if !strings.Contains(result, "command denied") {
+		t.Errorf("error detail lost on the way to the model; got %q", result)
+	}
+}
+
+// This is the regression guard for the defect this harness was built to find:
+// once history exceeded the token budget, observation masking rebuilt messages
+// without ToolCalls or ToolCallID, so the loop sent tool messages that answered
+// nothing. Providers reject that with a 400, meaning long conversations broke
+// while short ones stayed fine.
+func TestEval_ContextMaskingPreservesToolLinkage(t *testing.T) {
+	history := chatHistory(1, 400)
+	history = append(history, toolExchange("call_old", "shell", "file listing "+padding(400))...)
+	history = append(history, chatHistory(8, 400)...)
+
+	res := runTrajectoryEval(t, trajectoryScenario{
+		name:        "long history forces observation masking",
+		history:     history,
+		tightBudget: true,
+		turns:       []scriptedTurn{{content: "ok"}},
+	})
+	assertProtocolInvariants(t, res)
+
+	first := res.requestMessages(0)
+	if len(first) == 0 {
+		t.Fatal("no request recorded")
+	}
+	// Masking must actually have run, or this eval proves nothing.
+	if countRole(first, providers.RoleTool) == 0 {
+		t.Fatal("expected the seeded tool exchange to survive into the request")
+	}
+	var masked bool
+	for _, m := range first {
+		if strings.Contains(m.Content, "[Tool output truncated]") {
+			masked = true
+		}
+	}
+	if !masked {
+		t.Fatal("observation masking did not run; this scenario no longer exercises the path it guards")
+	}
+}
+
+// The memory window slices history to a fixed length. A cut landing between an
+// assistant tool call and its result leaves the result orphaned at the head of
+// the conversation, which is the same 400 by a different route.
+func TestEval_MemoryWindowDoesNotOrphanToolResults(t *testing.T) {
+	history := []session.Message{
+		{Role: session.RoleUser, Content: "run it"},
+	}
+	history = append(history, toolExchange("call_w", "shell", "output")...)
+
+	res := runTrajectoryEval(t, trajectoryScenario{
+		name:         "memory window cuts between a call and its result",
+		history:      history,
+		memoryWindow: 2,
+		turns:        []scriptedTurn{{content: "ok"}},
+	})
+	assertProtocolInvariants(t, res)
+
+	first := res.requestMessages(0)
+	if len(first) > 4 {
+		t.Errorf("memory window did not apply; %d messages sent", len(first))
+	}
+}
+
+func TestEval_MaxIterationsBoundsModelCalls(t *testing.T) {
+	// A model that calls a tool forever must be stopped by the iteration cap.
+	turns := make([]scriptedTurn, 10)
+	for i := range turns {
+		turns[i] = scriptedTurn{toolCalls: []providers.ToolCall{toolCall("call_loop", "shell", `{"command":"true"}`)}}
+	}
+
+	res := runTrajectoryEval(t, trajectoryScenario{
+		name:          "runaway tool loop",
+		turns:         turns,
+		maxIterations: 3,
+	})
+	assertProtocolInvariants(t, res)
+
+	if len(res.requests) != 3 {
+		t.Errorf("expected exactly 3 model calls under a cap of 3, got %d", len(res.requests))
+	}
+	if len(res.invocations) != 3 {
+		t.Errorf("expected 3 tool dispatches, got %d", len(res.invocations))
+	}
+	if res.final == "" {
+		t.Error("hitting the cap should still return something to the user")
+	}
+}
+
+func TestEval_SessionRecordsFullTrajectory(t *testing.T) {
+	res := runTrajectoryEval(t, trajectoryScenario{
+		name:        "trajectory is persisted",
+		userMessage: "check the time",
+		turns: []scriptedTurn{
+			{toolCalls: []providers.ToolCall{toolCall("call_s", "shell", `{"command":"date"}`)}},
+			{content: "It is Tuesday."},
+		},
+		toolOutputs: map[string]string{"shell": "Tuesday"},
+	})
+	assertProtocolInvariants(t, res)
+
+	// The session is what a restart reloads. If the tool linkage is not
+	// persisted, the next turn rebuilds a malformed conversation from disk.
+	var sawCall, sawResult bool
+	for _, m := range res.sess.Messages {
+		for _, tc := range m.ToolCalls {
+			if tc.ID == "call_s" && tc.Name == "shell" {
+				sawCall = true
+			}
+		}
+		if m.Role == session.RoleTool && m.ToolCallID == "call_s" {
+			sawResult = true
+			if !strings.Contains(m.Content, "Tuesday") {
+				t.Errorf("persisted tool result = %q", m.Content)
+			}
+		}
+	}
+	if !sawCall {
+		t.Error("session did not record the assistant tool call with its id")
+	}
+	if !sawResult {
+		t.Error("session did not record the tool result against its call id")
+	}
+}
+
+func TestEval_ProviderFailureAndEmptyResponse(t *testing.T) {
+	// Process deliberately turns a loop failure into a user-facing string with a
+	// nil error, so the channel always has something to print. The contract the
+	// eval guards is that the cause is not swallowed: a silent success-looking
+	// reply on a provider outage is the regression to catch.
+	t.Run("provider error is reported to the user", func(t *testing.T) {
+		res := runTrajectoryEval(t, trajectoryScenario{
+			turns: []scriptedTurn{{err: errors.New("upstream 503")}},
+		})
+		assertProtocolInvariants(t, res)
+		if res.err != nil {
+			t.Fatalf("Process should absorb the error, got %v", res.err)
+		}
+		if !strings.Contains(res.final, "upstream 503") {
+			t.Errorf("the failure cause never reached the user; reply was %q", res.final)
+		}
+	})
+
+	t.Run("empty choices yields a usable reply", func(t *testing.T) {
+		res := runTrajectoryEval(t, trajectoryScenario{
+			turns: []scriptedTurn{{noChoices: true}},
+		})
+		assertProtocolInvariants(t, res)
+		if res.err != nil {
+			t.Fatalf("an empty response should not be an error, got %v", res.err)
+		}
+		if strings.TrimSpace(res.final) == "" {
+			t.Error("expected a fallback reply rather than an empty string")
+		}
+	})
+}

--- a/internal/agent/evalharness_test.go
+++ b/internal/agent/evalharness_test.go
@@ -1,0 +1,386 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bigknoxy/joshbot/internal/bus"
+	"github.com/bigknoxy/joshbot/internal/config"
+	ctxpkg "github.com/bigknoxy/joshbot/internal/context"
+	"github.com/bigknoxy/joshbot/internal/providers"
+	"github.com/bigknoxy/joshbot/internal/session"
+	"github.com/bigknoxy/joshbot/internal/tools"
+)
+
+// This file is a behavioural eval harness for the ReAct loop.
+//
+// The distinction from the prompt_*_test.go files in this package matters:
+// those score the *text* of the system prompt with substring checks and never
+// invoke the agent. This harness runs the real loop — real tool dispatch, real
+// session mutation, real context budgeting — against a scripted provider that
+// replays a fixed sequence of model turns. No network, no API key, no clock
+// dependence.
+//
+// What it asserts is the wire protocol the loop produces, not prose. The loop's
+// actual job is to hand the model a well-formed conversation on every turn; a
+// break there degrades or kills the agent in production while unit tests that
+// only check the final string stay green.
+
+// scriptedTurn is one model response to replay.
+type scriptedTurn struct {
+	content   string
+	toolCalls []providers.ToolCall
+	err       error
+	// noChoices simulates a provider returning an empty Choices slice.
+	noChoices bool
+}
+
+// toolCall is a terser way to declare a scripted tool call.
+func toolCall(id, name, args string) providers.ToolCall {
+	return providers.ToolCall{
+		ID:       id,
+		Type:     "function",
+		Function: providers.FunctionCall{Name: name, Arguments: args},
+	}
+}
+
+// scriptedProvider replays turns in order and records every request it was
+// given. Recording the requests is the point: it is the only way to see what
+// the loop actually sent to the model.
+type scriptedProvider struct {
+	mu       sync.Mutex
+	turns    []scriptedTurn
+	calls    int
+	requests []providers.ChatRequest
+}
+
+func (p *scriptedProvider) Chat(ctx context.Context, req providers.ChatRequest) (*providers.ChatResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Copy the message slice; the loop appends to its own backing array and
+	// would otherwise mutate what we recorded.
+	msgs := make([]providers.Message, len(req.Messages))
+	copy(msgs, req.Messages)
+	req.Messages = msgs
+	p.requests = append(p.requests, req)
+
+	idx := p.calls
+	p.calls++
+
+	// Past the end of the script the model just stops calling tools, so a
+	// scenario that under-specifies its script terminates instead of hanging.
+	if idx >= len(p.turns) {
+		return &providers.ChatResponse{Choices: []providers.Choice{{
+			Message: providers.Message{Role: providers.RoleAssistant, Content: "script exhausted"},
+		}}}, nil
+	}
+
+	turn := p.turns[idx]
+	if turn.err != nil {
+		return nil, turn.err
+	}
+	if turn.noChoices {
+		return &providers.ChatResponse{Choices: []providers.Choice{}}, nil
+	}
+	return &providers.ChatResponse{Choices: []providers.Choice{{
+		Message: providers.Message{
+			Role:      providers.RoleAssistant,
+			Content:   turn.content,
+			ToolCalls: turn.toolCalls,
+		},
+	}}}, nil
+}
+
+func (p *scriptedProvider) ChatStream(ctx context.Context, req providers.ChatRequest) (<-chan providers.StreamChunk, error) {
+	ch := make(chan providers.StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (p *scriptedProvider) Transcribe(ctx context.Context, _ []byte, _ string) (string, error) {
+	return "", nil
+}
+
+func (p *scriptedProvider) Name() string             { return "scripted" }
+func (p *scriptedProvider) Config() providers.Config { return providers.Config{} }
+
+// toolInvocation is one recorded call into the tool layer.
+type toolInvocation struct {
+	name string
+	args map[string]any
+}
+
+// recordingTools implements ToolExecutor, recording invocations and returning
+// scripted output per tool name.
+type recordingTools struct {
+	mu      sync.Mutex
+	calls   []toolInvocation
+	outputs map[string]string
+	errs    map[string]error
+	schemas []providers.Tool
+}
+
+func (r *recordingTools) Execute(ctx context.Context, name string, args map[string]any) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, toolInvocation{name: name, args: args})
+	if err, ok := r.errs[name]; ok {
+		return "", err
+	}
+	if out, ok := r.outputs[name]; ok {
+		return out, nil
+	}
+	return "ok", nil
+}
+
+func (r *recordingTools) ExecuteWithContext(ctx context.Context, name string, args map[string]any, channel, channelID string, cb func(tools.AsyncResult)) (tools.ToolResult, bool) {
+	out, err := r.Execute(ctx, name, args)
+	if err != nil {
+		return tools.ToolResult{Error: err}, false
+	}
+	return tools.ToolResult{Output: out}, false
+}
+
+func (r *recordingTools) GetSchemas() []providers.Tool { return r.schemas }
+
+func (r *recordingTools) invocations() []toolInvocation {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]toolInvocation, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// trajectoryScenario describes one behavioural run.
+type trajectoryScenario struct {
+	name  string
+	turns []scriptedTurn
+	// userMessage is what the user sends; defaults to "do the thing".
+	userMessage string
+	// history seeds the session before the run.
+	history []session.Message
+	// toolOutputs / toolErrors script the tool layer.
+	toolOutputs map[string]string
+	toolErrors  map[string]error
+	// tightBudget wires a budget manager and compressor with almost no room,
+	// which forces the context-reduction paths to run.
+	tightBudget bool
+	// memoryWindow, when non-zero, caps how many history messages are kept.
+	memoryWindow  int
+	maxIterations int
+}
+
+// trajectoryResult is everything observable after a run.
+type trajectoryResult struct {
+	requests    []providers.ChatRequest
+	invocations []toolInvocation
+	final       string
+	err         error
+	sess        *session.Session
+}
+
+// requestMessages returns the messages sent on the nth model call (0-indexed).
+func (r trajectoryResult) requestMessages(n int) []providers.Message {
+	if n >= len(r.requests) {
+		return nil
+	}
+	return r.requests[n].Messages
+}
+
+// runEval executes a scenario against the real agent loop.
+func runTrajectoryEval(t *testing.T, sc trajectoryScenario) trajectoryResult {
+	t.Helper()
+
+	// The prompt cache is a package-level singleton keyed on file mtimes; two
+	// scenarios with empty workspaces would otherwise share a cached prompt.
+	InvalidatePromptCache()
+
+	cfg := config.Defaults()
+	cfg.Agents.Defaults.Workspace = t.TempDir()
+	cfg.Agents.Defaults.Model = "small"
+	cfg.Agents.Defaults.MaxTokens = 100
+	if sc.memoryWindow > 0 {
+		cfg.Agents.Defaults.MemoryWindow = sc.memoryWindow
+	}
+	if sc.maxIterations > 0 {
+		cfg.Agents.Defaults.MaxToolIterations = sc.maxIterations
+	}
+
+	provider := &scriptedProvider{turns: sc.turns}
+	toolLayer := &recordingTools{outputs: sc.toolOutputs, errs: sc.toolErrors}
+
+	sessions := newMockSessionManager()
+	sess, err := sessions.GetOrCreate(context.Background(), "cli:eval")
+	if err != nil {
+		t.Fatalf("GetOrCreate: %v", err)
+	}
+	for _, m := range sc.history {
+		if m.Timestamp.IsZero() {
+			m.Timestamp = time.Now()
+		}
+		sess.AddMessage(m)
+	}
+
+	opts := []Option{}
+	if sc.tightBudget {
+		// Margin 3800 against the 4096-token "small" window drives the budget
+		// to its 256-token floor, so any real history exceeds it.
+		opts = append(opts,
+			WithBudgetManager(ctxpkg.NewBudgetManager(ctxpkg.NewRegistry(), 3800)),
+			WithCompressor(&ctxpkg.Compressor{}),
+		)
+	}
+	if sc.maxIterations > 0 {
+		opts = append(opts, WithMaxIterations(sc.maxIterations))
+	}
+
+	a := NewAgent(cfg, provider, toolLayer, sessions, newMockLogger(), opts...)
+
+	userMsg := sc.userMessage
+	if userMsg == "" {
+		userMsg = "do the thing"
+	}
+
+	final, err := a.Process(context.Background(), bus.InboundMessage{
+		Channel:  "cli",
+		SenderID: "eval",
+		Content:  userMsg,
+	})
+
+	return trajectoryResult{
+		requests:    provider.requests,
+		invocations: toolLayer.invocations(),
+		final:       final,
+		err:         err,
+		sess:        sess,
+	}
+}
+
+// assertProtocolInvariants checks the properties that must hold on every
+// request the loop sends, in every scenario. These are the rules an
+// OpenAI-compatible endpoint enforces with a 400, so a violation here is an
+// outage in production rather than a style issue.
+//
+// Applying this to every scenario is deliberate: any eval added later inherits
+// the safety net without having to remember it.
+func assertProtocolInvariants(t *testing.T, res trajectoryResult) {
+	t.Helper()
+
+	for reqIdx, req := range res.requests {
+		msgs := req.Messages
+
+		if len(msgs) == 0 {
+			t.Errorf("request %d: no messages sent", reqIdx)
+			continue
+		}
+		if msgs[0].Role != providers.RoleSystem {
+			t.Errorf("request %d: first message role = %q, want system", reqIdx, msgs[0].Role)
+		}
+
+		// Every tool_call announced by an assistant message must be answered,
+		// and every tool message must answer a call that was announced first.
+		announced := map[string]int{} // id -> index announced at
+		answered := map[string]bool{}
+
+		for i, m := range msgs {
+			if m.Role == "" {
+				t.Errorf("request %d, message %d: empty role", reqIdx, i)
+			}
+
+			for _, tc := range m.ToolCalls {
+				if m.Role != providers.RoleAssistant {
+					t.Errorf("request %d, message %d: tool calls on a %q message", reqIdx, i, m.Role)
+				}
+				if tc.ID == "" {
+					t.Errorf("request %d, message %d: assistant announced a tool call with an empty id", reqIdx, i)
+					continue
+				}
+				announced[tc.ID] = i
+			}
+
+			if m.Role != providers.RoleTool {
+				continue
+			}
+			if m.ToolCallID == "" {
+				t.Errorf("request %d, message %d: tool message has an empty tool_call_id; "+
+					"an OpenAI-compatible provider rejects this with a 400", reqIdx, i)
+				continue
+			}
+			at, ok := announced[m.ToolCallID]
+			if !ok {
+				t.Errorf("request %d, message %d: tool message answers tool_call_id %q, "+
+					"which no preceding assistant message announced", reqIdx, i, m.ToolCallID)
+				continue
+			}
+			if at > i {
+				t.Errorf("request %d, message %d: tool result precedes the call that announced it", reqIdx, i)
+			}
+			answered[m.ToolCallID] = true
+		}
+
+		for id, at := range announced {
+			if !answered[id] {
+				t.Errorf("request %d: tool call %q announced at message %d never received a result; "+
+					"an OpenAI-compatible provider rejects this with a 400", reqIdx, id, at)
+			}
+		}
+	}
+}
+
+// toolResultFor returns the content of the tool message answering id.
+func toolResultFor(msgs []providers.Message, id string) (string, bool) {
+	for _, m := range msgs {
+		if m.Role == providers.RoleTool && m.ToolCallID == id {
+			return m.Content, true
+		}
+	}
+	return "", false
+}
+
+// countRole counts messages with the given role.
+func countRole(msgs []providers.Message, role providers.MessageRole) int {
+	n := 0
+	for _, m := range msgs {
+		if m.Role == role {
+			n++
+		}
+	}
+	return n
+}
+
+// padding builds filler content of a known token cost.
+func padding(n int) string { return strings.Repeat("x", n) }
+
+// toolExchange returns an assistant tool call plus its result, as session
+// messages, for seeding history.
+func toolExchange(id, name, result string) []session.Message {
+	return []session.Message{
+		{
+			Role:      session.RoleAssistant,
+			ToolCalls: []session.ToolCall{{ID: id, Name: name, Arguments: json.RawMessage(`{}`)}},
+		},
+		{
+			Role:       session.RoleTool,
+			Content:    result,
+			ToolCallID: id,
+		},
+	}
+}
+
+// chatHistory builds n user/assistant pairs of the given content size.
+func chatHistory(pairs, size int) []session.Message {
+	msgs := make([]session.Message, 0, pairs*2)
+	for i := 0; i < pairs; i++ {
+		msgs = append(msgs,
+			session.Message{Role: session.RoleUser, Content: fmt.Sprintf("u%d %s", i, padding(size))},
+			session.Message{Role: session.RoleAssistant, Content: fmt.Sprintf("a%d %s", i, padding(size))},
+		)
+	}
+	return msgs
+}


### PR DESCRIPTION
## What

Adds a **behavioural eval harness** for the ReAct loop, and fixes two defects it found on its first run.

The gap this closes: nothing in the repo verified how the agent *behaves*. The existing `prompt_eval_test.go` / `prompt_optimizer_test.go` / `prompt_variants_test.go` files score the system prompt string with `strings.Contains` and never invoke the agent, a model, or a tool — they are a prompt lint. A behavioural regression in the loop could ship with every test green.

## The bugs

Both broke **long** conversations while leaving short ones working, which is why they went unnoticed.

1. **`applyObservationMasking` dropped tool-call linkage.** It rebuilt older messages as `providers.Message{Role, Content}`, discarding `ToolCalls` from assistant messages and `ToolCallID` from tool messages. Once history exceeded the token budget, joshbot sent `role:"tool"` messages answering nothing — **an OpenAI-compatible endpoint rejects that request with a 400.**
2. **The `MemoryWindow` slice could orphan a tool result** by cutting between an assistant tool call and its result. Same 400, different route. `dropOrphanedToolResults` trims those.

## The harness

`evalharness_test.go` runs the real loop against a scripted provider that replays fixed model turns and **records every request**. No network, no API key, no clock dependence — it runs in normal CI.

Evals assert the **trajectory** — what was sent to the model, what was dispatched to tools, what was persisted to the session — rather than the reply text. Nine scenarios cover tool round trips, parallel calls, malformed tool arguments, tool errors, context masking, memory-window truncation, the iteration cap, session persistence, and provider failure.

`assertProtocolInvariants` runs on **every** scenario and enforces the wire-format rules a provider rejects with a 400. Any eval added later inherits it.

## Validation

Mutation tested — nine deliberate regressions introduced into `agent.go`, each confirmed to turn the suite red:

| Mutant | KILLED by |
|---|---|
| Revert the masking fix | `ContextMaskingPreservesToolLinkage` |
| Remove orphan stripping | `MemoryWindowDoesNotOrphanToolResults` |
| `dropOrphanedToolResults` → no-op | `MemoryWindowDoesNotOrphanToolResults` |
| `formatToolResult` drops the id | 6 tests |
| Never feed tool results back | 5 tests |
| Off-by-one iteration cap | `MaxIterationsBoundsModelCalls` |
| Swallow provider errors | `ProviderFailureAndEmptyResponse` |
| Run tools on unparseable args | `MalformedToolArgumentsAreReportedNotDispatched` |
| Persist results without the id | `SessionRecordsFullTrajectory` |

**9/9 killed.** Two were re-verified independently of the agent that ran the sweep.

- `internal/agent` coverage **63.5% → 75.3%**; total **50.5% → 52.1%**
- `gofmt` clean, `go vet` clean, `go test -race ./...` passes

## Note

`Process` intentionally converts loop errors into a user-facing string with a `nil` error. I initially wrote an eval asserting the error propagated; that was wrong about the contract, and the eval now asserts the cause reaches the user instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)