### PR TITLE
fix: validate LLM output before writing it into MEMORY.md

### DIFF
--- a/internal/learning/evalharness_test.go
+++ b/internal/learning/evalharness_test.go
@@ -1,0 +1,263 @@
+package learning
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bigknoxy/joshbot/internal/memory"
+	"github.com/bigknoxy/joshbot/internal/providers"
+)
+
+// This file is a behavioural eval harness for the consolidation content gate
+// added in response to GH issue #73: the consolidator was wrapping the raw
+// LLM completion (refusal, meta-commentary, verbose prose, whatever came
+// back) as a single high-confidence fact and persisting it straight into
+// MEMORY.md, which is loaded into every future turn's context.
+//
+// It follows the pattern in internal/agent/evalharness_test.go: a provider
+// double that replays a scripted completion and records every request it
+// received, run through the *real* Consolidator.RunOnce path (no network, no
+// API key, no clock dependence), with assertions on what actually lands in
+// MEMORY.md rather than on the raw completion string.
+
+// scriptedProvider replays a fixed completion for every Chat call and
+// records the requests it was given, so a test can assert on what the
+// consolidator actually sent as well as what it did with the reply.
+type scriptedProvider struct {
+	mu       sync.Mutex
+	content  string
+	requests []providers.ChatRequest
+}
+
+func (p *scriptedProvider) Chat(ctx context.Context, req providers.ChatRequest) (*providers.ChatResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.requests = append(p.requests, req)
+	return &providers.ChatResponse{Choices: []providers.Choice{{
+		Message: providers.Message{Role: providers.RoleAssistant, Content: p.content},
+	}}}, nil
+}
+
+func (p *scriptedProvider) ChatStream(ctx context.Context, req providers.ChatRequest) (<-chan providers.StreamChunk, error) {
+	ch := make(chan providers.StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (p *scriptedProvider) Transcribe(ctx context.Context, _ []byte, _ string) (string, error) {
+	return "", nil
+}
+
+func (p *scriptedProvider) Name() string             { return "scripted" }
+func (p *scriptedProvider) Config() providers.Config { return providers.DefaultConfig() }
+
+func (p *scriptedProvider) requestCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.requests)
+}
+
+// newTestConsolidator wires a Consolidator against a fresh memory.Manager
+// (with a couple of history lines seeded so RunOnce has something to send)
+// and a scripted provider that always replies with content.
+func newTestConsolidator(t *testing.T, content string) (*Consolidator, *memory.Manager, *scriptedProvider) {
+	t.Helper()
+	ctx := context.Background()
+	tmp := t.TempDir()
+	mm, err := memory.New(tmp)
+	if err != nil {
+		t.Fatalf("memory.New: %v", err)
+	}
+	if err := mm.Initialize(ctx); err != nil {
+		t.Fatalf("mem.Initialize: %v", err)
+	}
+	if err := mm.AppendHistory(ctx, "User asked about deploying the service."); err != nil {
+		t.Fatalf("AppendHistory: %v", err)
+	}
+	if err := mm.AppendHistory(ctx, "Agent walked through the systemd unit file."); err != nil {
+		t.Fatalf("AppendHistory: %v", err)
+	}
+
+	p := &scriptedProvider{content: content}
+	c := NewConsolidator(mm, p, time.Hour)
+	return c, mm, p
+}
+
+// factContents returns the Content of every stored FactSystem fact.
+func factContents(t *testing.T, mm *memory.Manager) []string {
+	t.Helper()
+	results, err := mm.Search(context.Background(), memory.SearchQuery{Category: memory.FactSystem, Max: 1000})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	out := make([]string, 0, len(results))
+	for _, r := range results {
+		out = append(out, r.Fact.Content)
+	}
+	return out
+}
+
+// TestEval_RunOnce_ValidOneLinersStored is the control case: a well-formed
+// completion of short factual one-liners should be stored verbatim, one fact
+// per line, each within the length bound.
+func TestEval_RunOnce_ValidOneLinersStored(t *testing.T) {
+	ctx := context.Background()
+	content := "User's name is Alice.\nAlice is working on the joshbot deployment.\nAlice prefers systemd over Docker."
+	c, mm, p := newTestConsolidator(t, content)
+
+	if err := c.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if p.requestCount() != 1 {
+		t.Fatalf("expected exactly 1 chat request, got %d", p.requestCount())
+	}
+
+	facts := factContents(t, mm)
+	if len(facts) != 3 {
+		t.Fatalf("expected 3 stored facts, got %d: %v", len(facts), facts)
+	}
+	for _, f := range facts {
+		if len(f) > maxFactContentLength {
+			t.Fatalf("fact exceeds length bound (%d): %q", maxFactContentLength, f)
+		}
+		if strings.TrimSpace(f) == "" {
+			t.Fatalf("stored an empty fact")
+		}
+	}
+
+	mem, err := mm.LoadMemory(ctx)
+	if err != nil {
+		t.Fatalf("LoadMemory: %v", err)
+	}
+	if !strings.Contains(mem, "Alice") {
+		t.Fatalf("expected MEMORY.md to contain consolidated facts, got: %q", mem)
+	}
+}
+
+// TestEval_RunOnce_RefusalRejected proves a refusal-shaped completion does
+// not become a permanent memory entry: MEMORY.md must be byte-identical to
+// its pre-RunOnce baseline (a golden diff, not just "non-empty").
+func TestEval_RunOnce_RefusalRejected(t *testing.T) {
+	ctx := context.Background()
+	content := "I don't have enough context to extract facts from this conversation."
+	c, mm, _ := newTestConsolidator(t, content)
+
+	baseline, err := mm.LoadMemory(ctx)
+	if err != nil {
+		t.Fatalf("LoadMemory baseline: %v", err)
+	}
+
+	if err := c.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	got, err := mm.LoadMemory(ctx)
+	if err != nil {
+		t.Fatalf("LoadMemory: %v", err)
+	}
+	if got != baseline {
+		t.Fatalf("expected MEMORY.md unchanged after refusal completion\nbaseline=%q\ngot=%q", baseline, got)
+	}
+	if facts := factContents(t, mm); len(facts) != 0 {
+		t.Fatalf("expected no stored facts after refusal, got: %v", facts)
+	}
+}
+
+// TestEval_RunOnce_WhitespaceOnlyRejected covers a completion that is not
+// the empty string but carries no content — this is the case that actually
+// exercises the new gate at the LLM boundary (a literal "" short-circuits to
+// the pre-existing heuristic fallback before saveSummary is ever called).
+func TestEval_RunOnce_WhitespaceOnlyRejected(t *testing.T) {
+	ctx := context.Background()
+	content := "   \n\t  \n   "
+	c, mm, _ := newTestConsolidator(t, content)
+
+	baseline, err := mm.LoadMemory(ctx)
+	if err != nil {
+		t.Fatalf("LoadMemory baseline: %v", err)
+	}
+
+	if err := c.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	got, err := mm.LoadMemory(ctx)
+	if err != nil {
+		t.Fatalf("LoadMemory: %v", err)
+	}
+	if got != baseline {
+		t.Fatalf("expected MEMORY.md unchanged after whitespace-only completion\nbaseline=%q\ngot=%q", baseline, got)
+	}
+}
+
+// TestEval_RunOnce_LongBlobRejected covers a wall-of-prose completion far
+// longer than any reasonable one-line fact (5000+ chars, well past what
+// MaxTokens:200 is meant to bound). It must be rejected outright rather than
+// stored as a single giant fact.
+func TestEval_RunOnce_LongBlobRejected(t *testing.T) {
+	ctx := context.Background()
+	content := strings.Repeat("This is verbose filler prose that does not look like a one-line fact at all. ", 65)
+	if len(content) < 4000 {
+		t.Fatalf("test setup: blob too short: %d chars", len(content))
+	}
+	c, mm, _ := newTestConsolidator(t, content)
+
+	baseline, err := mm.LoadMemory(ctx)
+	if err != nil {
+		t.Fatalf("LoadMemory baseline: %v", err)
+	}
+
+	if err := c.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	got, err := mm.LoadMemory(ctx)
+	if err != nil {
+		t.Fatalf("LoadMemory: %v", err)
+	}
+	if got != baseline {
+		t.Fatalf("expected MEMORY.md unchanged after oversized completion\nbaseline=%q\ngot len=%d", baseline, len(got))
+	}
+}
+
+// TestSaveSummary_EmptyStringRejected exercises the literal empty-string
+// case directly against saveSummary (the function named in the issue as the
+// culprit) rather than through RunOnce, since RunOnce treats a literal ""
+// completion as "no response" and defers to the pre-existing heuristic
+// fallback rather than ever calling saveSummary. This proves the gate itself
+// rejects empty content, independent of that fallback routing decision.
+func TestSaveSummary_EmptyStringRejected(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	mm, err := memory.New(tmp)
+	if err != nil {
+		t.Fatalf("memory.New: %v", err)
+	}
+	if err := mm.Initialize(ctx); err != nil {
+		t.Fatalf("mem.Initialize: %v", err)
+	}
+
+	baseline, err := mm.LoadMemory(ctx)
+	if err != nil {
+		t.Fatalf("LoadMemory baseline: %v", err)
+	}
+
+	c := NewConsolidator(mm, nil, time.Hour)
+	if err := c.saveSummary(ctx, ""); err != nil {
+		t.Fatalf("saveSummary: %v", err)
+	}
+
+	got, err := mm.LoadMemory(ctx)
+	if err != nil {
+		t.Fatalf("LoadMemory: %v", err)
+	}
+	if got != baseline {
+		t.Fatalf("expected MEMORY.md unchanged after empty completion\nbaseline=%q\ngot=%q", baseline, got)
+	}
+	if facts := factContents(t, mm); len(facts) != 0 {
+		t.Fatalf("expected no stored facts for empty completion, got: %v", facts)
+	}
+}

--- a/internal/learning/learning.go
+++ b/internal/learning/learning.go
@@ -2,11 +2,12 @@ package learning
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/charmbracelet/log"
 
 	"github.com/bigknoxy/joshbot/internal/memory"
 	"github.com/bigknoxy/joshbot/internal/providers"
@@ -118,7 +119,7 @@ func (c *Consolidator) RunOnce(ctx context.Context) error {
 
 	var summary string
 	if c.provider != nil {
-		sys := "You are a memory consolidation assistant. Extract a short list of factual one-line statements from the conversation."
+		sys := "You are a memory consolidation assistant. Extract a short list of factual one-line statements from the conversation, one per line, with no preamble or commentary. If there is nothing worth remembering, respond with nothing."
 		req := providers.ChatRequest{
 			Model: c.provider.Config().Model,
 			Messages: []providers.Message{
@@ -142,22 +143,50 @@ func (c *Consolidator) RunOnce(ctx context.Context) error {
 	}
 }
 
-// saveSummary tries structured fact parsing first, falls back to raw fact.
+// saveSummary applies a deterministic content gate to the raw completion
+// before persisting anything: it is split into candidate one-line facts,
+// each of which must be non-empty, within maxFactContentLength, and not look
+// like a refusal or meta-commentary (see extractValidFacts). A completion
+// that yields no valid facts is rejected outright — logged and discarded —
+// leaving MEMORY.md unchanged, rather than being stored as a single
+// unfiltered blob.
+//
+// The consolidation prompt asks for plain one-line statements, not JSON, so
+// this no longer attempts a JSON.Unmarshal fast path: that branch was dead
+// in production (the prompt never requests JSON) and its presence implied a
+// contract that was never exercised. See GH issue #73.
 func (c *Consolidator) saveSummary(ctx context.Context, summary string) error {
-	var facts []memory.Fact
-	if err := json.Unmarshal([]byte(summary), &facts); err == nil && len(facts) > 0 {
-		return c.mem.ReconcileFacts(ctx, facts)
+	validFacts, reason := extractValidFacts(summary, maxFactContentLength, c.maxFacts)
+	if len(validFacts) == 0 {
+		log.Warn("consolidation rejected: completion failed content gate",
+			"reason", reason,
+			"preview", previewString(summary, 80))
+		return nil
 	}
 
-	fact := memory.Fact{
-		ID:         memory.FactID(memory.FactSystem, summary),
-		Category:   memory.FactSystem,
-		Content:    summary,
-		Confidence: 0.6,
-		CreatedAt:  time.Now(),
-		UpdatedAt:  time.Now(),
+	now := time.Now()
+	facts := make([]memory.Fact, 0, len(validFacts))
+	for _, content := range validFacts {
+		facts = append(facts, memory.Fact{
+			ID:         memory.FactID(memory.FactSystem, content),
+			Category:   memory.FactSystem,
+			Content:    content,
+			Confidence: 0.6,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		})
 	}
-	return c.mem.ReconcileFacts(ctx, []memory.Fact{fact})
+	return c.mem.ReconcileFacts(ctx, facts)
+}
+
+// previewString returns s trimmed to at most n characters, for safe logging
+// of otherwise-unbounded model output.
+func previewString(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }
 
 // heuristicFallback picks lines that look like facts and writes them as consolidated section.

--- a/internal/learning/validate.go
+++ b/internal/learning/validate.go
@@ -1,0 +1,125 @@
+package learning
+
+import "strings"
+
+// maxFactContentLength bounds the length of a single consolidated fact. The
+// consolidation prompt asks for short factual one-line statements; anything
+// longer looks like unfiltered prose, not an extracted fact, and is rejected
+// rather than truncated (see GH issue #73).
+const maxFactContentLength = 300
+
+// refusalPatterns are case-insensitive substrings that mark a line as a
+// refusal or meta-commentary rather than an extracted fact. Matching is
+// deliberately whole-phrase (not single words) to avoid rejecting legitimate
+// facts that happen to share a word with one of these phrases.
+var refusalPatterns = []string{
+	"i don't have enough",
+	"i do not have enough",
+	"i don't have access",
+	"i do not have access",
+	"not enough context",
+	"not enough information",
+	"as an ai",
+	"as a language model",
+	"i cannot extract",
+	"i can't extract",
+	"unable to extract",
+	"i'm sorry",
+	"i am sorry",
+	"i don't know",
+	"i do not know",
+	"no facts",
+	"no factual",
+	"i cannot determine",
+	"i can't determine",
+	"here are the facts",
+	"here is a summary",
+	"here's a summary",
+	"i don't see",
+	"i do not see",
+}
+
+// looksLikeRefusalOrMeta reports whether line reads like a refusal or
+// meta-commentary rather than an extracted fact.
+func looksLikeRefusalOrMeta(line string) bool {
+	lower := strings.ToLower(line)
+	for _, p := range refusalPatterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// stripListMarker removes a leading list marker ("- ", "* ", "• ", "1. ",
+// "2) ") so downstream checks see the actual content, since models commonly
+// format "a short list of one-line statements" as a bulleted or numbered
+// list.
+func stripListMarker(line string) string {
+	line = strings.TrimSpace(line)
+	for _, prefix := range []string{"- ", "* ", "• "} {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		}
+	}
+	i := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	if i > 0 && i < len(line) && (line[i] == '.' || line[i] == ')') {
+		if rest := strings.TrimSpace(line[i+1:]); rest != "" {
+			return rest
+		}
+	}
+	return line
+}
+
+// extractValidFacts splits a raw model completion into candidate one-line
+// facts and applies a deterministic content gate: each line must be
+// non-empty after trimming a list marker, within maxFactLen characters, and
+// must not look like a refusal or meta-commentary. At most maxFacts
+// survivors are returned, in order.
+//
+// If no line survives, facts is nil and reason explains why, for logging.
+// The caller must not persist anything in that case.
+func extractValidFacts(summary string, maxFactLen, maxFacts int) (facts []string, reason string) {
+	trimmed := strings.TrimSpace(summary)
+	if trimmed == "" {
+		return nil, "empty or whitespace-only completion"
+	}
+
+	var rejectedLong, rejectedRefusal int
+	for _, raw := range strings.Split(trimmed, "\n") {
+		line := stripListMarker(raw)
+		if line == "" {
+			continue
+		}
+		if len(line) > maxFactLen {
+			rejectedLong++
+			continue
+		}
+		if looksLikeRefusalOrMeta(line) {
+			rejectedRefusal++
+			continue
+		}
+		facts = append(facts, line)
+		if len(facts) >= maxFacts {
+			break
+		}
+	}
+
+	if len(facts) == 0 {
+		switch {
+		case rejectedRefusal > 0 && rejectedLong == 0:
+			reason = "completion looked like a refusal or meta-commentary"
+		case rejectedLong > 0 && rejectedRefusal == 0:
+			reason = "completion exceeded per-fact length bound"
+		case rejectedLong > 0 || rejectedRefusal > 0:
+			reason = "completion contained no usable facts (too long or refusal-like)"
+		default:
+			reason = "completion contained no usable facts"
+		}
+		return nil, reason
+	}
+	return facts, ""
+}


### PR DESCRIPTION
Closes #73.

The consolidator asked the model for "factual one-line statements", then wrapped the **entire raw completion** as a single 0.6-confidence fact and persisted it to `MEMORY.md` — a file loaded into every subsequent turn's context. A refusal, meta-commentary, a hallucination or a wall of prose all became permanent memory. It runs every 10 minutes in service mode.

## Changes

- New `internal/learning/validate.go`: `extractValidFacts` applies a deterministic gate — per-fact length bound (300 chars), rejection of empty/whitespace, rejection of refusal and meta-commentary phrasing, list-marker stripping, total bound via the existing `maxFacts`.
- `saveSummary` now stores **one fact per validated line** rather than the whole completion as one blob, which is what the prompt actually asks for. A completion yielding no valid facts is logged and discarded, leaving `MEMORY.md` untouched.
- Dropped the dead `json.Unmarshal` branch. The prompt never requested JSON, so it never fired in production; keeping it implied a contract that was never exercised.

Every check is deterministic. No LLM-as-judge — a nondeterministic CI gate is worse than no gate.

## Validation

Tests written first and watched failing, with the old code persisting exactly what the issue described:

```
--- FAIL: TestEval_RunOnce_RefusalRejected
    got="...## system\n- [2026-07-25] I don't have enough context to extract facts from this conversation. (confidence: 0.6)"
--- FAIL: TestEval_RunOnce_WhitespaceOnlyRejected
    got="...## system\n- [2026-07-25]    \n\t  \n    (confidence: 0.6)"
--- FAIL: TestEval_RunOnce_LongBlobRejected
    got len=4096
```

Mutation check — guard replaced with `validFacts := []string{summary}`:

```
--- FAIL: TestEval_RunOnce_ValidOneLinersStored
--- FAIL: TestEval_RunOnce_RefusalRejected
--- FAIL: TestEval_RunOnce_WhitespaceOnlyRejected
--- FAIL: TestEval_RunOnce_LongBlobRejected
--- FAIL: TestSaveSummary_EmptyStringRejected
--- PASS: TestConsolidator_RunOnce
```

`TestConsolidator_RunOnce` passing unchanged is the point: it asserts only that memory is non-empty, which is the gap the issue identified.

`gofmt`/`vet` clean, `go test -race ./...` passes.

## Honest limits

Validated entirely through a scripted provider — not against a live LLM. `refusalPatterns` is a fixed phrase list and will not catch every possible refusal phrasing; expect to extend it as real provider output is observed. The length and emptiness bounds are unconditional and catch the unbounded-blob case regardless of wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)