### PR TITLE
fix: reject a degenerate summary instead of returning an empty context

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -508,7 +508,7 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 		}
 
 		// Proactive context compaction: check if we need to compact after tool execution
-		messages = a.checkAndCompactContext(messages, sess)
+		messages = a.checkAndCompactContext(ctx, messages, sess)
 	}
 
 	// Hit max iterations
@@ -570,7 +570,7 @@ func (a *Agent) afterReActDetection(finalOutput string, toolRecords []skills.Too
 
 // checkAndCompactContext estimates current message tokens and compacts context if threshold is exceeded.
 // It returns the original messages if under threshold, or compacted messages otherwise.
-func (a *Agent) checkAndCompactContext(messages []providers.Message, sess *session.Session) []providers.Message {
+func (a *Agent) checkAndCompactContext(ctx context.Context, messages []providers.Message, sess *session.Session) []providers.Message {
 	// Only proceed if we have budget manager and compressor
 	if a.budget == nil || a.compressor == nil {
 		return messages
@@ -609,7 +609,7 @@ func (a *Agent) checkAndCompactContext(messages []providers.Message, sess *sessi
 
 	// Get session messages for compression (excluding system prompt)
 	sessionMsgs := messages[1:] // Skip system message
-	compressed, err := a.compressor.CompressMessages(model, sessionMsgs, thresholdBudget)
+	compressed, err := a.compressor.CompressMessages(ctx, model, sessionMsgs, thresholdBudget)
 	if err != nil {
 		a.logger.Warn("Context compaction failed", "error", err)
 		return messages

--- a/internal/context/compression_summary_test.go
+++ b/internal/context/compression_summary_test.go
@@ -1,0 +1,210 @@
+package contextpkg
+
+// This file targets GitHub issue #74: CompressMessages returned a provider's
+// summary verbatim once a conversation exceeded 50 messages, without checking
+// that the summary had any content. A choice with empty (or whitespace-only,
+// or implausibly short) Content made the function return ("", nil) — an empty
+// compressed context, no error — and skipped the deterministic
+// newest-backwards fallback below it because the early return had already
+// fired.
+//
+// Following the scripted-provider convention from
+// internal/agent/evalharness_test.go: no network, no API key, no clock
+// dependence. scriptedProvider below replays a single configured response (or
+// error) and records the context.Context it was called with, which is what
+// lets TestCompressMessages_ManyMessages_ContextPropagates prove the
+// caller-supplied context.Context reaches the provider instead of an
+// internal context.Background().
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bigknoxy/joshbot/internal/providers"
+)
+
+// scriptedProvider is a minimal providers.Provider that returns a fixed
+// response or error and records the context.Context it was invoked with.
+type scriptedProvider struct {
+	resp        string
+	err         error
+	capturedCtx context.Context
+	calls       int
+}
+
+func (s *scriptedProvider) Chat(ctx context.Context, req providers.ChatRequest) (*providers.ChatResponse, error) {
+	s.calls++
+	s.capturedCtx = ctx
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &providers.ChatResponse{
+		Choices: []providers.Choice{{Message: providers.Message{Content: s.resp}}},
+	}, nil
+}
+
+func (s *scriptedProvider) ChatStream(ctx context.Context, req providers.ChatRequest) (<-chan providers.StreamChunk, error) {
+	return nil, nil
+}
+
+func (s *scriptedProvider) Transcribe(ctx context.Context, audioData []byte, prompt string) (string, error) {
+	return "", nil
+}
+
+func (s *scriptedProvider) Name() string             { return "scripted" }
+func (s *scriptedProvider) Config() providers.Config { return providers.DefaultConfig() }
+
+// manyMessages returns n distinct, non-empty messages so a real deterministic
+// join is always possible as a fallback. The content includes the message's
+// index so tests can assert the fallback actually contains real conversation
+// content rather than just being "non-empty".
+func manyMessages(n int) []providers.Message {
+	msgs := make([]providers.Message, 0, n)
+	for i := 0; i < n; i++ {
+		msgs = append(msgs, providers.Message{
+			Role:    providers.RoleUser,
+			Content: fmt.Sprintf("message number %d with enough content to be joined", i),
+		})
+	}
+	return msgs
+}
+
+// marker key used to prove a caller-supplied context.Context value reaches
+// the provider call, rather than the function substituting its own
+// context.Background().
+type ctxMarkerKey struct{}
+
+func TestCompressMessages_ManyMessages_NormalSummaryReturned(t *testing.T) {
+	msgs := manyMessages(60)
+	mock := &scriptedProvider{resp: "The user and assistant discussed the project roadmap and agreed on next steps."}
+	c := &Compressor{Provider: mock}
+
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == "" {
+		t.Fatalf("CompressMessages returned (\"\", nil) for a normal, non-degenerate summary")
+	}
+	if out != mock.resp {
+		t.Fatalf("expected the provider's plausible summary verbatim, got %q", out)
+	}
+}
+
+func TestCompressMessages_ManyMessages_EmptyChoiceFallsThrough(t *testing.T) {
+	msgs := manyMessages(60)
+	mock := &scriptedProvider{resp: ""} // len(resp.Choices) > 0 but Content is empty
+	c := &Compressor{Provider: mock}
+
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == "" {
+		t.Fatalf("regression of issue #74: CompressMessages returned (\"\", nil) for a choice with empty Content")
+	}
+	if !strings.Contains(out, "message number 59") {
+		t.Fatalf("expected the deterministic newest-backwards fallback (containing the newest message), got %q", out)
+	}
+}
+
+func TestCompressMessages_ManyMessages_WhitespaceOnlyChoiceFallsThrough(t *testing.T) {
+	msgs := manyMessages(60)
+	mock := &scriptedProvider{resp: "   \n\t  \n  "} // non-empty string, but no real content
+	c := &Compressor{Provider: mock}
+
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatalf("CompressMessages returned a whitespace-only compressed context")
+	}
+	if !strings.Contains(out, "message number 59") {
+		t.Fatalf("expected the deterministic newest-backwards fallback, got %q", out)
+	}
+}
+
+func TestCompressMessages_ManyMessages_ImplausiblyShortSummaryFallsThrough(t *testing.T) {
+	msgs := manyMessages(60)
+	mock := &scriptedProvider{resp: "ok"} // non-empty, non-whitespace, but not a plausible summary of 60 messages
+	c := &Compressor{Provider: mock}
+
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == "" {
+		t.Fatalf("CompressMessages returned (\"\", nil) for an implausibly short summary")
+	}
+	if out == mock.resp {
+		t.Fatalf("expected the implausibly short summary %q to be rejected in favor of the deterministic fallback, got it back verbatim", mock.resp)
+	}
+	if !strings.Contains(out, "message number 59") {
+		t.Fatalf("expected the deterministic newest-backwards fallback, got %q", out)
+	}
+}
+
+func TestCompressMessages_ManyMessages_ProviderErrorFallsThrough(t *testing.T) {
+	msgs := manyMessages(60)
+	mock := &scriptedProvider{err: errors.New("upstream 500")}
+	c := &Compressor{Provider: mock}
+
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == "" {
+		t.Fatalf("CompressMessages returned (\"\", nil) after a provider error")
+	}
+	if !strings.Contains(out, "message number 59") {
+		t.Fatalf("expected the deterministic newest-backwards fallback, got %q", out)
+	}
+}
+
+func TestCompressMessages_ManyMessages_ContextPropagates(t *testing.T) {
+	msgs := manyMessages(60)
+	mock := &scriptedProvider{resp: "A sufficiently long and plausible summary of the conversation history."}
+	c := &Compressor{Provider: mock}
+
+	ctx := context.WithValue(context.Background(), ctxMarkerKey{}, "issue-74")
+	_, err := c.CompressMessages(ctx, "test-model", msgs, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.calls == 0 {
+		t.Fatalf("expected the provider to be called")
+	}
+	if mock.capturedCtx == nil || mock.capturedCtx.Value(ctxMarkerKey{}) != "issue-74" {
+		t.Fatalf("expected the caller-supplied context to reach Provider.Chat, got %v", mock.capturedCtx)
+	}
+}
+
+func TestCompressMessages_ManyMessages_CanceledContextFallsThrough(t *testing.T) {
+	msgs := manyMessages(60)
+	mock := &scriptedProvider{resp: "should never be used because the context is already canceled before the call"}
+	c := &Compressor{Provider: mock}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if mock.capturedCtx != nil {
+		t.Fatalf("sanity check failed: provider called before CompressMessages ran")
+	}
+	out, err := c.CompressMessages(ctx, "test-model", msgs, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.capturedCtx == nil {
+		t.Fatalf("expected the provider to still be invoked with the canceled context (propagation is the caller's responsibility to check, not CompressMessages' to skip)")
+	}
+	if mock.capturedCtx.Err() == nil {
+		t.Fatalf("expected the provider to observe a canceled context")
+	}
+	if out == "" {
+		t.Fatalf("expected a non-empty result even when the propagated context is canceled")
+	}
+}

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -137,10 +137,26 @@ func lastNonEmptyContent(messages []providers.Message, maxChars int) (string, bo
 	return "", false
 }
 
+// minPlausibleSummaryChars is the floor below which a provider-generated
+// summary is treated as degenerate — an empty completion, a refusal stub,
+// a truncated stream — rather than a genuine summary of 50+ messages of
+// conversation, and is therefore rejected in favor of the deterministic
+// fallback. This is a length heuristic only; it is deliberately not an
+// LLM-as-judge check.
+const minPlausibleSummaryChars = 15
+
+// isPlausibleSummary reports whether s, once surrounding whitespace is
+// trimmed, is non-empty and at least minChars long.
+func isPlausibleSummary(s string, minChars int) bool {
+	return len(strings.TrimSpace(s)) >= minChars
+}
+
 // CompressMessages returns a compacted string representation of messages limited by token budget.
 // It naively keeps the most recent messages until the token budget is met; if exceeded and a Provider
-// is available, it will ask the provider to summarize them.
-func (c *Compressor) CompressMessages(model string, messages []providers.Message, budget int) (string, error) {
+// is available, it will ask the provider to summarize them. ctx governs the provider call(s) and is
+// the caller's responsibility to cancel/time out; CompressMessages does not create its own background
+// context for provider requests.
+func (c *Compressor) CompressMessages(ctx context.Context, model string, messages []providers.Message, budget int) (string, error) {
 	if len(messages) == 0 {
 		return "", fmt.Errorf("no messages to compress")
 	}
@@ -173,10 +189,14 @@ func (c *Compressor) CompressMessages(model string, messages []providers.Message
 			},
 			MaxTokens: 200,
 		}
-		resp, err := c.Provider.Chat(context.Background(), req)
-		if err == nil && len(resp.Choices) > 0 {
+		resp, err := c.Provider.Chat(ctx, req)
+		if err == nil && len(resp.Choices) > 0 && isPlausibleSummary(resp.Choices[0].Message.Content, minPlausibleSummaryChars) {
 			return resp.Choices[0].Message.Content, nil
 		}
+		// A missing/empty/whitespace-only/implausibly-short summary (refusal,
+		// truncated stream, provider error) is a failed compression: fall
+		// through to the deterministic newest-backwards join below instead of
+		// returning an empty compressed context with a nil error.
 	}
 	// join messages from newest backwards until budget
 	var parts []string
@@ -213,8 +233,8 @@ func (c *Compressor) CompressMessages(model string, messages []providers.Message
 			},
 			MaxTokens: 200,
 		}
-		resp, err := c.Provider.Chat(context.Background(), req)
-		if err == nil && len(resp.Choices) > 0 && resp.Choices[0].Message.Content != "" {
+		resp, err := c.Provider.Chat(ctx, req)
+		if err == nil && len(resp.Choices) > 0 && isPlausibleSummary(resp.Choices[0].Message.Content, 1) {
 			return resp.Choices[0].Message.Content, nil
 		}
 	}

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -31,7 +31,7 @@ func TestCompressMessages_NoProvider_UnderBudget(t *testing.T) {
 	}
 	c := &Compressor{Provider: nil}
 	// generous budget
-	out, err := c.CompressMessages("test-model", msgs, 1000)
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 1000)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestCompressMessages_WithProvider_ExceedsBudget(t *testing.T) {
 	}
 	mock := &mockProv{resp: "SUMMARY"}
 	c := &Compressor{Provider: mock}
-	out, err := c.CompressMessages("test-model", msgs, 10) // tiny budget forces summarization
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 10) // tiny budget forces summarization
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestCompressMessages_SingleMessageExceedsBudget(t *testing.T) {
 	}
 	c := &Compressor{Provider: nil}
 	// tiny budget that the single message exceeds
-	out, err := c.CompressMessages("test-model", msgs, 50)
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 50)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestCompressMessages_ProviderReturnsEmpty(t *testing.T) {
 	}
 	mock := &mockProv{resp: ""}
 	c := &Compressor{Provider: mock}
-	out, err := c.CompressMessages("test-model", msgs, 10)
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestCompressMessages_AllEmptyContent(t *testing.T) {
 		{Role: providers.RoleAssistant, Content: ""},
 	}
 	c := &Compressor{Provider: nil}
-	out, err := c.CompressMessages("test-model", msgs, 100)
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 100)
 	if err == nil {
 		t.Fatalf("expected error for all-empty messages, got nil, out=%q", out)
 	}
@@ -111,7 +111,7 @@ func TestCompressMessages_ToolResultTriggersCompaction(t *testing.T) {
 		{Role: providers.RoleAssistant, Content: "The Royals won 5-3."},
 	}
 	c := &Compressor{Provider: nil}
-	out, err := c.CompressMessages("test-model", msgs, 10)
+	out, err := c.CompressMessages(context.Background(), "test-model", msgs, 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Closes #74.

Past 50 messages, `CompressMessages` replaced the conversation with a provider summary and returned it verbatim. The guard checked `len(resp.Choices) > 0` but never the content — so a choice with empty `Content` returned **`("", nil)`**: an empty compressed context, no error, and the deterministic fallback skipped because the early return had already fired. The assistant would forget everything before the compression point and carry on.

Same shape as the tool-linkage bug fixed in v1.35.1 — long conversations break while short ones stay green.

## Changes

- `isPlausibleSummary` gates both provider-summary return paths; a degenerate summary falls through to the deterministic newest-backwards join.
- `CompressMessages` now takes a `context.Context` instead of calling `context.Background()`, so cancellation propagates. One exported signature, one production call site (`Agent.checkAndCompactContext`), threaded from the `ctx` already in `reactLoop`.

## Validation

Tests written first; pre-fix they failed to compile against the old signature, which is the correct signal since neither the ctx parameter nor the content check existed:

```
internal/context/compression_summary_test.go:85:75: too many arguments in call to c.CompressMessages
	have (context.Context, string, []providers.Message, number)
	want (string, []providers.Message, int)
```

Mutation check — content guard reverted, ctx threading left intact:

```
--- FAIL: TestCompressMessages_ManyMessages_EmptyChoiceFallsThrough
    regression of issue #74: CompressMessages returned ("", nil) for a choice with empty Content
--- FAIL: TestCompressMessages_ManyMessages_WhitespaceOnlyChoiceFallsThrough
--- FAIL: TestCompressMessages_ManyMessages_ImplausiblyShortSummaryFallsThrough
```

`gofmt`/`vet` clean, `go test -race ./...` passes. `internal/context` coverage 54.5% → 65.2%.

## Judgement call to review

The 15-character plausibility floor on the 50+-message path is a heuristic, not a correctness property. It rejects "ok" as a summary of fifty messages, which is right in spirit, but it is a guess at where the line sits. The empty and whitespace-only cases are unambiguous; that floor is the part worth arguing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)