### PR TITLE
docs: bring all documentation back in sync with the code

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,10 +14,22 @@
 ## Checklist
 
 - [ ] Tests added/updated
-- [ ] Documentation updated
 - [ ] `go vet` passes
 - [ ] `gofmt` passes
 - [ ] Tests pass
+
+## Documentation
+
+Docs ship with the change — this PR, not a follow-up. Tick what this change touches,
+or tick the last box and say why.
+
+- [ ] `README.md` / `docs/INSTALL.md` — commands, flags, config keys, examples
+- [ ] `site/index.html` / `site/architecture.html` — capabilities, architecture, counts
+- [ ] `SECURITY.md` — the security model matches what is enforced
+- [ ] `CLAUDE.md` / `AGENTS.md` — gotchas that would surprise an agent
+- [ ] `skills/*/SKILL.md` — bundled skills match what the tools now permit
+- [ ] `CHANGELOG.md` — entry under `[Unreleased]`
+- [ ] Nothing observable changed, so no docs needed — because: ______
 
 ## Related Issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,26 @@ Two pages live in `site/`:
 
 The header nav on both pages must be kept in sync (same links, same active state logic).
 
+## HARD RULE: documentation ships with the change
+
+**A change that alters observable behaviour updates the docs in the same PR.** Not a
+follow-up, not an issue. A change is not done until the docs match. See the table in
+`CLAUDE.md` for which file covers what.
+
+Non-negotiable parts:
+
+- **Verify before writing.** Read the source — or run the command — for every documented
+  command, flag, config key or behaviour. Config keys must match the `json:`/`mapstructure:`
+  struct tags exactly.
+- **No unverifiable numbers.** LOC, test counts, tool counts, binary sizes: measure them
+  when you write them, or leave them out. A stale number reads as authoritative.
+- **Removing a stale claim matters as much as adding a true one.** Drift runs both ways.
+- **`site/index.html` and `site/architecture.html` are in scope.** They drift fastest
+  because nothing fails when they are wrong.
+
+This rule exists because the softer version did not work: `CLAUDE.md` already said the
+site MUST stay in sync while the site sat eight releases out of date.
+
 ## Pre-Release Checklist
 
 ```bash
@@ -449,6 +469,16 @@ go test -race ./...
 ./joshbot agent -m "hello"    # Verify response
 ./joshbot status               # Verify config
 ```
+
+Documentation gate — a release does not go out with any of these unchecked:
+
+- [ ] `README.md`, `docs/INSTALL.md` — commands, flags, config keys, examples current
+- [ ] `site/index.html`, `site/architecture.html` — capabilities, architecture, counts
+- [ ] `SECURITY.md` — matches what is actually enforced
+- [ ] `CLAUDE.md`, `AGENTS.md` — gotchas cover anything that would surprise an agent
+- [ ] `skills/*/SKILL.md` — no instruction the tools no longer permit
+- [ ] `CHANGELOG.md` — entry under `[Unreleased]`
+- [ ] Every quoted count or size re-measured, not carried over
 
 ## Release Process
 1. Push changes to main first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # joshbot — Architect's Guide
 
-joshbot is a self-hosted Go personal AI assistant (~19.6K LOC non-test, ~850 test functions across 55 files). Single binary, zero runtime deps.
+joshbot is a self-hosted Go personal AI assistant (~22.1K LOC non-test, 985 test functions across 73 files). Single binary, zero runtime deps.
 
 **`AGENTS.md` (repo root) is the full agent guide** — key interfaces, code style, naming, concurrency and logging patterns, complete gotchas list. Read it before non-trivial work. This file is the quick index.
 
@@ -10,13 +10,13 @@ joshbot is a self-hosted Go personal AI assistant (~19.6K LOC non-test, ~850 tes
 - **~17MB binary**, ~30ms startup
 - **Architecture**: goroutine message bus → ReAct agent loop → multi-provider LLM
 - **Channels**: CLI (readline) + Telegram (long-polling, telebot)
-- **Providers**: openrouter, openai, nvidia, groq, ollama, anthropic, poolside, azure, custom, litellm
+- **Providers**: openrouter, openai, nvidia, groq, ollama, anthropic, poolside, azure, custom, litellm, github-copilot (device-flow auth via `joshbot auth github-copilot`)
 - **Config**: `~/.joshbot/config.json`, env vars with `JOSHBOT_` prefix, two formats (legacy + model-centric)
 - **Memory**: MEMORY.md (always in context) + HISTORY.md (appended event log) + fact extraction + consolidation
 - **Skills**: SKILL.md files with YAML frontmatter, auto-discovered from workspace, progressive loading
 - **Tools**: filesystem, shell (deny-listed), web (exa-cli/DuckDuckGo/MCP), message, skill_registry, memory_search
 - **Sessions**: JSONL files at `~/.joshbot/sessions/`, keyed `channel:senderID`
-- **Cron**: Scheduled jobs via cron.yml in workspace
+- **Cron**: Jobs persisted as JSON at `workspace/cron/jobs.json` (see `internal/cron`); no agent-facing tool currently adds/lists/deletes jobs — see gotchas
 - **Heartbeat**: Unchecked task scanner via HEARTBEAT.md
 
 ## Commands
@@ -36,8 +36,10 @@ go vet ./... && gofmt -l .                   # CI gates on both
 
 `cmd/joshbot` entrypoint. Under `internal/`: `agent` (ReAct loop), `bus` (message bus),
 `channels` (cli.go, telegram.go), `providers` (registry.go = provider routing keys),
-`tools`, `memory`, `skills`, `session`, `context`, `config`, `cron`, `heartbeat`,
-`subagent`, `service` (build-tagged per-OS), `learning`, `integration`.
+`copilot` (github-copilot device-flow auth + provider), `tools`, `memory`, `skills`
+(+ `skills/trust.go` = workspace-skill approval store), `session`, `context`, `config`,
+`configure`, `cron`, `heartbeat`, `subagent`, `service` (build-tagged per-OS), `learning`,
+`integration`, `log`.
 
 ## Panel review
 
@@ -56,6 +58,9 @@ experience, growth, Go systems) that debates and scores a change. Charters are i
 - Session key is computed from `Channel:SenderID` — there is no `SessionKey` field.
 - `internal/service/` is build-tagged (`factory_linux.go` / `factory_darwin.go` / `factory_other.go`) — all must export the same signature.
 - Telegram hard-fails over 4096 chars; `Send` splits longer content via `splitMessage` (code-fence aware, byte-indexed).
+- Shell commands run with an allowlisted environment (`internal/tools/shell_env.go`), not the full parent env — no provider API keys, and anything credential-shaped by name (TOKEN, SECRET, API_KEY, etc.) is stripped even if otherwise allowlisted. A workflow relying on `GH_TOKEN`/`GITHUB_TOKEN` as an env var will not see it; use `gh auth login`'s on-disk config instead.
+- `tools.shell_sandbox` (`"off"` default, `"workspace"`) applies Landlock filesystem containment on Linux via a re-exec helper; `tools.shell_sandbox_allow_network` (off by default) gates outbound TCP when sandboxed.
+- Workspace skills (anything under `workspace/skills/`, as opposed to the bundled `skills/` dir) are inert until an operator runs `joshbot skills trust <name>`; trust is bound to a content hash in `~/.joshbot/skills.trust`, so editing a trusted skill revokes it. `Loader.Create` (used by the skill_registry tool) writes but never approves. A workspace skill that reuses a bundled skill's name replaces it in the registry and is withheld until trusted — it does not silently "take over" the bundled behavior.
 
 ## Website (site/)
 
@@ -64,6 +69,39 @@ Two pages in `site/`:
 - `architecture.html` — Official architecture docs + diagrams
 
 **Both MUST stay in sync with the codebase.** Update when major features, architecture, config, or capabilities change.
+
+## HARD RULE: documentation ships with the change
+
+**Every change that alters observable behaviour updates the docs in the same PR.** Not
+a follow-up, not an issue — the same PR. A change is not done until the docs match.
+
+This applies to `*.md` and `*.html` alike:
+
+| If you change | Update |
+|---|---|
+| A CLI command, flag or its output | `README.md`, `docs/INSTALL.md` |
+| A config key, default or its semantics | `README.md`, `docs/INSTALL.md`, `site/architecture.html` |
+| A security boundary or its limits | `SECURITY.md`, `AGENTS.md` gotchas |
+| Architecture, packages, data flow | `site/architecture.html`, `CLAUDE.md` layout |
+| A capability users would notice | `README.md`, `site/index.html`, `CHANGELOG.md` |
+| A behaviour that would trip up an agent | `AGENTS.md` gotchas, `CLAUDE.md` gotchas |
+| Anything in `internal/tools/` the agent calls | the relevant `skills/*/SKILL.md` |
+
+Rules that make this stick:
+
+- **Verify, do not assume.** Every documented command, flag, config key and code path
+  gets read in the source — or run — before you write it down. Config keys must match
+  the `json:`/`mapstructure:` struct tags exactly.
+- **No unverifiable numbers.** LOC, test counts, tool counts and binary sizes must be
+  measured at the time of writing or removed. A stale number is worse than none: it
+  reads as authoritative.
+- **Stale claims count as bugs.** Deleting a claim that is no longer true is as
+  important as adding one that is. Drift runs both ways.
+- **`site/*.html` is not optional.** It is the public face and it drifts fastest,
+  because nothing fails when it is wrong.
+
+Prose alone has already failed once: this file said the site MUST stay in sync while
+the site sat eight releases out of date. Treat the checklist below as the gate.
 
 ## Pre-release checklist
 
@@ -74,6 +112,18 @@ gofmt -d .          # MUST be empty
 go test -race ./... # MUST pass
 # CI also fails if total coverage drops below 45%
 ```
+
+Then, before tagging — no code change ships without this:
+
+- [ ] `README.md` — commands, flags, config keys and examples match the code
+- [ ] `docs/INSTALL.md` — install path, first-run flow and command list are current
+- [ ] `site/index.html` / `site/architecture.html` — capabilities, architecture, counts
+- [ ] `SECURITY.md` — the security model matches what is actually enforced
+- [ ] `CLAUDE.md` / `AGENTS.md` — gotchas cover anything that would surprise an agent
+- [ ] `skills/*/SKILL.md` — bundled skills do not instruct the agent to do something
+      the tools no longer permit
+- [ ] `CHANGELOG.md` — an entry exists under `[Unreleased]`
+- [ ] Any count or size quoted anywhere was re-measured, not carried over
 
 ## PR & release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,10 +149,12 @@ joshbot/
 │   ├── bus/               # Internal message bus
 │   ├── channels/          # Chat channels (CLI, Telegram)
 │   ├── config/            # Configuration loading
+│   ├── configure/         # `joshbot configure` wizard and provider setup
 │   ├── context/           # LLM context and system prompt
 │   ├── copilot/           # GitHub Copilot integration
 │   ├── cron/              # Scheduled task runner
 │   ├── heartbeat/         # Proactive task system
+│   ├── integration/       # Cross-package integration tests
 │   ├── learning/          # Self-learning memory
 │   ├── log/               # Structured logging
 │   ├── memory/            # MEMORY.md + HISTORY.md management
@@ -161,13 +163,13 @@ joshbot/
 │   ├── session/           # Session management
 │   ├── skills/            # Skill discovery and loading
 │   ├── subagent/          # Subagent delegation
-│   └── tools/             # Tool system and implementations
-├── pkg/
+│   └── tools/             # Tool system and implementations (incl. shell sandbox, env allowlisting)
+├── pkg/                   # Stale, incomplete refactor — internal/ is the source of truth, do not edit
 │   ├── bus/               # Public message bus types
 │   └── channels/          # Public channel types
 ├── docs/                  # Documentation
-├── workspace/             # User data (skills, memory)
-└── tasks/                 # Task tracking
+├── skills/                # Bundled skill sources (memory, cron, github, skill-creator)
+└── tasks/                 # Task tracking notes
 ```
 
 For more details on architecture and component interactions, see [AGENTS.md](./AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ go build -o joshbot ./cmd/joshbot
 
 ```bash
 docker build -t joshbot .
-docker run -it -v ~/.joshbot:/root/.joshbot joshbot onboard
+docker run -it -v ~/.joshbot:/home/joshbot/.joshbot joshbot onboard
 ```
 
 ## Usage
@@ -77,6 +77,12 @@ joshbot agent --debug # CLI chat with debug logging
 joshbot gateway # Start all channels (Telegram, etc.)
 joshbot gateway --debug # Gateway with debug logging
 joshbot status # Show configuration and status
+joshbot skills list # Review workspace skills and approval state
+joshbot skills trust <name> # Approve a workspace skill after reviewing it
+joshbot configure # Configure LLM providers and settings
+joshbot auth github-copilot # Authenticate with GitHub Copilot
+joshbot service install # Install joshbot as a system service
+joshbot update # Update to the latest release
 joshbot uninstall # Remove joshbot binary and config
 ```
 
@@ -150,6 +156,17 @@ Skills are markdown files that extend joshbot's capabilities without code change
 ### Creating Custom Skills
 
 joshbot can create its own skills! Ask it to learn something, and it will create `~/.joshbot/workspace/skills/{name}/SKILL.md` with YAML frontmatter.
+
+A workspace skill becomes part of the agent's standing instructions, so it is **inert until an operator approves it** — including skills the agent creates for itself. Approval is bound to the file's SHA-256, so editing an approved skill revokes it until it's approved again. Bundled skills (the ones listed above) are exempt.
+
+```bash
+joshbot skills list          # See what's pending
+joshbot skills trust <name>  # Approve after reviewing the file
+joshbot skills trust --all   # Approve every pending skill
+joshbot skills untrust <name> # Revoke approval
+```
+
+`joshbot status` also flags any skills awaiting review.
 
 Skills use **progressive loading**:
 - **Level 1:** Name + description always in context (~100 tokens)
@@ -294,10 +311,21 @@ For backward compatibility, the old format still works:
     "exec": { "timeout": 60 },
     "restrict_to_workspace": true,
     "shell_allow_list": [],
-    "filesystem_allowed_paths": []
+    "filesystem_allowed_paths": [],
+    "shell_sandbox": "off",
+    "shell_sandbox_allow_network": false
   }
 }
 ```
+
+### Shell Sandbox
+
+`tools.shell_sandbox` adds OS-level containment for shell commands, on top of the deny list (which screens command text — a filter, not a boundary). It's off by default so upgrading doesn't silently change what an existing setup can do.
+
+- `"off"` (default) — no containment beyond the deny list.
+- `"workspace"` — confines the filesystem to the workspace plus toolchain build caches (e.g. `GOCACHE`, `~/.cache`); `$HOME` and everything else outside that is unreachable. Outbound TCP is denied unless `tools.shell_sandbox_allow_network` is `true`.
+
+Implemented via [Landlock](https://landlock.io/) and **Linux-only**. It fails closed: an unrecognized value, running on a non-Linux OS, or a kernel without Landlock support is a startup error rather than a silent no-op — set it back to `"off"` if you need to run without containment.
 
 ### Environment Variables
 
@@ -414,27 +442,35 @@ After auth, you can run `joshbot agent` or `joshbot gateway` normally.
 | `write_file` | Write/create files |
 | `edit_file` | Find-and-replace editing |
 | `list_dir` | List directory contents |
-| `shell` | Execute shell commands (with safety guards) |
-| `web_search` | Search the web (requires Brave API key) |
+| `glob` | Find files by pattern |
+| `grep` | Search file contents |
+| `shell` | Execute shell commands (deny-listed, allowlisted env, optional Linux sandbox) |
+| `web_search` | Search the web (exa-cli / Exa MCP / DuckDuckGo — no key required) |
 | `web_fetch` | Fetch and extract web page content |
-| `message` | Send messages to channels |
-| `spawn` | Create background tasks |
-| `cron` | Schedule reminders/tasks |
+| `message` | Send messages to other channels |
 | `memory_search` | Search stored facts by keyword, category, or tags |
-| `skill_registry` | List, create, and delete skills |
+| `skill_registry` | List, create, and delete skills (workspace skills need `joshbot skills trust` before use) |
+| `parallel_subagent` | Run multiple subagent tasks in parallel |
+| `chain_execution` | Run subagent steps sequentially, feeding output forward |
 
 **Security defaults:**
-- `web_fetch` blocks localhost, private IP ranges, and metadata hosts (SSRF protection).
+- `web_fetch` and `web_search` block localhost, private IP ranges, and metadata hosts (SSRF protection), enforced at dial time.
 - `restrict_to_workspace` limits file and shell operations to the workspace unless explicitly allowed.
+- Shell commands get an allowlisted environment, not joshbot's own — provider API keys and other secret-shaped variables are never inherited.
+- `tools.shell_sandbox: "workspace"` additionally confines shell commands with an OS-level sandbox (Landlock, Linux only) — see [Shell Sandbox](#shell-sandbox) below.
 
 ## Chat Commands
 
-| Command | Description |
-|---------|-------------|
-| `/start` | Start a conversation |
-| `/new` | Start fresh (saves memory first) |
-| `/help` | Show available commands |
-| `/status` | Show system status |
+| Command | Channel | Description |
+|---------|---------|-------------|
+| `/start` | Telegram | Start a conversation (shows the help text) |
+| `/new` | Both | Start a new session (clears context) |
+| `/help` | Both | Show available commands |
+| `/clear` | CLI | Clear the terminal screen |
+| `/history` | CLI | Show input history |
+| `/quit`, `/exit` | CLI | Exit the program |
+
+There is no `/status` chat command — use `joshbot status` from the shell instead.
 
 ## Architecture
 
@@ -451,8 +487,8 @@ joshbot/
 │   ├── providers/   # LLM provider layer
 │   ├── session/     # Conversation persistence (JSONL)
 │   ├── cron/        # Task scheduling
-│   └── heartbeat/   # Proactive wake-ups
-└── config/          # Configuration
+│   ├── heartbeat/   # Proactive wake-ups
+│   └── config/      # Configuration loading
 ```
 
 **Key patterns:**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,20 +45,26 @@ Please include the following information in your report:
 
 When running joshbot:
 
-- **API Keys**: Never commit API keys or tokens to version control. Use environment variables or the config file with restricted permissions (`~/.joshbot/config.json` should be `0600`)
-- **Shell Tool**: The shell tool executes commands with the same permissions as the joshbot process. Run joshbot with the minimum required privileges
+- **API Keys**: Never commit API keys or tokens to version control. Use environment variables or the config file — `~/.joshbot/config.json` is written `0600` automatically
+- **Shell Tool**: The shell tool executes commands with the same permissions as the joshbot process by default. Run joshbot with the minimum required privileges, and consider enabling `tools.shell_sandbox` (see below) for real containment
 - **Telegram Bot Token**: Keep your Telegram bot token secure. If compromised, regenerate it via @BotFather immediately
 - **Memory Files**: `MEMORY.md` and `HISTORY.md` may contain sensitive information. Ensure `~/.joshbot/` directory permissions are restrictive
+- **Workspace Skills**: A `SKILL.md` becomes part of the agent's standing instructions, so treat one you didn't write yourself as untrusted input until you've read it and run `joshbot skills trust <name>`
 - **Updates**: Keep joshbot updated to the latest version to receive security patches
 
 ### Security Architecture
 
 - **No secret logging**: API keys and tokens are never written to logs
-- **File permissions**: Auth files are created with `0600` permissions
+- **File permissions**: Config (`config.json`), auth tokens, and the skills trust store are all written `0600`
 - **Input validation**: All tool inputs are validated before execution
-- **Sandbox awareness**: joshbot runs with the same permissions as the user — it does not implement its own sandbox
+- **Command screening is defence in depth, not a boundary**: the shell tool's deny list closes known-dangerous command shapes, but no deny list can be sound against an adversarial model or a prompt-injected instruction. The only hard boundary is the OS-level sandbox below.
+- **Shell sandbox (opt-in, Linux only)**: setting `tools.shell_sandbox: "workspace"` confines shell commands via Landlock — filesystem access limited to the workspace and toolchain caches, outbound TCP denied unless `tools.shell_sandbox_allow_network` is `true`. It's off by default (existing behavior is unchanged unless you opt in), and it fails closed: an unrecognized value, a non-Linux host, or a kernel without Landlock support is a startup error rather than a silent no-op.
+- **Environment isolation**: shell commands no longer inherit joshbot's own process environment. They receive an allowlisted subset (PATH, common toolchain variables) with anything credential-shaped — API keys, tokens, secrets — stripped, so a spawned command cannot read joshbot's own provider credentials via `env`.
+- **Skill approval**: a `SKILL.md` found in the workspace — including one the agent creates for itself via `skill_registry` — is inert until approved via `joshbot skills trust`. Approval is bound to the file's SHA-256, so editing an approved skill revokes it. Skills bundled with the release are exempt.
 
 ### Tool-Specific Security Notes
 
+- **`shell` tool**: Screens commands against a deny list (defence in depth, not a boundary — see above) and, when `restrict_to_workspace` is set, confines the working directory. Enable `tools.shell_sandbox` for actual OS-level containment.
 - **`memory_search` tool**: Can read all stored facts, including potentially sensitive information in MEMORY.md. Access control is file-permission based — ensure `~/.joshbot/` directory permissions are restrictive.
-- **`skill_registry` tool**: Can create, list, and delete skills (SKILL.md files). Skill creation writes files under `~/.joshbot/workspace/skills/` and can introduce new instructions for the agent to follow. Treat skill changes as configuration changes — review skill content before use.
+- **`skill_registry` tool**: Can create, list, and delete skills (SKILL.md files). Skill creation writes files under `~/.joshbot/workspace/skills/`, but a newly created skill does not take effect until an operator approves it with `joshbot skills trust` — see Skill Approval above. Treat skill changes as configuration changes — review skill content before approving.
+- **`web_fetch` / `web_search` tools**: Refuse to connect to localhost, private IP ranges, and cloud metadata hosts, enforced at connection time (not just URL string matching) to resist DNS-rebinding-style bypasses.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -62,13 +62,18 @@ Before installing joshbot, ensure you have the following:
 The fastest way to install joshbot is using the binary install script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash
 ```
 
 This script will:
 1. Download the latest pre-built binary for your platform
 2. Verify the checksum
-3. Install the binary to `/usr/local/bin` (requires sudo) or `~/.local/bin`
+3. Install the binary to `~/.local/bin` (preferred) or `/usr/local/bin`
+
+For a specific version:
+```bash
+curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash -s -- -v v1.0.0
+```
 
 After installation, verify it works:
 
@@ -119,10 +124,10 @@ joshbot can run in Docker for isolated deployments:
 docker build -t joshbot .
 
 # Run first-time setup (interactive)
-docker run -it -v ~/.joshbot:/root/.joshbot joshbot onboard
+docker run -it -v ~/.joshbot:/home/joshbot/.joshbot joshbot onboard
 
 # Run gateway mode
-docker run -d -v ~/.joshbot:/root/.joshbot joshbot gateway
+docker run -d -v ~/.joshbot:/home/joshbot/.joshbot joshbot gateway
 ```
 
 #### Docker Compose
@@ -155,8 +160,8 @@ joshbot onboard
 The wizard will guide you through:
 
 1. **LLM Provider Configuration**
-   - Enter your OpenRouter API key (or skip to configure later)
-   - Get a free key at: https://openrouter.ai/keys
+   - Choose a provider — NVIDIA NIM is the recommended default (free tier), with OpenRouter, Groq, Ollama, GitHub Copilot, and Poolside also offered
+   - Enter your API key for the chosen provider (OpenRouter's free tier key: https://openrouter.ai/keys)
 
 2. **Personality Selection**
    ```
@@ -169,7 +174,7 @@ The wizard will guide you through:
    ```
 
 3. **Model Selection**
-   - Default: `openai/gpt-4` (or use `openrouter/free` for free via OpenRouter)
+   - Default depends on the provider you configured — e.g. `moonshotai/kimi-k2-thinking` for NVIDIA NIM, `openrouter/free` for OpenRouter
    - You can specify any model supported by your provider
 
 ### Onboarding Options
@@ -255,9 +260,9 @@ joshbot status
 
 ```
 ╔═══════════════════════════════════════════╗
-║            joshbot status                 ║
+║            joshbot status                ║
 ╚═══════════════════════════════════════════╝
-Version:        1.0.0
+Version:        1.39.1
 Config file:    ~/.joshbot/config.json (exists)
 Workspace:      ~/.joshbot/workspace (exists)
 Sessions:       ~/.joshbot/sessions
@@ -269,8 +274,10 @@ Memory window:  50
 
 Providers:      openrouter
 Telegram:       disabled
-Workspace restricted: disabled
+Workspace restricted: enabled
 ```
+
+If a provider is present but not registered, `status` says why — for example `nvidia (disabled — missing "api_key")` or `openrouter (disabled — set "enabled": true)`. If any workspace skills are awaiting approval, a `Skills:` line lists them.
 
 ### All Commands
 
@@ -280,7 +287,13 @@ Workspace restricted: disabled
 | `joshbot agent` | Interactive CLI chat mode |
 | `joshbot gateway` | Start all channels (Telegram, etc.) |
 | `joshbot status` | Show configuration and status |
-| `joshbot --version` | Show version |
+| `joshbot skills list` \| `trust <name>` \| `untrust <name>` | Review and approve workspace skills |
+| `joshbot configure` | Configure LLM providers and settings |
+| `joshbot auth github-copilot` \| `status` | Manage OAuth authentication |
+| `joshbot service install` \| `uninstall` \| `status` | Manage joshbot as a system service |
+| `joshbot update` | Update to the latest release |
+| `joshbot uninstall` | Remove the binary and optionally its config |
+| `joshbot version` / `joshbot --version` | Show version |
 | `joshbot --help` | Show help |
 
 ---
@@ -293,16 +306,19 @@ joshbot stores all configuration and data in `~/.joshbot/`:
 
 ```
 ~/.joshbot/
-├── config.json          # Main configuration file
+├── config.json          # Main configuration file (0600)
+├── skills.trust         # Approved workspace skills (0600)
 ├── sessions/            # Conversation history (JSONL)
 ├── media/               # Downloaded media files
-├── cron/                # Scheduled tasks
+├── cron/                # Reserved, currently unused
 └── workspace/           # Memory, skills, and context files
     ├── SOUL.md          # Personality definition
     ├── USER.md          # User profile
     ├── AGENTS.md        # Agent behavior instructions
     ├── IDENTITY.md      # Bot identity
     ├── HEARTBEAT.md     # Proactive tasks checklist
+    ├── cron/
+    │   └── jobs.json    # Scheduled reminder/cron jobs
     ├── memory/
     │   ├── MEMORY.md    # Long-term memory
     │   └── HISTORY.md   # Event log
@@ -392,7 +408,8 @@ The old format is still supported for backward compatibility:
     "openrouter": {
       "api_key": "sk-or-v1-your-key-here",
       "api_base": "",
-      "extra_headers": {}
+      "extra_headers": {},
+      "enabled": true
     }
   },
   "agents": {
@@ -420,7 +437,9 @@ The old format is still supported for backward compatibility:
     "exec": { "timeout": 60 },
     "restrict_to_workspace": true,
     "shell_allow_list": [],
-    "filesystem_allowed_paths": []
+    "filesystem_allowed_paths": [],
+    "shell_sandbox": "off",
+    "shell_sandbox_allow_network": false
   },
   "gateway": {
     "host": "0.0.0.0",
@@ -429,6 +448,8 @@ The old format is still supported for backward compatibility:
   "log_level": "info"
 }
 ```
+
+> **Important:** each provider under `providers` needs `"enabled": true` to register — omitting it silently disables that provider rather than erroring.
 
 ### Environment Variables
 
@@ -569,9 +590,29 @@ Example:
 
 > Tip: When `shell_allow_list` is non-empty, commands must match an entry exactly or use it as a prefix (e.g., `git status`).
 
+#### Shell Sandbox (Linux only, opt-in)
+
+`restrict_to_workspace` and `shell_allow_list` are text-based checks — useful, but not a hard boundary. `tools.shell_sandbox` adds real OS-level containment via [Landlock](https://landlock.io/):
+
+```json
+{
+  "tools": {
+    "shell_sandbox": "workspace",
+    "shell_sandbox_allow_network": false
+  }
+}
+```
+
+- `"off"` (default) — no containment beyond the checks above.
+- `"workspace"` — confines shell commands' filesystem access to the workspace plus toolchain build caches (e.g. `GOCACHE`, `~/.cache`); everything else, including the rest of `$HOME`, is unreachable. Outbound TCP is denied unless `shell_sandbox_allow_network` is `true`.
+
+This is Linux-only and fails closed: an unrecognized value, a non-Linux OS, or a kernel without Landlock support makes joshbot refuse to start rather than run unconfined. Set it back to `"off"` if that happens and you don't need containment.
+
+Separately, spawned shell commands no longer inherit joshbot's own environment — they get an allowlisted subset (PATH, common toolchain variables, etc.) with anything credential-shaped stripped out, so provider API keys are not exposed to commands the agent runs.
+
 #### Web Fetch SSRF Protection
 
-`web_fetch` blocks localhost, private IP ranges, and metadata hostnames (for example: `127.0.0.1`, `10.0.0.0/8`, `169.254.169.254`, and `metadata.google.internal`). If you see **"URL blocked by security policy"**, use a public URL or proxy through a safe external endpoint.
+`web_fetch` and `web_search` block localhost, private IP ranges, and metadata hostnames (for example: `127.0.0.1`, `10.0.0.0/8`, `169.254.169.254`, and `metadata.google.internal`), enforced at connection time. If you see **"URL blocked by security policy"**, use a public URL or proxy through a safe external endpoint.
 
 #### Telegram Setup
 
@@ -607,10 +648,12 @@ workspace/
 ├── AGENTS.md            # Instructions for the agent
 ├── IDENTITY.md          # Bot's self-concept
 ├── HEARTBEAT.md         # Proactive task checklist
+├── cron/
+│   └── jobs.json        # Scheduled reminder/cron jobs
 ├── memory/
 │   ├── MEMORY.md        # Long-term facts (always in context)
 │   └── HISTORY.md       # Searchable event log
-└── skills/              # Custom skills (auto-discovered)
+└── skills/              # Custom skills (auto-discovered, need approval — see below)
     └── my-skill/
         └── SKILL.md
 ```
@@ -623,7 +666,20 @@ workspace/
 | `USER.md` | Your profile, preferences, and current projects |
 | `MEMORY.md` | Important facts the bot remembers across conversations |
 | `HISTORY.md` | Timestamped log of past conversations (grep-searchable) |
-| `HEARTBEAT.md` | Tasks for autonomous processing (checked every 30 min) |
+| `HEARTBEAT.md` | Tasks for autonomous processing (checked every 5 min) |
+
+### Skill Approval
+
+A `SKILL.md` placed in `workspace/skills/` — whether you write it or the agent creates it for itself — becomes part of the agent's standing instructions, so it is **inert until you approve it**:
+
+```bash
+joshbot skills list          # See what's pending
+joshbot skills trust <name>  # Approve after reading the file
+joshbot skills trust --all   # Approve everything pending
+joshbot skills untrust <name> # Revoke approval
+```
+
+Approval is bound to the file's SHA-256 hash, so editing an approved skill revokes it until it's approved again. `joshbot status` also surfaces any skills awaiting review. Skills bundled with the release (see the [README](../README.md#bundled-skills)) don't need approval.
 
 ### Memory System
 
@@ -662,7 +718,7 @@ joshbot onboard
 
 # Or manually create config
 mkdir -p ~/.joshbot
-echo '{"providers":{"openrouter":{"api_key":"sk-or-..."}}}' > ~/.joshbot/config.json
+echo '{"providers":{"openrouter":{"api_key":"sk-or-...","enabled":true}}}' > ~/.joshbot/config.json
 ```
 
 #### LLM calls failing
@@ -745,6 +801,18 @@ export PATH=$PATH:$(go env GOPATH)/bin
 
 #### Permission denied
 
+**Problem:** Can't write to `~/.joshbot/`.
+
+**Solution:**
+```bash
+# Fix permissions
+chmod -R 755 ~/.joshbot
+
+# Or recreate
+rm -rf ~/.joshbot
+joshbot onboard
+```
+
 #### GitHub Copilot not authenticated
 
 **Problem:** Copilot models return "not authenticated" or "requires authentication".
@@ -758,21 +826,9 @@ The device flow saves a token to `~/.joshbot/auth.json` and enables the `github-
 
 #### "URL blocked by security policy"
 
-**Problem:** `web_fetch` refuses a URL.
+**Problem:** `web_fetch` or `web_search` refuses a URL.
 
-**Solution:** Use a public URL. `web_fetch` blocks localhost/private IPs and metadata endpoints to prevent SSRF.
-
-**Problem:** Can't write to `~/.joshbot/`.
-
-**Solution:**
-```bash
-# Fix permissions
-chmod -R 755 ~/.joshbot
-
-# Or recreate
-rm -rf ~/.joshbot
-joshbot onboard
-```
+**Solution:** Use a public URL. Both tools block localhost/private IPs and metadata endpoints to prevent SSRF.
 
 ### Getting Help
 

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -329,7 +329,7 @@ footer a:hover { text-decoration: underline; }
 <div class="container">
   <div class="page-hero">
     <h1>Architecture</h1>
-    <div class="meta"><span>joshbot</span> &middot; Go 1.24 &middot; ~19,640 LOC &middot; 597+ tests</div>
+    <div class="meta"><span>joshbot</span> &middot; Go 1.24 &middot; ~22,076 LOC &middot; 985+ tests</div>
   </div>
 
   <section>
@@ -358,7 +358,7 @@ footer a:hover { text-decoration: underline; }
         <div class="arrow-label">routed to agent goroutine</div>
         <div class="box amber full"><span class="name">Agent (ReAct Loop)</span><div class="desc">max 20 iterations: think → act → observe</div></div>
         <div class="diagram-row wrap" style="margin-top: 8px;">
-          <div class="box purple"><span class="name">Tools Registry</span><div class="desc">20 built-in tools</div></div>
+          <div class="box purple"><span class="name">Tools Registry</span><div class="desc">22 built-in tools</div></div>
           <div class="box green"><span class="name">Memory System</span><div class="desc">MEMORY.md + HISTORY.md</div></div>
           <div class="box green"><span class="name">Skills System</span><div class="desc">SKILL.md auto-discovery</div></div>
           <div class="box cyan"><span class="name">LLM Providers</span><div class="desc">OpenRouter, Anthropic, etc.</div></div>
@@ -432,14 +432,15 @@ footer a:hover { text-decoration: underline; }
     <p>The project follows Go conventions with <code>cmd/</code> for the entry point and <code>internal/</code> for all implementation packages.</p>
 
     <div class="file-tree">joshbot/
-├── <span class="dir">cmd/joshbot/</span>       <span class="highlight">← CLI entry point, service wiring (~3,340 LOC)</span>
+├── <span class="dir">cmd/joshbot/</span>       <span class="highlight">← CLI entry point, service wiring (~4,050 LOC)</span>
 │   ├── main.go             entry point, flags, gateway
-│   └── main_test.go
+│   ├── skills_cmd.go       joshbot skills subcommands (list/trust/untrust)
+│   └── main_test.go, utils_test.go
 ├── <span class="dir">internal/</span>             <span class="highlight">← all implementation</span>
 │   ├── <span class="dir">agent/</span>              ReAct loop, context assembly, prompt caching
 │   ├── <span class="dir">memory/</span>             structured fact store (fact.go, search.go)
-│   ├── <span class="dir">skills/</span>             discovery, detection, extraction, validation
-│   ├── <span class="dir">tools/</span>              20 built-in tools + registry
+│   ├── <span class="dir">skills/</span>             discovery, detection, extraction, validation, trust
+│   ├── <span class="dir">tools/</span>              22 built-in tools + registry, shell sandbox, shell env allowlist
 │   ├── <span class="dir">channels/</span>           CLI + Telegram channel implementations
 │   ├── <span class="dir">bus/</span>                goroutine message bus
 │   ├── <span class="dir">providers/</span>          LLM provider layer (OpenRouter, Anthropic, etc.)
@@ -503,6 +504,14 @@ footer a:hover { text-decoration: underline; }
         <h4>Subagent Delegation</h4>
         <p>Parallel fan-out or sequential chain execution. Each subagent gets a focused one-turn LLM call with its own system prompt. Results merged back into the parent agent context.</p>
       </div>
+      <div class="pattern-card">
+        <h4>Defense in Depth for Shell</h4>
+        <p>A deny-list screens command text, an allowlisted environment strips API keys before spawn, and an opt-in Landlock sandbox confines the filesystem and network at the kernel level — each layer catches what the one before it can't guarantee.</p>
+      </div>
+      <div class="pattern-card">
+        <h4>Trust-Gated Workspace Skills</h4>
+        <p>A workspace SKILL.md becomes standing system-prompt content, so it's inert until an operator runs <code>joshbot skills trust</code>. Trust is bound to a content hash and stored outside the workspace, so editing a trusted skill revokes it.</p>
+      </div>
     </div>
   </section>
 
@@ -514,13 +523,14 @@ footer a:hover { text-decoration: underline; }
     <p>The core ReAct loop. Each message triggers up to 20 think-act-observe iterations. System prompt is assembled from identity files + memory + skills summaries (with mtime-based caching). The agent serializes the tool schema from the Registry into the LLM's function calling format.</p>
 
     <h3>Tools (<code>internal/tools/</code>)</h3>
-    <p>20 tools implement the <code>Tool</code> interface. Each declares Name, Description, Parameters, and Execute. The Registry handles discovery and execution. Tools include: filesystem, shell (with safety deny-list), web fetch (SSRF-protected), memory search, skill management, parallel subagent, chain execution, message sending, and more.</p>
+    <p>22 tools implement the <code>Tool</code> interface. Each declares Name, Description, Parameters, and Execute. The Registry handles discovery and execution. Tools include: filesystem (plus read/write/edit/list/glob/grep aliases), shell (deny-listed, opt-in sandbox), web fetch (SSRF-protected, aliased for search/fetch/code/company/research), memory search, skill management, config, parallel subagent, chain execution, subagent profile config, and message sending.</p>
+    <p>Shell commands run with an <strong>allowlisted environment</strong> (<code>internal/tools/shell_env.go</code>) rather than inheriting joshbot's own process environment — provider API keys and other secrets are stripped before a command spawns, screened a second time against secret-shaped variable names. Optionally, <code>tools.shell_sandbox: "workspace"</code> confines shell commands to the workspace plus build caches and denies outbound network via Linux Landlock (<code>internal/tools/sandbox*.go</code>); it's off by default, Linux-only, and fails closed if the kernel doesn't support it. Web fetches are checked for SSRF both by hostname up front and again at dial time against the resolved IP, closing the DNS-rebinding gap between the two checks.</p>
 
     <h3>Memory System (<code>internal/memory/</code>)</h3>
     <p>Two files: <code>MEMORY.md</code> (always in context — key facts, preferences, decisions) and <code>HISTORY.md</code> (grep-searchable event log for recall). Facts are extracted after each conversation turn by the learning module.</p>
 
     <h3>Skills System (<code>internal/skills/</code>)</h3>
-    <p>Markdown files with YAML frontmatter in <code>workspace/skills/{name}/SKILL.md</code>. Auto-discovered on startup. Progressive loading: summary only in system prompt, full content loaded when the skill is invoked. The detection module observes tool usage patterns and auto-creates skills.</p>
+    <p>Markdown files with YAML frontmatter in <code>workspace/skills/{name}/SKILL.md</code>. Auto-discovered on startup. Progressive loading: summary only in system prompt, full content loaded when the skill is invoked. The detection module observes tool usage patterns and auto-creates skills. Workspace skills are <strong>inert until an operator approves them</strong> with <code>joshbot skills trust</code> — approval is bound to a hash of the skill's content, stored outside the workspace, so editing an approved skill (or having something write a new one) revokes trust rather than inheriting it. Skills bundled with the release itself are exempt.</p>
 
     <h3>Providers (<code>internal/providers/</code>)</h3>
     <p>Multi-provider LLM support via a unified <code>Provider</code> interface. Registered providers: OpenRouter, OpenAI, NVIDIA, Groq, Ollama, Anthropic, Poolside, Azure, Custom, LiteLLM. Provider auto-selection by model prefix. ExtraBody support for provider-specific fields (e.g., poolside's chat_template_kwargs).</p>
@@ -554,7 +564,7 @@ footer a:hover { text-decoration: underline; }
   }
 }</div>
     </div>
-    <p>Environment variable overrides: <code>JOSHBOT_PROVIDERS__OPENROUTER__API_KEY</code> or <code>JOSHBOT_MODELS_CONFIG__AGENT__MODEL</code>. Config is validated JSON, stored at <code>~/.joshbot/config.json</code>.</p>
+    <p>Environment variable overrides: <code>JOSHBOT_PROVIDERS__OPENROUTER__API_KEY</code> or <code>JOSHBOT_MODELS_CONFIG__AGENT__MODEL</code>. Config is validated JSON, stored at <code>~/.joshbot/config.json</code>, written with <code>0600</code> permissions since it holds live provider API keys. An explicit <code>--config &lt;file&gt;</code> flag names a specific config file, overriding the default home-directory location.</p>
   </section>
 </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -477,19 +477,19 @@ footer a:hover { text-decoration: underline; }
 <section class="features">
   <div class="features-inner">
     <div class="feature-item">
-      <div class="value">19,640</div>
+      <div class="value">22,076</div>
       <div class="label">Lines of Go</div>
     </div>
     <div class="feature-item">
-      <div class="value">48</div>
+      <div class="value">73</div>
       <div class="label">Test Files</div>
     </div>
     <div class="feature-item">
-      <div class="value">597+</div>
+      <div class="value">985+</div>
       <div class="label">Test Functions</div>
     </div>
     <div class="feature-item">
-      <div class="value">20</div>
+      <div class="value">22</div>
       <div class="label">Built-in Tools</div>
     </div>
   </div>

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -55,3 +55,5 @@ gh search prs "query"         # Search PRs
 - Always check `gh auth status` before operations
 - Use `--json` flag for machine-readable output
 - Use `--jq` for filtering JSON output
+- Shell commands run with a stripped-down environment — variables that look like credentials (including `GH_TOKEN`/`GITHUB_TOKEN`) are never passed through. Authenticate with `gh auth login` (its on-disk config under `HOME` is preserved) rather than relying on a token env var.
+- If the operator has turned on `tools.shell_sandbox: workspace`, outbound network is blocked by default (`tools.shell_sandbox_allow_network` must be on) — `gh` commands will fail with a network error until that's enabled.

--- a/skills/memory/SKILL.md
+++ b/skills/memory/SKILL.md
@@ -19,7 +19,8 @@ You have a two-file memory system for maintaining context across conversations:
 - Location: `memory/HISTORY.md` in your workspace
 - **Append-only** log of timestamped conversation summaries
 - NOT loaded into context (to save space) - search it when needed
-- Search with: `grep` tool directly, or `shell` with `grep -i "keyword" memory/HISTORY.md`
+- Search raw entries with: `grep` tool directly, or `shell` with `grep -i "keyword" memory/HISTORY.md`
+- For extracted long-term facts (as opposed to raw history text), prefer the `memory_search` tool — it searches structured facts by relevance rather than literal text match
 - Each entry is 2-5 sentences with timestamp `[YYYY-MM-DD HH:MM]`
 
 ## Best Practices

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -51,6 +51,10 @@ Include examples, best practices, and common patterns.
 - When you discover a useful pattern that should be remembered
 - When integrating with a new tool or service
 
+## New Skills Need Operator Approval
+
+A skill you create in the workspace is written to disk but is inert: it is withheld from your own context until an operator reviews it and runs `joshbot skills trust <name>`. After creating a skill, tell the user it needs approval before it will actually be available to you. Editing an already-approved skill revokes its approval, so it needs re-trusting after any change.
+
 ## Workspace Skills Override Bundled
 
-If you create a workspace skill with the same name as a bundled skill, your workspace version takes priority. This lets you customize built-in behaviors.
+If you create a workspace skill with the same name as a bundled skill, your workspace version replaces it in the registry — but is still subject to the approval rule above. Until it's trusted, that name resolves to nothing rather than falling back to the bundled version, so the built-in behavior effectively disappears until the operator approves (or you delete) the workspace copy.


### PR DESCRIPTION
Audited every `.md` and `.html` file against the source. Eight releases of drift.

## Corrections that were actively misleading

- **README** — Docker mount was `/root/.joshbot`; the image runs as user `joshbot` with `HOME=/home/joshbot`, so that path was never read. The tools table claimed `web_search` needs a **Brave API key** (no Brave integration exists anywhere) and listed `spawn` and `cron` tools that do not exist, while omitting `glob` and `grep`.
- **docs/INSTALL.md** — pointed at the broken installer (#91). Omitted `skills`, `configure`, `auth`, `service`, `update` and `version` **entirely**. Its own troubleshooting snippet reproduced the missing-`enabled` footgun it was meant to fix. Heartbeat documented as 30m; `main.go` overrides to 5m.
- **SECURITY.md** — stated joshbot "does not implement its own sandbox", untrue since v1.38.0.
- **skills/skill-creator** — said a workspace skill "takes priority" over a same-named bundled one. It actually *replaces* it and is then withheld until trusted, so reusing a bundled name **removes that capability**. The agent was being taught something that would break its own tooling.
- **CLAUDE.md** — "Scheduled jobs via cron.yml in workspace". No `cron.yml` exists anywhere in the repo.

## Counts, re-measured

Every number was measured, not carried over:

| | was | now |
|---|---|---|
| LOC (non-test) | 19,640 | 22,076 |
| Test files | 48 | 73 |
| Test functions | 597+ | 985 |
| Built-in tools | 20 | 22 |

I checked these myself rather than taking the specialists' word: the two agents disagreed on test functions (985 vs 995), and the higher figure came from a broken filter — `grep -rho` suppresses filenames, so its `grep -v /pkg/` did nothing and counted the stale `pkg/` tests the docs explicitly exclude. 985 is correct. The tool count I verified by enumerating registrations: 11 base + 6 filesystem aliases + 5 web aliases.

HTML well-formedness re-verified independently with a tag-stack parser; both pages are clean.

## The rule

Added to `CLAUDE.md`, `AGENTS.md` and the PR template: **docs ship with the change, same PR**. Includes a table mapping change type → file, a ban on quoting numbers without re-measuring, and a release gate.

The soft version of this rule already existed — `CLAUDE.md` said the site MUST stay in sync while the site sat eight releases stale. So the new version names files, and the PR template's generic "Documentation updated" checkbox is replaced with a specific list, because a generic checkbox is what got ticked while this drift accumulated.

## Two code bugs found, filed not fixed

- **#90** — cron is advertised, has a bundled skill teaching `cron create ...`, and starts a service at boot. **No cron tool exists**, and nothing outside `internal/cron` ever calls `AddJob`. The agent will try the command and fail. Verified independently.
- **#91** — `scripts/install.sh` builds `joshbot_linux_amd64`; actual assets are `joshbot_v1.39.1_linux_amd64`. It is the installer `.goreleaser.yaml` bundles into release archives.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)