### PR TITLE
fix: stop reporting disabled providers as configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ For backward compatibility, the old format still works:
 {
   "providers": {
     "openrouter": {
-      "api_key": "sk-or-v1-your-key-here"
+      "api_key": "sk-or-v1-your-key-here",
+      "enabled": true
     }
   },
   "agents": {

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -545,6 +546,14 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 				multiProvider.Register("custom", customProvider, model, priority, p.Enabled)
 				log.Info("Registered custom provider", "api_base", p.APIBase)
 			}
+		}
+
+		// Fail fast if the legacy provider map produced zero usable providers,
+		// rather than deferring to an opaque "no providers configured" error
+		// the first time Chat() is called. Distinguishes an empty config from
+		// providers present but none enabled (issue #71).
+		if len(multiProvider.GetProviderNames()) == 0 {
+			return nil, nil, nil, nil, nil, nil, noProvidersRegisteredError(cfg.Providers)
 		}
 	}
 
@@ -2479,14 +2488,7 @@ func runStatus(c *cli.Context) error {
 		}
 		fmt.Printf("Models:         %s\n", strings.Join(modelNames, ", "))
 	} else {
-		providerNames := make([]string, 0, len(cfg.Providers))
-		for name := range cfg.Providers {
-			providerNames = append(providerNames, name)
-		}
-		if len(providerNames) == 0 {
-			providerNames = []string{"none"}
-		}
-		fmt.Printf("Providers:      %s\n", strings.Join(providerNames, ", "))
+		fmt.Printf("Providers:      %s\n", formatProviderStatus(cfg.Providers))
 	}
 	fmt.Printf("Telegram:       %s\n", boolToEnabled(cfg.Channels.Telegram.Enabled))
 	fmt.Printf("Workspace restricted: %s\n", boolToEnabled(cfg.Tools.RestrictToWorkspace))
@@ -3487,6 +3489,75 @@ func runAuthStatus(c *cli.Context) error {
 }
 
 // Helper functions
+
+// providerRequiresAPIKey reports whether the named legacy provider must have
+// a non-empty api_key to be registered by setupComponents. Keep this in sync
+// with the gating conditions there: openrouter/nvidia/groq/poolside/custom
+// all require p.APIKey != "", while ollama (local server) and github-copilot
+// (OAuth token file, not api_key) do not.
+func providerRequiresAPIKey(name string) bool {
+	switch name {
+	case "ollama", "github-copilot":
+		return false
+	default:
+		return true
+	}
+}
+
+// formatProviderStatus renders the legacy providers map for `joshbot status`,
+// flagging any provider that setupComponents will NOT register: either
+// because "enabled": true is missing, or (for providers that need one)
+// because api_key is empty. This mirrors the registration gates in
+// setupComponents so status never claims a provider is configured when it
+// is actually inert. See issue #71.
+func formatProviderStatus(providersCfg map[string]config.ProviderConfig) string {
+	if len(providersCfg) == 0 {
+		return "none"
+	}
+
+	names := make([]string, 0, len(providersCfg))
+	for name := range providersCfg {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		p := providersCfg[name]
+		switch {
+		case !p.Enabled:
+			parts = append(parts, fmt.Sprintf(`%s (disabled — set "enabled": true)`, name))
+		case providerRequiresAPIKey(name) && p.APIKey == "":
+			parts = append(parts, fmt.Sprintf(`%s (disabled — missing "api_key")`, name))
+		default:
+			parts = append(parts, name)
+		}
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// noProvidersRegisteredError builds the diagnostic error returned when the
+// legacy provider config yields zero registered providers. It distinguishes
+// "no providers in config at all" from "providers present but none enabled",
+// naming the enabled field in the latter case so a hand-editing user has
+// somewhere to look. See issue #71.
+func noProvidersRegisteredError(providersCfg map[string]config.ProviderConfig) error {
+	if len(providersCfg) == 0 {
+		return fmt.Errorf("no providers configured. Run 'joshbot onboard' first")
+	}
+
+	names := make([]string, 0, len(providersCfg))
+	for name := range providersCfg {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return fmt.Errorf(
+		"no providers enabled: %d provider(s) found in config (%s) but none have \"enabled\": true — add \"enabled\": true to the provider you want to use",
+		len(providersCfg), strings.Join(names, ", "),
+	)
+}
 
 func boolToEnabled(b bool) string {
 	if b {

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -3538,20 +3538,35 @@ func formatProviderStatus(providersCfg map[string]config.ProviderConfig) string 
 }
 
 // noProvidersRegisteredError builds the diagnostic error returned when the
-// legacy provider config yields zero registered providers. It distinguishes
-// "no providers in config at all" from "providers present but none enabled",
-// naming the enabled field in the latter case so a hand-editing user has
-// somewhere to look. See issue #71.
+// legacy provider config yields zero registered providers.
+//
+// It names the actual cause rather than guessing. A provider can fail to
+// register for two different reasons, and telling someone to set
+// "enabled": true when it is already set is exactly the kind of misleading
+// diagnostic issue #71 was filed about. See issue #71.
 func noProvidersRegisteredError(providersCfg map[string]config.ProviderConfig) error {
 	if len(providersCfg) == 0 {
 		return fmt.Errorf("no providers configured. Run 'joshbot onboard' first")
 	}
 
 	names := make([]string, 0, len(providersCfg))
-	for name := range providersCfg {
+	var keyless []string
+	for name, p := range providersCfg {
 		names = append(names, name)
+		if p.Enabled && providerRequiresAPIKey(name) && p.APIKey == "" {
+			keyless = append(keyless, name)
+		}
 	}
 	sort.Strings(names)
+	sort.Strings(keyless)
+
+	// Enabled but unusable: the enabled flag is not the problem.
+	if len(keyless) > 0 {
+		return fmt.Errorf(
+			"no providers usable: %s enabled but missing \"api_key\" — set an api_key, or run 'joshbot configure'",
+			strings.Join(keyless, ", "),
+		)
+	}
 
 	return fmt.Errorf(
 		"no providers enabled: %d provider(s) found in config (%s) but none have \"enabled\": true — add \"enabled\": true to the provider you want to use",

--- a/cmd/joshbot/main_test.go
+++ b/cmd/joshbot/main_test.go
@@ -186,3 +186,31 @@ func TestNoProvidersRegisteredError(t *testing.T) {
 		}
 	})
 }
+
+// An enabled provider with no api_key must not be told to set "enabled": true —
+// it already is. A diagnostic that names the wrong cause is the bug this issue
+// was filed about.
+func TestNoProvidersRegisteredError_EnabledButKeyless(t *testing.T) {
+	err := noProvidersRegisteredError(map[string]config.ProviderConfig{
+		"openrouter": {Enabled: true, APIKey: ""},
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), `add "enabled": true`) {
+		t.Errorf("error blames the enabled flag on an already-enabled provider: %v", err)
+	}
+	if !strings.Contains(err.Error(), "api_key") {
+		t.Errorf("error should name the missing api_key; got %v", err)
+	}
+}
+
+// ollama needs no api_key, so an enabled ollama with no key is not the cause.
+func TestNoProvidersRegisteredError_KeylessProviderNotBlamed(t *testing.T) {
+	err := noProvidersRegisteredError(map[string]config.ProviderConfig{
+		"openrouter": {Enabled: false, APIKey: "sk-x"},
+	})
+	if !strings.Contains(err.Error(), `"enabled": true`) {
+		t.Errorf("a disabled provider should still point at the enabled flag; got %v", err)
+	}
+}

--- a/cmd/joshbot/main_test.go
+++ b/cmd/joshbot/main_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bigknoxy/joshbot/internal/bus"
+	"github.com/bigknoxy/joshbot/internal/config"
 	"github.com/bigknoxy/joshbot/internal/tools"
 )
 
@@ -90,4 +91,98 @@ func TestRunAgentLoopSetsChatID(t *testing.T) {
 	if chatID != "cli_user" {
 		t.Fatalf("expected chat ID 'cli_user', got %q", chatID)
 	}
+}
+
+// TestFormatProviderStatus covers the `status` provider line for issue #71:
+// a provider missing "enabled": true (or, where applicable, an api_key) must
+// be visibly flagged rather than listed as if it were configured and ready.
+func TestFormatProviderStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		providers map[string]config.ProviderConfig
+		want      string
+	}{
+		{
+			name:      "no providers",
+			providers: map[string]config.ProviderConfig{},
+			want:      "none",
+		},
+		{
+			name: "api key set but enabled absent",
+			providers: map[string]config.ProviderConfig{
+				"openrouter": {APIKey: "sk-or-v1-anything"},
+			},
+			want: `openrouter (disabled — set "enabled": true)`,
+		},
+		{
+			name: "api key set and enabled true",
+			providers: map[string]config.ProviderConfig{
+				"openrouter": {APIKey: "sk-or-v1-anything", Enabled: true},
+			},
+			want: "openrouter",
+		},
+		{
+			name: "enabled true but no api key",
+			providers: map[string]config.ProviderConfig{
+				"nvidia": {Enabled: true},
+			},
+			want: `nvidia (disabled — missing "api_key")`,
+		},
+		{
+			name: "ollama does not require an api key",
+			providers: map[string]config.ProviderConfig{
+				"ollama": {Enabled: true},
+			},
+			want: "ollama",
+		},
+		{
+			name: "mixed providers sorted and each flagged independently",
+			providers: map[string]config.ProviderConfig{
+				"openrouter": {APIKey: "sk-or-v1-anything"},
+				"groq":       {APIKey: "gsk_anything", Enabled: true},
+			},
+			want: `groq, openrouter (disabled — set "enabled": true)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatProviderStatus(tt.providers)
+			if got != tt.want {
+				t.Fatalf("formatProviderStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNoProvidersRegisteredError covers issue #71 part 2: the error raised
+// when the legacy provider map yields zero registered providers must say
+// whether the config had no providers at all, or providers present but none
+// enabled -- and the latter must name the "enabled" field so a hand-editing
+// user has somewhere to look.
+func TestNoProvidersRegisteredError(t *testing.T) {
+	t.Run("empty config", func(t *testing.T) {
+		err := noProvidersRegisteredError(map[string]config.ProviderConfig{})
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if strings.Contains(err.Error(), "enabled") {
+			t.Fatalf("error for an empty config should not talk about the enabled field: %q", err.Error())
+		}
+	})
+
+	t.Run("present but none enabled", func(t *testing.T) {
+		err := noProvidersRegisteredError(map[string]config.ProviderConfig{
+			"openrouter": {APIKey: "sk-or-v1-anything"},
+		})
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "enabled") {
+			t.Fatalf("error should name the enabled field, got %q", err.Error())
+		}
+		if !strings.Contains(err.Error(), "openrouter") {
+			t.Fatalf("error should name the configured-but-inert provider, got %q", err.Error())
+		}
+	})
 }


### PR DESCRIPTION
Closes #71.

A provider without `"enabled": true` is silently skipped, and `status` — the command you run to diagnose exactly that — listed it anyway as though it were fine.

## Changes

1. `status` flags providers that will not be registered, mirroring the real gates in `setupComponents`:
   ```
   Providers:      openrouter (disabled — set "enabled": true)
   Providers:      nvidia (disabled — missing "api_key"), openrouter (disabled — set "enabled": true)
   ```
2. Startup now fails fast with a diagnostic naming the actual cause, instead of deferring to a generic "no providers configured" at first `Chat()`.
3. `README.md`'s legacy example gains `"enabled": true` — it was the source of the footgun.

## Review correction

The first cut of this branch always blamed the `enabled` flag, so an **enabled** provider with an empty `api_key` produced *"none have enabled: true — add enabled: true"*, which is false and unactionable. Telling someone to set a flag that is already set is precisely the lying-diagnostic defect this issue is about. `noProvidersRegisteredError` now distinguishes the two causes, with regression tests for both.

## Validation

Tests written first; pre-fix they failed to compile because the tested behaviour did not exist:

```
cmd/joshbot/main_test.go:150:11: undefined: formatProviderStatus
cmd/joshbot/main_test.go:165:10: undefined: noProvidersRegisteredError
FAIL	github.com/bigknoxy/joshbot/cmd/joshbot [build failed]
```

**Dogfooded against the real binary**, three configs, isolated from any live install:

| config | `status` | `agent -m` |
|---|---|---|
| `api_key`, no `enabled` | `openrouter (disabled — set "enabled": true)` | names the `enabled` flag, exit 1 |
| `api_key` + `enabled: true` | `openrouter` | proceeds |
| `enabled: true`, no `api_key` | `nvidia (disabled — missing "api_key")` | names the missing key, exit 1 |

`gofmt`/`vet` clean, `go test -race ./...` passes.

## Noted, not fixed here

`config.Defaults()` always seeds `Providers: {"openrouter": {}}` and `json.Unmarshal` merges into the existing map, so `cfg.Providers` is effectively never empty from a real config file. The "no providers at all" branch is implemented and unit-tested but unreachable in practice, which also makes the pre-existing `len(cfg.Providers) == 0` checks in `runAgent`/`runGateway` largely dead. Out of scope — flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)