### PR TITLE
fix(poolside): make poolside actually configurable and working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Poolside could not be configured correctly by any route** — three separate defects, all found by dogfooding against the live API. The interactive `configure` wizard offered `https://api.poolside.ai/v1` as the default endpoint, **a host that does not resolve**, so anyone accepting the default got a config that could never connect; the real endpoint is `https://inference.poolside.ai/v1`. The registered default model, `poolside/laguna-m.1`, carries a deprecation date of 2026-07-28 — two days out — so the out-of-the-box choice was about to stop working; it is now `poolside/laguna-s-2.1`. And `configure --help` omitted poolside from the list of providers it accepts, alongside five others. The endpoint is now recorded once in the provider registry (`ProviderInfo.DefaultAPIBase`) and read from there by the wizard, with a test asserting the declared endpoint matches the one the factory actually dials — the duplicate copy is what drifted.
+
 ## [1.40.2] - 2026-07-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A lightweight personal AI assistant written in Go, featuring self-learning memor
 - **Subagent Delegation** - Spawns focused subagents for complex multi-step tasks
 - **Telegram Integration** - Chat from your phone with full media support
 - **Interactive CLI** - Rich terminal interface with markdown rendering
-- **Multi-Provider LLM** - OpenRouter, Anthropic, OpenAI, Groq, DeepSeek, Gemini, NVIDIA, and more
+- **Multi-Provider LLM** - OpenRouter, Anthropic, OpenAI, Groq, Poolside, DeepSeek, Gemini, NVIDIA, and more
 - **Model-Centric Config** - Simplified model configuration with provider auto-detection and fallback chains
 - **Prompt Caching** - Intelligent caching of system prompts with mtime-based invalidation for faster responses
 - **Tool Use** - File operations, shell commands, web search, scheduling, and more
@@ -276,6 +276,32 @@ The new model-centric format is simpler and more intuitive. Define models direct
 | `deepseek/` | DeepSeek | `https://api.deepseek.com/v1` |
 | `gemini/` | Google Gemini | `https://generativelanguage.googleapis.com/v1beta` |
 | `cerebras/` | Cerebras | `https://api.cerebras.ai/v1` |
+| `poolside/` | Poolside | `https://inference.poolside.ai/v1` |
+
+The prefix is stripped before the request is sent, because for most providers it
+is joshbot's routing hint rather than part of the model name. **Poolside is the
+exception** — its published IDs really are `poolside/laguna-s-2.1`, so the prefix
+is kept. Nothing else needs to change; just use the ID exactly as the provider
+lists it.
+
+### Poolside
+
+```bash
+joshbot configure \
+  --provider poolside \
+  --api-key "$POOLSIDE_API_KEY" \
+  --model poolside/laguna-s-2.1
+```
+
+The API base defaults to `https://inference.poolside.ai/v1`, so `--api-base` is
+optional. Current models are `poolside/laguna-s-2.1` and `poolside/laguna-xs-2.1`
+(`poolside/laguna-m.1` is deprecated as of 2026-07-28). Ask the endpoint for the
+authoritative list:
+
+```bash
+curl -s https://inference.poolside.ai/v1/models \
+  -H "Authorization: Bearer $POOLSIDE_API_KEY" | jq -r '.data[].id'
+```
 
 ### Legacy Provider Configuration (Still Supported)
 

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -2660,7 +2660,18 @@ func runConfigure(c *cli.Context) error {
 		if err := conf.ConfigureProvider(opts); err != nil {
 			return err
 		}
-		fmt.Printf("Provider %q configured with model %q.\n", opts.Name, cfg.Providers[opts.Name].Model)
+		// Report the model that will actually be used. When --model is omitted
+		// the provider entry is left empty and the effective model comes from
+		// the agent defaults or the provider's registered default; printing the
+		// empty provider field made a working setup look broken.
+		effectiveModel := cfg.Providers[opts.Name].Model
+		if effectiveModel == "" {
+			effectiveModel = cfg.Agents.Defaults.Model
+		}
+		if effectiveModel == "" {
+			effectiveModel = providers.GetDefaultModel(opts.Name)
+		}
+		fmt.Printf("Provider %q configured with model %q.\n", opts.Name, effectiveModel)
 	}
 
 	if provider := c.String("set-default"); provider != "" {

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -238,7 +238,7 @@ func runApp() error {
 					},
 					&cli.StringFlag{
 						Name:  "provider",
-						Usage: "Provider to configure (nvidia, openrouter, groq, ollama, github-copilot)",
+						Usage: "Provider to configure (openrouter, openai, anthropic, poolside, nvidia, groq, ollama, azure, custom, litellm, github-copilot)",
 					},
 					&cli.StringFlag{
 						Name:  "api-key",
@@ -2966,15 +2966,19 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 			p.Model = strings.TrimSpace(modelInput)
 		}
 	case "poolside":
+		// Taken from the registry, not written out again here: the previous
+		// hardcoded default was "https://api.poolside.ai/v1", a host that does
+		// not resolve, so the wizard handed every user a broken config.
+		poolsideBase := providers.GetDefaultAPIBaseFor("poolside")
 		if exists && p.APIBase != "" {
 			fmt.Printf("API base URL [%s]: ", p.APIBase)
 		} else {
-			fmt.Print("API base URL [https://api.poolside.ai/v1]: ")
+			fmt.Printf("API base URL [%s]: ", poolsideBase)
 		}
 		fmt.Scanln(&apiBase)
 		if apiBase == "" {
 			if p.APIBase == "" {
-				apiBase = "https://api.poolside.ai/v1"
+				apiBase = poolsideBase
 			} else {
 				apiBase = p.APIBase
 			}

--- a/internal/providers/poolside_test.go
+++ b/internal/providers/poolside_test.go
@@ -6,9 +6,11 @@ import (
 )
 
 // Verified live against https://inference.poolside.ai/v1/models on 2026-07-26:
-//   poolside/laguna-m.1     deprecation_date 2026-07-28
-//   poolside/laguna-xs-2.1  no deprecation
-//   poolside/laguna-s-2.1   no deprecation
+//
+//	poolside/laguna-m.1     deprecation_date 2026-07-28
+//	poolside/laguna-xs-2.1  no deprecation
+//	poolside/laguna-s-2.1   no deprecation
+//
 // The registered default must not be a model that is about to be withdrawn.
 func TestPoolsideDefaultModelIsNotDeprecated(t *testing.T) {
 	got := GetDefaultModel("poolside")

--- a/internal/providers/poolside_test.go
+++ b/internal/providers/poolside_test.go
@@ -1,0 +1,80 @@
+package providers
+
+import (
+	"strings"
+	"testing"
+)
+
+// Verified live against https://inference.poolside.ai/v1/models on 2026-07-26:
+//   poolside/laguna-m.1     deprecation_date 2026-07-28
+//   poolside/laguna-xs-2.1  no deprecation
+//   poolside/laguna-s-2.1   no deprecation
+// The registered default must not be a model that is about to be withdrawn.
+func TestPoolsideDefaultModelIsNotDeprecated(t *testing.T) {
+	got := GetDefaultModel("poolside")
+	if got == "poolside/laguna-m.1" {
+		t.Errorf("default model %q is deprecated 2026-07-28; anyone relying on the default breaks", got)
+	}
+	if !strings.HasPrefix(got, "poolside/") {
+		t.Errorf("default model %q must carry the poolside/ prefix — the API 404s without it", got)
+	}
+}
+
+// The API base must be discoverable from the registry rather than duplicated at
+// each call site. api.poolside.ai does not resolve; inference.poolside.ai does.
+func TestPoolsideDefaultAPIBase(t *testing.T) {
+	const want = "https://inference.poolside.ai/v1"
+	got := GetDefaultAPIBaseFor("poolside")
+	if got != want {
+		t.Errorf("GetDefaultAPIBaseFor(%q) = %q, want %q", "poolside", got, want)
+	}
+}
+
+// Every provider that has a fixed endpoint should expose it, so a wizard or
+// docs cannot drift from what the factory actually dials.
+func TestDefaultAPIBaseForKnownProviders(t *testing.T) {
+	tests := map[string]string{
+		"poolside":   "https://inference.poolside.ai/v1",
+		"openrouter": "https://openrouter.ai/api/v1",
+		"groq":       "https://api.groq.com/openai/v1",
+	}
+	for provider, want := range tests {
+		if got := GetDefaultAPIBaseFor(provider); got != want {
+			t.Errorf("GetDefaultAPIBaseFor(%q) = %q, want %q", provider, got, want)
+		}
+	}
+}
+
+// An unknown provider has no fixed endpoint.
+func TestDefaultAPIBaseForUnknown(t *testing.T) {
+	if got := GetDefaultAPIBaseFor("nope"); got != "" {
+		t.Errorf("GetDefaultAPIBaseFor(unknown) = %q, want empty", got)
+	}
+}
+
+// The endpoint recorded in ProviderInfo must be the one the factory actually
+// dials. They are separate literals, so nothing but a test keeps them equal —
+// and a stale copy in the configure wizard is exactly what broke poolside setup.
+func TestDefaultAPIBaseMatchesWhatFactoryDials(t *testing.T) {
+	for _, name := range []string{"poolside", "openrouter", "openai", "nvidia", "groq"} {
+		declared := GetDefaultAPIBaseFor(name)
+		if declared == "" {
+			t.Errorf("%s declares no DefaultAPIBase", name)
+			continue
+		}
+		// Build the provider with an empty APIBase: the factory fills in its own.
+		p, err := GetProvider(name, Config{APIKey: "x"})
+		if err != nil {
+			t.Errorf("GetProvider(%q): %v", name, err)
+			continue
+		}
+		lp, ok := p.(*LiteLLMProvider)
+		if !ok {
+			continue // provider does not expose its config this way
+		}
+		if lp.cfg.APIBase != declared {
+			t.Errorf("%s: factory dials %q but ProviderInfo declares %q",
+				name, lp.cfg.APIBase, declared)
+		}
+	}
+}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -17,6 +17,12 @@ type ProviderInfo struct {
 	DefaultModel string
 	DisplayName  string
 	Description  string
+	// DefaultAPIBase is the endpoint the factory dials when a config supplies
+	// none. Recorded here so wizards, docs and tests read the same value the
+	// factory uses instead of each hardcoding their own copy — a duplicate in
+	// the configure wizard is how "https://api.poolside.ai/v1", a host that
+	// does not resolve, was offered to users as the default.
+	DefaultAPIBase string
 }
 
 // registry is the global provider registry.
@@ -116,6 +122,18 @@ func normalizeProviderName(name string) string {
 
 // GetDefaultModel returns the default model for a provider.
 // Returns empty string if provider not found or no default set.
+// GetDefaultAPIBaseFor returns a provider's fixed endpoint, or "" if it has
+// none (Ollama, Azure and Custom take theirs from config).
+func GetDefaultAPIBaseFor(name string) string {
+	registryLock.RLock()
+	defer registryLock.RUnlock()
+
+	if info, exists := registry[normalizeProviderName(name)]; exists {
+		return info.DefaultAPIBase
+	}
+	return ""
+}
+
 func GetDefaultModel(name string) string {
 	registryLock.RLock()
 	defer registryLock.RUnlock()
@@ -161,9 +179,10 @@ func init() {
 			}
 			return NewLiteLLMProvider(cfg), nil
 		},
-		DefaultModel: "openrouter/free",
-		DisplayName:  "OpenRouter",
-		Description:  "Many models, one API key",
+		DefaultAPIBase: "https://openrouter.ai/api/v1",
+		DefaultModel:   "openrouter/free",
+		DisplayName:    "OpenRouter",
+		Description:    "Many models, one API key",
 	})
 
 	// Register OpenAI
@@ -174,9 +193,10 @@ func init() {
 			}
 			return NewLiteLLMProvider(cfg), nil
 		},
-		DefaultModel: "gpt-4o",
-		DisplayName:  "OpenAI",
-		Description:  "GPT-4 and more",
+		DefaultAPIBase: "https://api.openai.com/v1",
+		DefaultModel:   "gpt-4o",
+		DisplayName:    "OpenAI",
+		Description:    "GPT-4 and more",
 	})
 
 	// Register NVIDIA
@@ -187,9 +207,10 @@ func init() {
 			}
 			return NewLiteLLMProvider(cfg), nil
 		},
-		DefaultModel: "moonshotai/kimi-k2-thinking",
-		DisplayName:  "NVIDIA NIM",
-		Description:  "Free tier available",
+		DefaultAPIBase: "https://integrate.api.nvidia.com/v1",
+		DefaultModel:   "moonshotai/kimi-k2-thinking",
+		DisplayName:    "NVIDIA NIM",
+		Description:    "Free tier available",
 	})
 
 	// Register Groq
@@ -200,9 +221,10 @@ func init() {
 			}
 			return NewLiteLLMProvider(cfg), nil
 		},
-		DefaultModel: "llama-3.3-70b-versatile",
-		DisplayName:  "Groq",
-		Description:  "Fast inference",
+		DefaultAPIBase: "https://api.groq.com/openai/v1",
+		DefaultModel:   "llama-3.3-70b-versatile",
+		DisplayName:    "Groq",
+		Description:    "Fast inference",
 	})
 
 	// Register Ollama
@@ -229,9 +251,10 @@ func init() {
 			}
 			return NewLiteLLMProvider(cfg), nil
 		},
-		DefaultModel: "claude-sonnet-4-20250514",
-		DisplayName:  "Anthropic",
-		Description:  "Claude models",
+		DefaultAPIBase: "https://api.anthropic.com/v1",
+		DefaultModel:   "claude-sonnet-4-20250514",
+		DisplayName:    "Anthropic",
+		Description:    "Claude models",
 	})
 
 	// Register Poolside
@@ -242,9 +265,13 @@ func init() {
 			}
 			return NewLiteLLMProvider(cfg), nil
 		},
-		DefaultModel: "poolside/laguna-m.1",
-		DisplayName:  "Poolside",
-		Description:  "AI for software development",
+		DefaultAPIBase: "https://inference.poolside.ai/v1",
+		// laguna-m.1 carries deprecation_date 2026-07-28; laguna-s-2.1 is the
+		// current second-generation model and has none. The "poolside/" prefix
+		// is part of the ID the API expects — see prefixesPartOfModelID.
+		DefaultModel: "poolside/laguna-s-2.1",
+		DisplayName:    "Poolside",
+		Description:    "AI for software development",
 	})
 
 	// Register Azure (requires API base, no default model)

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -270,8 +270,8 @@ func init() {
 		// current second-generation model and has none. The "poolside/" prefix
 		// is part of the ID the API expects — see prefixesPartOfModelID.
 		DefaultModel: "poolside/laguna-s-2.1",
-		DisplayName:    "Poolside",
-		Description:    "AI for software development",
+		DisplayName:  "Poolside",
+		Description:  "AI for software development",
 	})
 
 	// Register Azure (requires API base, no default model)


### PR DESCRIPTION
Follow-up to #101. That PR made poolside's model IDs reach the API intact; this one makes the provider genuinely configurable. All three defects were found by dogfooding against the live endpoint with a real key.

## Defects

**1. The configure wizard offered an endpoint that does not exist.**

```
$ curl https://api.poolside.ai/v1/models
curl: (6) Could not resolve host: api.poolside.ai
```

`cmd/joshbot/main.go` hardcoded `https://api.poolside.ai/v1` as the interactive default. The real endpoint — the one the provider factory itself dials — is `https://inference.poolside.ai/v1`. Anyone accepting the wizard default got a config that could never connect.

**2. The default model is deprecated in two days.**

Live from `/v1/models` on 2026-07-26:

| model | deprecation_date |
|---|---|
| `poolside/laguna-m.1` | **2026-07-28** |
| `poolside/laguna-xs-2.1` | none |
| `poolside/laguna-s-2.1` | none |

`laguna-m.1` was the registered default, so the out-of-the-box choice was about to stop working. Now `laguna-s-2.1`.

**3. `configure --help` omitted poolside** — and openai, anthropic, azure, custom and litellm — from the `--provider` list, so a user reading the help would not know it was accepted.

## Root cause of #1, and the fix

The endpoint existed as two independent literals: one in the provider factory, one in the wizard. Nothing kept them equal, so the wizard's copy rotted.

`ProviderInfo.DefaultAPIBase` now records it once, the wizard reads it from there, and `TestDefaultAPIBaseMatchesWhatFactoryDials` constructs each provider and asserts the declared endpoint equals the one the factory actually assigns. A future drift fails the build rather than shipping a dead URL.

## Also fixed

`configure --provider poolside --api-key K` (no `--model`) printed `configured with model ""`, which reads as broken. The provider entry is legitimately empty there — the effective model comes from the agent defaults — so it now reports what will actually be used.

## Verified end to end

With **pure defaults** — no `--model`, no `--api-base`:

```
$ joshbot configure --provider poolside --api-key "$POOLSIDE_API_KEY"
Provider "poolside" configured with model "poolside/laguna-s-2.1".

$ joshbot status
Model:          poolside/laguna-s-2.1

$ joshbot agent -m "say hi"
Hey there! 👋 I'm joshbot, your friendly personal AI assistant...
```

That is the whole point: a user who types the documented command and nothing else now gets a working assistant.

## Tests

New `internal/providers/poolside_test.go`. Mutation: 3 applied, 3 killed.

| Mutation | Killed by |
|---|---|
| restore the deprecated default model | `TestPoolsideDefaultModelIsNotDeprecated` |
| remove poolside's `DefaultAPIBase` | `TestPoolsideDefaultAPIBase` |
| declared base drifts from what the factory dials | `TestDefaultAPIBaseMatchesWhatFactoryDials` |

## Documentation

Per the HARD RULE: `README.md` gains poolside in the feature list, a row in the provider auto-detection table, an explanation of why its prefix is *kept* when every other provider's is stripped, and a copy-pasteable setup block with a `curl` for the authoritative model list. `CHANGELOG.md` under `[Unreleased]`.

## Gates

`go build` · `go vet` · `gofmt -l` clean · `go test -race ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
