### PR TITLE
chore: release v1.40.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ htmlcov/
 
 # Playwright browser testing artifacts
 .playwright-mcp/
+*.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.40.1] - 2026-07-26
+
 ### Fixed
 - **A one-shot reminder's countdown restarted with the process** — `delay:` schedules were stored as a duration only, so on every start the scheduler called `time.After(duration)` again. A "remind me in 30 minutes" that was 29 minutes in when joshbot restarted fired 30 minutes *after* the restart, and a reminder could be pushed back indefinitely by routine restarts. Jobs now persist an absolute `due_at`, so a restart waits out only the remaining time, and a reminder that came due while joshbot was stopped fires shortly after it starts instead of being lost. Reminders saved before this change have no `due_at`; they are backfilled as due one duration from load — the previous behaviour — so an existing `jobs.json` does not fire everything at once. Recurring (`every:`) jobs are unchanged.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -262,7 +262,7 @@ joshbot status
 ╔═══════════════════════════════════════════╗
 ║            joshbot status                ║
 ╚═══════════════════════════════════════════╝
-Version:        1.40.0
+Version:        1.40.1
 Config file:    ~/.joshbot/config.json (exists)
 Workspace:      ~/.joshbot/workspace (exists)
 Sessions:       ~/.joshbot/sessions


### PR DESCRIPTION
Cuts v1.40.1 — patch, bug fixes only.

- Moves the `[Unreleased]` entry under a dated `[1.40.1]` heading
- Updates the sample `joshbot status` output in `docs/INSTALL.md`
- Broadens the gitignore secrets pattern to `*.env`

Contents: #99 — one-shot reminders now persist an absolute `due_at` so their countdown survives a restart, plus the `omitempty` tag fix and on-disk shape test.

Gates: `go build` · `go vet` · `gofmt -l` clean · `go test -race ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)