### PR TITLE
chore: release v1.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.42.0] - 2026-07-26
+
 ### Added
 - **Interactive CLI progress indicators** — `joshbot agent` in interactive mode used to go silent for the whole ReAct loop (often 30–90s with tool calls), giving no signal the process was working, stuck, or dead. It now shows a single-line elapsed-time spinner while waiting on the model, and announces each tool call with a completion line and elapsed time (e.g. `⏺ shell(go test ./...)` / `⎿ ok (1.2s)`). Wired via an optional `agent.ProgressFunc` callback (nil by default — zero behaviour change for other callers) and gated on stdout being a real terminal, so piped and non-interactive output (`agent -m`, `scripts/verify-local.sh`) stays clean and undecorated.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -262,7 +262,7 @@ joshbot status
 ╔═══════════════════════════════════════════╗
 ║            joshbot status                ║
 ╚═══════════════════════════════════════════╝
-Version:        1.41.0
+Version:        1.42.0
 Config file:    ~/.joshbot/config.json (exists)
 Workspace:      ~/.joshbot/workspace (exists)
 Sessions:       ~/.joshbot/sessions


### PR DESCRIPTION
Cuts v1.42.0 — minor, since interactive CLI progress output is a user-visible capability.

Contents:
- #110 — Telegram no longer silently drops a reply whose formatting it rejected
- #111 — interactive CLI shows tool-call progress and a spinner
- #109 — every quoted number in the docs re-measured

Note: #109's changelog entry was silently lost when #110 merged (both edited the same `[Unreleased]` region and git auto-resolved in favour of one). It has been restored, so all three entries appear under this release.

Gates: `go build` · `go vet` · `gofmt -l` clean · `go test -race ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)