### PR TITLE
chore: release v1.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.39.2] - 2026-07-26
+
 ### Fixed
 - **Two abandoned copies of the install and uninstall scripts** — `scripts/install.sh` and `scripts/uninstall.sh` were forks frozen before the v-prefixed asset-name fix landed in the repo-root copies. The `scripts/` installer tried three naming patterns, none of which matched what `release.yml` actually publishes, and downgraded a checksum mismatch to a warning it continued past; the `scripts/` uninstaller predated systemd/launchd/pipx removal. Nothing referenced either file except a `.goreleaser.yaml` glob, and the advertised `curl | bash` path was never affected — but both were what a reader looking in `scripts/` would find first. Deleted, the glob repointed, and the naming contract between `install.sh` and `.github/workflows/release.yml` is now pinned by tests so the two cannot drift silently again.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -262,7 +262,7 @@ joshbot status
 ╔═══════════════════════════════════════════╗
 ║            joshbot status                ║
 ╚═══════════════════════════════════════════╝
-Version:        1.39.1
+Version:        1.39.2
 Config file:    ~/.joshbot/config.json (exists)
 Workspace:      ~/.joshbot/workspace (exists)
 Sessions:       ~/.joshbot/sessions


### PR DESCRIPTION
Cuts v1.39.2.

- Moves the `[Unreleased]` entry under a dated `[1.39.2]` heading
- Updates the sample `joshbot status` output in `docs/INSTALL.md` to the new version

Contents: #93 — removal of the abandoned `scripts/install.sh` / `scripts/uninstall.sh` forks, plus mutation-verified tests pinning the installer↔release naming contract.

Gates: `go build` · `go vet` · `gofmt -l` clean · `go test -race ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)