### PR TITLE
docs: re-measure every quoted number

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-joshbot is a lightweight personal AI assistant (~19,640 LOC Go non-test, 597 test functions across 48 test files) with self-learning memory, auto-skill-creation from tool usage patterns, and Telegram integration. Architecture: goroutine-based message bus decoupling chat channels from a ReAct agent loop backed by multi-provider LLM via OpenRouter-compatible APIs.
+joshbot is a lightweight personal AI assistant (~22,813 LOC Go non-test, 1,056 test functions across 83 test files) with self-learning memory, auto-skill-creation from tool usage patterns, and Telegram integration. Architecture: goroutine-based message bus decoupling chat channels from a ReAct agent loop backed by multi-provider LLM via OpenRouter-compatible APIs.
 
 Module: `github.com/bigknoxy/joshbot`. Go 1.24.0.
 
@@ -96,12 +96,12 @@ go mod tidy
 ## Code Architecture
 
 ```
-cmd/joshbot/main.go            -- CLI entry (urfave/cli/v2), service wiring, ~3,704 LOC
+cmd/joshbot/main.go            -- CLI entry (urfave/cli/v2), service wiring, ~3,980 LOC
   internal/
     agent/agent.go             -- ReAct loop (max 20 iterations)
     agent/context.go           -- System prompt assembly (identity files + memory + skills)
     bus/bus.go                 -- Channel-based message bus (Inbound/OutboundMessage in bus.go)
-    channels/cli.go            -- CLI readline channel (bufio.Reader)
+    channels/cli.go            -- DEAD CODE: no callers; live CLI is runAgentLoop in cmd/joshbot/main.go
     channels/telegram.go       -- Telegram long-polling channel (telebot)
     config/config.go           -- JSON config, env overrides (JOSHBOT_ prefix)
     configure/configure.go     -- Config wizard, provider selection, non-interactive configure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Every quoted number in the docs re-measured** — `AGENTS.md` claimed 19,640 LOC, 597 test functions and 48 test files against an actual 22,813 / 1,056 / 83, so the test-file count was off by 73%. `CLAUDE.md` and `site/architecture.html` were closer but also stale, and a "~30ms startup" claim was deleted rather than carried forward — it measures nearer 10ms and nothing keeps it honest. `AGENTS.md` also described `internal/channels/cli.go` as the CLI channel; it has no callers at all, and the live interactive CLI is `runAgentLoop` in `cmd/joshbot/main.go`.
+
 ## [1.41.0] - 2026-07-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,15 @@
 # joshbot — Architect's Guide
 
-joshbot is a self-hosted Go personal AI assistant (~22.1K LOC non-test, 985 test functions across 73 files). Single binary, zero runtime deps.
+joshbot is a self-hosted Go personal AI assistant (~22.8K LOC non-test, 1,056 test functions across 83 files). Single binary, zero runtime deps.
 
 **`AGENTS.md` (repo root) is the full agent guide** — key interfaces, code style, naming, concurrency and logging patterns, complete gotchas list. Read it before non-trivial work. This file is the quick index.
 
 ## Key facts
 
 - **Go 1.24.0**, module `github.com/bigknoxy/joshbot`
-- **~17MB binary**, ~30ms startup
+- **~17MB binary**
 - **Architecture**: goroutine message bus → ReAct agent loop → multi-provider LLM
-- **Channels**: CLI (readline) + Telegram (long-polling, telebot)
+- **Channels**: CLI (`runAgentLoop` in `cmd/joshbot/main.go`) + Telegram (long-polling, telebot)
 - **Providers**: openrouter, openai, nvidia, groq, ollama, anthropic, poolside, azure, custom, litellm, github-copilot (device-flow auth via `joshbot auth github-copilot`)
 - **Config**: `~/.joshbot/config.json`, env vars with `JOSHBOT_` prefix, two formats (legacy + model-centric)
 - **Memory**: MEMORY.md (always in context) + HISTORY.md (appended event log) + fact extraction + consolidation
@@ -101,7 +101,20 @@ Rules that make this stick:
   the `json:`/`mapstructure:` struct tags exactly.
 - **No unverifiable numbers.** LOC, test counts, tool counts and binary sizes must be
   measured at the time of writing or removed. A stale number is worse than none: it
-  reads as authoritative.
+  reads as authoritative. Two traps have produced wrong figures here, so scope the
+  measurement explicitly to `./internal ./cmd` rather than sweeping from the repo root:
+
+  ```bash
+  find ./internal ./cmd -name '*.go' ! -name '*_test.go' -exec cat {} + | wc -l
+  grep -rhE '^func Test' --include='*_test.go' ./internal ./cmd ./tests | wc -l
+  find ./internal ./cmd ./tests -name '*_test.go' | wc -l
+  ```
+
+  A bare `find .` also descends into `.claude/worktrees/`, where agents keep whole
+  copies of the repo — that alone inflated the LOC count from 22,813 to 68,487. And
+  `grep -rho` suppresses filenames, so a later `grep -v /pkg/` silently filters
+  nothing. Sanity-check by running a count with and without the exclusion and
+  confirming the two differ.
 - **Stale claims count as bugs.** Deleting a claim that is no longer true is as
   important as adding one that is. Drift runs both ways.
 - **`site/*.html` is not optional.** It is the public face and it drifts fastest,

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -329,7 +329,7 @@ footer a:hover { text-decoration: underline; }
 <div class="container">
   <div class="page-hero">
     <h1>Architecture</h1>
-    <div class="meta"><span>joshbot</span> &middot; Go 1.24 &middot; ~22,076 LOC &middot; 985+ tests</div>
+    <div class="meta"><span>joshbot</span> &middot; Go 1.24 &middot; ~22,813 LOC &middot; 1,056 tests</div>
   </div>
 
   <section>
@@ -432,7 +432,7 @@ footer a:hover { text-decoration: underline; }
     <p>The project follows Go conventions with <code>cmd/</code> for the entry point and <code>internal/</code> for all implementation packages.</p>
 
     <div class="file-tree">joshbot/
-├── <span class="dir">cmd/joshbot/</span>       <span class="highlight">← CLI entry point, service wiring (~4,050 LOC)</span>
+├── <span class="dir">cmd/joshbot/</span>       <span class="highlight">← CLI entry point, service wiring (~4,133 LOC)</span>
 │   ├── main.go             entry point, flags, gateway
 │   ├── skills_cmd.go       joshbot skills subcommands (list/trust/untrust)
 │   └── main_test.go, utils_test.go


### PR DESCRIPTION
Item 4 from the UX/quality list.

## What was stale

| Claim | Where | Was | Actually |
|---|---|---|---|
| non-test LOC | `AGENTS.md` | ~19,640 | **22,813** |
| test functions | `AGENTS.md` | 597 | **1,056** |
| test files | `AGENTS.md` | 48 | **83** (off by 73%) |
| non-test LOC | `CLAUDE.md` | ~22.1K | ~22.8K |
| test functions | `CLAUDE.md` | 985 | 1,056 |
| `main.go` LOC | `AGENTS.md` | ~3,704 | 3,980 |
| LOC / tests | `site/architecture.html` | ~22,076 / 985+ | 22,813 / 1,056 |
| `cmd/` LOC | `site/architecture.html` | ~4,050 | 4,133 |
| startup | `CLAUDE.md` | ~30ms | **deleted** |

Startup measures ~10ms, but nothing keeps that honest, so per the HARD RULE the claim is removed rather than replaced with another number that will rot.

Binary size (~17MB) and coverage (54.7%) were already accurate.

## Also corrected

`AGENTS.md` described `internal/channels/cli.go` as "CLI readline channel (bufio.Reader)". It has **no callers anywhere** — the live interactive CLI is `runAgentLoop` in `cmd/joshbot/main.go`. That mislabelling is what sent my own first diagnosis of #104 to the wrong file. `CLAUDE.md`'s channel summary said "CLI (readline)"; there is no readline.

## The measurement traps, now written down

Two distinct ways to get these numbers wrong, both encountered on this repo:

- A bare `find .` from the repo root descends into `.claude/worktrees/`, where agents keep entire copies of the repo. That alone reports **68,487** LOC instead of 22,813.
- `grep -rho` suppresses filenames, so a subsequent `grep -v /pkg/` silently filters nothing — this produced a wrong test count in an earlier pass.

The HARD RULE section now carries the exact scoped commands and a note to sanity-check exclusions by confirming the count changes when applied.

## Verification

Every figure above was measured independently rather than accepted from the agent that drafted the change — including catching that its own documented method returns 68,487 from the repo root.

Gates: `go build` · `go vet` · `gofmt -l` clean · `go test -race ./...` pass. Both site pages re-checked for well-formedness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)