### PR TITLE
chore: release v1.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.40.0] - 2026-07-26
+
 ### Added
 - **`cron` tool — scheduled reminders the agent can actually create** — joshbot advertised scheduled reminders, shipped a skill teaching the agent to run `cron create ...`, and started a scheduler at boot, but no tool existed and nothing outside `internal/cron` ever called `AddJob`: the scheduler ran with a permanently empty job list and every attempt produced a confident-sounding failure. The tool exposes create/list/delete, is registered only when a scheduler is actually running, and returns the job ID so a reminder can be cancelled. Schedules are durations (`30m`, `2h`, `1d`, `1h30m`), one-off or repeating.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -262,7 +262,7 @@ joshbot status
 ╔═══════════════════════════════════════════╗
 ║            joshbot status                ║
 ╚═══════════════════════════════════════════╝
-Version:        1.39.2
+Version:        1.40.0
 Config file:    ~/.joshbot/config.json (exists)
 Workspace:      ~/.joshbot/workspace (exists)
 Sessions:       ~/.joshbot/sessions


### PR DESCRIPTION
Cuts v1.40.0 — minor, since it adds a user-visible capability.

- Moves the `[Unreleased]` entries under a dated `[1.40.0]` heading
- Updates the sample `joshbot status` output in `docs/INSTALL.md`

Contents: #95 — the `cron` tool (#90), six `internal/cron` service fixes, the rewritten cron skill, and the skill/tool drift lint.

Gates: `go build` · `go vet` · `gofmt -l` clean · `go test -race ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)