### PR TITLE
fix: stop leaking Telegram message text to stderr, and actually stop the poller

### DIFF
--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"net/http"
 	"net/url"
-	"os"
 	"regexp"
 	"runtime/debug"
 	"strconv"
@@ -339,7 +338,7 @@ func (t *TelegramChannel) handleMessage(ctx telebot.Context) (err error) {
 	}()
 
 	msg := ctx.Message()
-	fmt.Fprintf(os.Stderr, "!!! handleMessage called sender=%d text=%q\n", msg.Sender.ID, msg.Text)
+	log.Debug("handleMessage called", "sender", msg.Sender.ID)
 
 	// Check if it's a command - let specific handlers deal with it
 	if strings.HasPrefix(msg.Text, "/") {
@@ -397,7 +396,7 @@ Just send me a message and I'll respond!`
 // handleNew handles the /new command to start a new session.
 func (t *TelegramChannel) handleNew(ctx telebot.Context) error {
 	msg := ctx.Message()
-	fmt.Fprintf(os.Stderr, "!!! handleNew called sender=%d text=%q\n", msg.Sender.ID, msg.Text)
+	log.Debug("handleNew called", "sender", msg.Sender.ID)
 
 	// Send new session command to bus
 	inbound := bus.InboundMessage{

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -244,6 +244,10 @@ func (t *TelegramChannel) runBot(ctx context.Context, bot *telebot.Bot) {
 
 			// Set up handlers on new bot
 			t.setupHandlers(newBot)
+
+			// Rebind the loop's local bot so the next iteration restarts
+			// the new bot instead of the stale one.
+			bot = newBot
 		}
 	}
 }
@@ -855,9 +859,12 @@ func (t *TelegramChannel) Stop() error {
 	t.running = false
 	close(t.stopCh)
 
-	// Stop the bot
+	// Stop the bot's long poller so runBot's blocking bot.Start() call
+	// returns. bot.Close() is the Telegram Bot API "close" session-teardown
+	// RPC (for moving a bot between API servers) and never unblocks
+	// bot.Start(), which would leak the poller goroutine.
 	if t.bot != nil {
-		t.bot.Close()
+		t.bot.Stop()
 		t.bot = nil
 	}
 

--- a/internal/channels/telegram_more_test.go
+++ b/internal/channels/telegram_more_test.go
@@ -2,6 +2,8 @@ package channels
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -149,6 +151,62 @@ func TestTelegramChannel_StopWhenRunning(t *testing.T) {
 	case <-tg.stopCh:
 	default:
 		t.Error("stopCh should be closed after Stop")
+	}
+}
+
+// TestTelegramChannel_StopStopsPollerGoroutine exercises the real
+// Start-shaped path: it hands a live *telebot.Bot polling a fake Telegram
+// API server to runBot (the same way Start() does), then calls Stop() and
+// asserts the goroutine blocked inside runBot (via bot.Start()) actually
+// returns.
+//
+// bot.Close() (the Telegram Bot API "close" session-teardown RPC) never
+// touches the internal channel that unblocks bot.Start()'s event loop, so
+// runBot leaks the polling goroutine forever when Stop() calls it. Only
+// bot.Stop() does. Before the fix, this test times out waiting for runBot
+// to return.
+func TestTelegramChannel_StopStopsPollerGoroutine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"result":[]}`))
+	}))
+	defer srv.Close()
+
+	bot, err := telebot.NewBot(telebot.Settings{
+		Token:   "test-token",
+		URL:     srv.URL,
+		Poller:  &telebot.LongPoller{Timeout: 10 * time.Millisecond},
+		Offline: true, // skip the getMe() network call NewBot would otherwise make
+	})
+	if err != nil {
+		t.Fatalf("failed to create test bot: %v", err)
+	}
+
+	tg := newTestTelegramChannel()
+	tg.mu.Lock()
+	tg.running = true
+	tg.bot = bot
+	tg.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		tg.runBot(context.Background(), bot)
+		close(done)
+	}()
+
+	// Give the poller goroutine time to actually start polling the fake
+	// server before we ask it to stop.
+	time.Sleep(150 * time.Millisecond)
+
+	if err := tg.Stop(); err != nil {
+		t.Fatalf("Stop returned %v", err)
+	}
+
+	select {
+	case <-done:
+		// runBot returned: bot.Start() unblocked and the poller goroutine exited.
+	case <-time.After(2 * time.Second):
+		t.Fatal("runBot did not return after Stop(); the underlying poller goroutine leaked")
 	}
 }
 


### PR DESCRIPTION
Closes #70. Closes #72.

## #70 — every user message was written to stderr

`telegram.go` carried two leftover debug statements from commit `c8b3194` (2026-05-31):

```go
fmt.Fprintf(os.Stderr, "!!! handleMessage called sender=%d text=%q\n", msg.Sender.ID, msg.Text)
```

These bypassed the log-level system entirely, so every message a user sent the bot landed in the journal in plaintext regardless of `log_level`. Replaced with `log.Debug` carrying the sender ID only — the message text is dropped.

## #72 — `Stop()` called the wrong method

`Stop()` called `bot.Close()`, which is the Telegram Bot API `close` RPC (server-side session teardown for moving a bot between API servers). The method that stops the local long-poller is `bot.Stop()`. `Close()` never touches telebot's internal `b.stop` channel, so `bot.Start()` never returned and the poller goroutine leaked — while the channel logged "Telegram channel stopped".

Also rebinds the loop's local `bot` in `runBot`'s reconnect branch, which previously rebound only `t.bot` and would have restarted the stale bot.

## Validation

Test written first and **watched failing** before the fix:

```
=== RUN   TestTelegramChannel_StopStopsPollerGoroutine
    telegram_more_test.go:209: runBot did not return after Stop(); the underlying poller goroutine leaked
--- FAIL: TestTelegramChannel_StopStopsPollerGoroutine (2.15s)
```

The test drives the real `runBot` path with a `telebot.Bot` in `Offline` mode against an `httptest` server faking `getUpdates`, then asserts the goroutine returns within 2s. This matters because the pre-existing `TestTelegramChannel_StopWhenRunning` sets `running = true` directly, leaving `t.bot` nil so the buggy line never executed.

`gofmt`/`vet` clean, `go test -race ./...` passes.

**Not covered:** the reconnect-branch rebind has no dedicated test — it is unreachable today and forcing it would need test-only network hooks in `createBot`. Verified by reading only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)