### PR TITLE
fix(install): create --bin-dir, fail loudly, verify before installing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,6 +495,7 @@ Documentation gate — a release does not go out with any of these unchecked:
 - [ ] `SECURITY.md` — matches what is actually enforced
 - [ ] `CLAUDE.md`, `AGENTS.md` — gotchas cover anything that would surprise an agent
 - [ ] `internal/skills/bundled/*/SKILL.md` — no instruction the tools no longer permit
+- [ ] `./scripts/test-install.sh` passes — not in CI (it downloads real artifacts), so it only runs if you run it
 - [ ] `CHANGELOG.md` — entry under `[Unreleased]`
 - [ ] Every quoted count or size re-measured, not carried over
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The installer failed silently when `--bin-dir` named a directory that did not exist** — it reported a successful download and checksum, then died on a bare `mv: No such file or directory` with nothing else printed. `--bin-dir` now creates the directory, including nested paths. Several other failure modes were mute or misleading for the same underlying reason: `--bin-dir` with no value exited on `shift 2` printing nothing at all, a read-only install directory passed the pre-flight check (which accepted a writable *parent*) and failed later at the `mv`, and a version with no matching build printed four raw URLs. Each now names what went wrong and what to do about it, and a single `EXIT` trap reports anything undiagnosed — previously `download_binary` installed its own cleanup trap, which silently replaced the error handler.
+
+### Changed
+- **The installer refuses to install an unverified binary** — a checksum *mismatch* already aborted, but missing or unfetchable checksums printed "No checksums available" and carried on installing. Verification being unavailable now fails closed, since every joshbot release publishes `checksums.txt` and its absence means the download path is not what it should be. `JOSHBOT_SKIP_CHECKSUM=1` overrides it deliberately. `scripts/test-install.sh` now exercises all of this against the real release — 16 checks covering directory creation, argument handling, overwrite protection, permissions and both checksum failure modes. It is not wired into CI, because it downloads published artifacts and would fail on a release that does not exist yet; run it by hand before tagging and after any change to `install.sh`.
+- **The installer writes the binary atomically** — it staged the download in `/tmp` and moved it across filesystems onto the target path, which is a copy rather than a rename, so an interruption could leave a truncated binary at the exact path the user runs. It now stages inside the install directory and renames, and reports that the existing installation was left untouched when a write fails.
+
 ## [1.45.2] - 2026-08-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ Then, before tagging — no code change ships without this:
 - [ ] `CLAUDE.md` / `AGENTS.md` — gotchas cover anything that would surprise an agent
 - [ ] `internal/skills/bundled/*/SKILL.md` — bundled skills do not instruct the agent to do something
       the tools no longer permit
+- [ ] `./scripts/test-install.sh` passes — not in CI (it downloads real artifacts), so it only runs if you run it
 - [ ] `CHANGELOG.md` — an entry exists under `[Unreleased]`
 - [ ] Any count or size quoted anywhere was re-measured, not carried over
 

--- a/cmd/joshbot/release_assets_test.go
+++ b/cmd/joshbot/release_assets_test.go
@@ -92,21 +92,50 @@ func TestInstallerMatchesReleaseAssetNaming(t *testing.T) {
 }
 
 // TestInstallerFailsClosedOnChecksumMismatch guards the security property that
-// a corrupted or tampered download aborts the install rather than warning.
+// a download which cannot be verified aborts the install rather than warning.
+//
+// This is a static check because the behavioural one needs the network: the
+// end-to-end coverage lives in scripts/test-install.sh, which is not run in CI.
+// It asserts the property rather than an exact sentence — the wording of these
+// messages is expected to change, the failing-closed is not.
 func TestInstallerFailsClosedOnChecksumMismatch(t *testing.T) {
 	install := readRepoFile(t, "install.sh")
 
-	idx := strings.Index(install, "Checksum mismatch")
-	if idx < 0 {
-		t.Fatal("install.sh no longer handles checksum mismatch")
+	// aborts reports whether the block introduced by marker stops the install.
+	// `die` is the script's abort helper; a bare `exit 1` also qualifies.
+	aborts := func(marker string) bool {
+		idx := strings.Index(strings.ToLower(install), strings.ToLower(marker))
+		if idx < 0 {
+			return false
+		}
+		// Start at the beginning of the marker's own line: the message is an
+		// argument to `die`, so the call itself sits before the marker text.
+		if lineStart := strings.LastIndex(install[:idx], "\n"); lineStart >= 0 {
+			idx = lineStart + 1
+		}
+		block := install[idx:]
+		if end := strings.Index(block, "\n    fi"); end > 0 {
+			block = block[:end]
+		}
+		return strings.Contains(block, "die ") || strings.Contains(block, "exit 1")
 	}
-	// Look at the handling block following the message.
-	tail := install[idx:]
-	if end := strings.Index(tail, "\n    fi"); end > 0 {
-		tail = tail[:end]
+
+	// A checksum that does not match: the download is corrupt or tampered with.
+	if !aborts("checksum mismatch") {
+		t.Error("install.sh must abort on a checksum mismatch, not warn and continue")
 	}
-	if !strings.Contains(tail, "exit 1") {
-		t.Errorf("install.sh must exit on checksum mismatch, not continue; got:\n%s", tail)
+
+	// Checksums that cannot be fetched at all. This used to print
+	// "No checksums available" and install anyway, which turned
+	// "verification unavailable" into "not verified".
+	if !aborts("could not fetch the release checksums") {
+		t.Error("install.sh must abort when the release checksums cannot be fetched")
+	}
+
+	// The override has to exist and be opt-in, so an operator who genuinely
+	// needs it is not stuck, and nobody gets it by accident.
+	if !strings.Contains(install, "JOSHBOT_SKIP_CHECKSUM") {
+		t.Error("install.sh should offer a documented override for the fail-closed check")
 	}
 }
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -66,14 +66,24 @@ curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | 
 ```
 
 This script will:
-1. Download the latest pre-built binary for your platform
-2. Verify the checksum
+1. Download the pre-built binary for your platform
+2. Verify it against the release checksums — and **refuse to install** if they
+   do not match, or cannot be fetched at all
 3. Install the binary to `~/.local/bin` (preferred) or `/usr/local/bin`
 
-For a specific version:
+For a specific version, or a different directory:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash -s -- -v v1.0.0
+curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash -s -- --version v1.45.2
+curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash -s -- --bin-dir ~/bin
 ```
+
+`--bin-dir` creates the directory if it does not exist. Re-running the script
+upgrades an existing installation in place; installing over an unrelated binary
+at the same path requires `--force`.
+
+Checksum verification fails closed: if the release checksums cannot be
+retrieved, the script installs nothing rather than continuing unverified. Set
+`JOSHBOT_SKIP_CHECKSUM=1` to override that, at your own risk.
 
 After installation, verify it works:
 

--- a/install.sh
+++ b/install.sh
@@ -13,8 +13,54 @@
 #   -f, --force            Overwrite existing installation
 #   -h, --help            Show this help message
 #
+# Environment:
+#   JOSHBOT_SKIP_CHECKSUM=1  Install even if the release checksums cannot be
+#                            fetched. Off by default: verification being
+#                            unavailable must not quietly become no verification.
+#
 
 set -e
+
+# Any unexpected failure must say something. Without this, `set -e` aborts the
+# script silently: `--bin-dir` with no value died on `shift 2` and printed
+# nothing at all, and a failed `mv` left only the raw mv error with no context.
+# TEMP_DIR is cleaned up by the single EXIT trap below. There must be exactly
+# one: a second `trap ... EXIT` silently replaces the first, and download_binary
+# used to install its own cleanup trap that removed this error reporting.
+TEMP_DIR=""
+HANDLED=false
+
+# die reports a diagnosed failure and stops. Every line is printed to stderr so
+# a caller piping stdout still sees why it failed.
+die() {
+    HANDLED=true
+    local line
+    for line in "$@"; do
+        echo "$line" >&2
+    done
+    exit 1
+}
+
+on_exit() {
+    local status=$?
+    [ -n "$TEMP_DIR" ] && rm -rf "$TEMP_DIR"
+    # Only for failures we did not diagnose ourselves. A `die` message is
+    # already actionable; appending "Installation failed" to it is noise.
+    if [ "$status" -ne 0 ] && [ "$HANDLED" != "true" ]; then
+        echo "" >&2
+        echo "Installation failed (exit $status)." >&2
+        echo "Report this at https://github.com/bigknoxy/joshbot/issues" >&2
+    fi
+    exit $status
+}
+trap on_exit EXIT
+
+# require_value exits with a usable message when a flag is missing its argument.
+require_value() {
+    if [ -z "${2:-}" ]; then
+        die "Error: $1 needs a value (e.g. $1 $3)"
+    fi
+}
 
 # Configuration
 REPO="bigknoxy/joshbot"
@@ -29,10 +75,12 @@ FORCE=false
 while [[ $# -gt 0 ]]; do
     case $1 in
         -b|--bin-dir)
+            require_value "--bin-dir" "${2:-}" "~/.local/bin"
             INSTALL_DIR="$2"
             shift 2
             ;;
         -v|--version)
+            require_value "--version" "${2:-}" "v1.45.2"
             VERSION="$2"
             shift 2
             ;;
@@ -54,12 +102,15 @@ Options:
     -f, --force            Overwrite existing installation
     -h, --help            Show this help message
 
+Environment:
+    JOSHBOT_SKIP_CHECKSUM=1  Install even if the release checksums cannot be
+                             fetched (not recommended)
+
 EOF
             exit 0
             ;;
         *)
-            echo "Unknown option: $1"
-            exit 1
+            die "Unknown option: $1" "Run with --help to see the available options."
             ;;
     esac
 done
@@ -112,8 +163,9 @@ get_latest_version() {
     version=$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" | grep -o '"tag_name": "[^"]*' | cut -d'"' -f4)
     
     if [ -z "$version" ]; then
-        echo "Error: Could not determine latest version" >&2
-        exit 1
+        die "Error: could not determine the latest joshbot version." \
+            "GitHub may be unreachable, or rate-limiting this address." \
+            "Retry, or pin a version with --version (e.g. --version v1.45.2)."
     fi
     
     echo "$version"
@@ -122,6 +174,14 @@ get_latest_version() {
 # Determine install directory
 get_install_dir() {
     if [ -n "$INSTALL_DIR" ]; then
+        # Create it. An explicit --bin-dir that does not exist yet is a normal
+        # request, not an error — and leaving it missing meant the install died
+        # on a raw "mv: No such file or directory" after already reporting a
+        # successful download and checksum.
+        if [ ! -d "$INSTALL_DIR" ] && ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+            die "Error: could not create install directory: ${INSTALL_DIR}" \
+                "Choose a writable location with --bin-dir, or create it first."
+        fi
         echo "$INSTALL_DIR"
         return
     fi
@@ -188,10 +248,11 @@ download_binary() {
     
     echo "Downloading joshbot ${version} for ${os}/${arch}..."
     
-    # Create temp directory
+    # Create temp directory. Cleanup is handled by the single EXIT trap; adding
+    # one here would replace it and lose the failure message.
     local temp_dir
     temp_dir=$(mktemp -d)
-    trap "rm -rf $temp_dir" EXIT
+    TEMP_DIR="$temp_dir"
     
     # Try to download archive first, fall back to raw binary
     local use_archive=false
@@ -224,12 +285,17 @@ download_binary() {
                     downloaded_file="$dest2"
                     echo "  ✓ Binary downloaded: $(basename "$dest2")"
                 else
-                    echo "Error: Failed to download joshbot ${version} for ${os}/${arch}" >&2
-                    echo "Tried:" >&2
+                    echo "Error: no joshbot ${version} build for ${os}/${arch}." >&2
+                    echo "" >&2
+                    echo "Check that the release exists and publishes this platform:" >&2
+                    echo "  https://github.com/${REPO}/releases/tag/${version}" >&2
+                    echo "" >&2
+                    echo "URLs tried:" >&2
                     echo "  - ${binary_url_v}" >&2
                     echo "  - ${archive_url}" >&2
                     echo "  - ${binary_url}" >&2
                     echo "  - ${binary_url_alt}" >&2
+                    HANDLED=true
                     exit 1
                 fi
             fi
@@ -265,16 +331,28 @@ download_binary() {
             if [ "$checksum" = "$actual_checksum" ]; then
                 echo "  ✓ Checksum verified"
             else
-                echo "Error: Checksum mismatch — download may be corrupted or tampered with" >&2
-                echo "Expected: $checksum" >&2
-                echo "Actual:   $actual_checksum" >&2
-                exit 1
+                die "Error: checksum mismatch — the download is corrupted or tampered with." \
+                    "Expected: $checksum" \
+                    "Actual:   $actual_checksum" \
+                    "Nothing was installed."
             fi
         else
-            echo "  Checksum not found in release"
+            die "Error: ${downloaded_basename} is not listed in the release checksums." \
+                "Refusing to install a binary that cannot be verified." \
+                "Set JOSHBOT_SKIP_CHECKSUM=1 to override, at your own risk."
         fi
     else
-        echo "  No checksums available"
+        # Fail closed. Every joshbot release publishes checksums.txt, so its
+        # absence means the download path is not what it should be — and
+        # "verification unavailable" must never quietly become "not verified".
+        if [ "${JOSHBOT_SKIP_CHECKSUM:-}" = "1" ]; then
+            echo "  ! Checksums unavailable — continuing because JOSHBOT_SKIP_CHECKSUM=1"
+        else
+            die "Error: could not fetch the release checksums from:" \
+                "  ${checksum_url}" \
+                "Refusing to install an unverified binary." \
+                "Set JOSHBOT_SKIP_CHECKSUM=1 to override, at your own risk."
+        fi
     fi
     
     # Extract or prepare binary
@@ -297,8 +375,8 @@ download_binary() {
     
     # Check if binary exists
     if [ ! -f "$binary" ]; then
-        echo "Error: Failed to locate binary after download" >&2
-        exit 1
+        die "Error: could not find the joshbot binary after download." \
+            "The release layout may have changed; please report this."
     fi
     
     # Make executable
@@ -311,8 +389,8 @@ download_binary() {
     fi
     
     if [ -f "$target" ] && [ "$FORCE" = "false" ] && [ -z "$current_version" ]; then
-        echo "Error: Binary already exists at ${target}. Use --force to overwrite." >&2
-        exit 1
+        die "Error: joshbot is already installed at ${target}." \
+            "Re-run with --force to overwrite it."
     fi
     
     # Force overwrite during upgrade
@@ -321,12 +399,27 @@ download_binary() {
     fi
     
     if [ -f "$target" ] && [ "$FORCE" = "false" ]; then
-        echo "Error: Binary already exists at ${target}. Use --force to overwrite." >&2
-        exit 1
+        die "Error: joshbot is already installed at ${target}." \
+            "Re-run with --force to overwrite it."
     fi
     
-    # Move binary to install directory
-    mv -f "$binary" "$target"
+    # Stage inside the install directory, then rename over the target.
+    #
+    # A direct mv from the temp dir is a cross-filesystem copy, which is not
+    # atomic: an interrupted install would leave a truncated binary at the very
+    # path the user runs. A rename within one directory is atomic, so the target
+    # is either the old binary or the complete new one.
+    local staged="${target}.new-$$"
+    if ! cp -f "$binary" "$staged"; then
+        die "Error: could not write to ${install_dir}." \
+            "The existing joshbot, if any, was left untouched."
+    fi
+    chmod +x "$staged"
+    if ! mv -f "$staged" "$target"; then
+        rm -f "$staged"
+        die "Error: could not install to ${target}." \
+            "The existing joshbot, if any, was left untouched."
+    fi
     
     echo ""
     if [ -n "$current_version" ]; then
@@ -369,11 +462,15 @@ main() {
         echo "Installing to: ${install_dir} (upgrading)"
     fi
     
-    # Check write permission to install directory
-    if [ ! -w "$install_dir" ] && [ ! -w "$(dirname "$install_dir")" ]; then
-        echo "Error: No write permission to install directory: ${install_dir}" >&2
-        echo "Try running with sudo or use --bin-dir to specify a writable location" >&2
-        exit 1
+    # Check write permission on the directory we will actually write into.
+    #
+    # This used to also accept a writable *parent*, which is not the same thing:
+    # a read-only install dir inside a writable parent passed the check and then
+    # failed at the mv with a bare "Permission denied".
+    if [ ! -w "$install_dir" ]; then
+        die "Error: no write permission for install directory: ${install_dir}" \
+            "Re-run with --bin-dir pointing somewhere writable (e.g. ~/.local/bin)," \
+            "or with sudo if you meant to install system-wide."
     fi
     
     download_binary "$version" "$os" "$arch" "$install_dir" "$current_version"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Exercises install.sh against the real GitHub release.
+#
+# Not run in CI: it downloads published artifacts, so it needs the network and
+# it would fail on a release that has not been published yet. Run it by hand
+# before tagging, and after any change to install.sh.
+#
+# Usage: ./scripts/test-install.sh [version]
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALLER="${SCRIPT_DIR}/install.sh"
+VERSION="${1:-}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+check() {
+    local name="$1" got="$2" want="$3"
+    if [ "$got" = "$want" ]; then
+        printf '  PASS  %s\n' "$name"
+        pass=$((pass + 1))
+    else
+        printf '  FAIL  %s (got %q, want %q)\n' "$name" "$got" "$want"
+        fail=$((fail + 1))
+    fi
+}
+
+run() {
+    if [ -n "$VERSION" ]; then
+        bash "$INSTALLER" --version "$VERSION" "$@" >/dev/null 2>&1
+    else
+        bash "$INSTALLER" "$@" >/dev/null 2>&1
+    fi
+}
+
+echo "Testing $INSTALLER"
+
+# The bug this suite exists for: --bin-dir naming a directory that does not
+# exist reported a successful download and then died on a bare mv error.
+run --bin-dir "$WORK/new/nested/bin"
+check "creates a nested --bin-dir" "$?" "0"
+check "  binary is installed and executable" \
+    "$(test -x "$WORK/new/nested/bin/joshbot" && echo yes)" "yes"
+check "  binary runs" \
+    "$("$WORK/new/nested/bin/joshbot" --version >/dev/null 2>&1 && echo yes)" "yes"
+
+# Argument handling must never fail mutely.
+run --bin-dir
+check "--bin-dir with no value fails" "$?" "1"
+run --version
+check "--version with no value fails" "$?" "1"
+run --not-a-flag
+check "unknown flag fails" "$?" "1"
+bash "$INSTALLER" --help >/dev/null 2>&1
+check "--help exits clean" "$?" "0"
+
+# Overwrite protection.
+run --bin-dir "$WORK/new/nested/bin"
+check "reinstalling without --force refuses" "$?" "1"
+run --bin-dir "$WORK/new/nested/bin" --force
+check "reinstalling with --force succeeds" "$?" "0"
+
+# Permission and availability failures.
+mkdir -p "$WORK/readonly" && chmod 500 "$WORK/readonly"
+run --bin-dir "$WORK/readonly"
+check "unwritable install dir fails" "$?" "1"
+chmod 700 "$WORK/readonly"
+
+bash "$INSTALLER" --bin-dir "$WORK/absent" --version v99.99.99 >/dev/null 2>&1
+check "a release with no build fails" "$?" "1"
+
+# Verification must fail closed: unreachable checksums install nothing.
+sed "s#https://github.com/\${REPO}/releases/download/\${version}/checksums.txt#file:///nonexistent/checksums.txt#" \
+    "$INSTALLER" > "$WORK/nochecksum.sh"
+bash "$WORK/nochecksum.sh" --bin-dir "$WORK/unverified" >/dev/null 2>&1
+check "unfetchable checksums refuse to install" "$?" "1"
+check "  and install nothing" \
+    "$(ls "$WORK/unverified" 2>/dev/null | wc -l | tr -d ' ')" "0"
+JOSHBOT_SKIP_CHECKSUM=1 bash "$WORK/nochecksum.sh" --bin-dir "$WORK/override" >/dev/null 2>&1
+check "JOSHBOT_SKIP_CHECKSUM=1 overrides deliberately" "$?" "0"
+
+# A wrong checksum must abort rather than install.
+printf '%064d  joshbot_v0.0.0_any\n' 0 > "$WORK/wrong.txt"
+sed "s#https://github.com/\${REPO}/releases/download/\${version}/checksums.txt#file://$WORK/wrong.txt#" \
+    "$INSTALLER" > "$WORK/mismatch.sh"
+bash "$WORK/mismatch.sh" --bin-dir "$WORK/tampered" >/dev/null 2>&1
+check "a checksum mismatch refuses to install" "$?" "1"
+check "  and installs nothing" \
+    "$(ls "$WORK/tampered" 2>/dev/null | wc -l | tr -d ' ')" "0"
+
+echo
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Found by dogfooding: `--bin-dir` naming a directory that does not exist reported a successful download **and a verified checksum**, then died on a bare `mv: No such file or directory`. Nothing else was printed.

```
Downloading joshbot v1.45.2 for linux/amd64...
  ✓ Checksum verified
Installing to .../bin...
mv: cannot move '/tmp/tmp.79otVp1AFa/joshbot_v1.45.2_linux_amd64' to '.../bin/joshbot': No such file or directory
```

`--bin-dir` now creates the directory, including nested paths.

## The same root cause, three more times

Nothing translated a failure into an explanation:

| Case | Before | Now |
|---|---|---|
| `--bin-dir` with no value | died on `shift 2`, **printed nothing at all** | names the flag and shows an example |
| read-only install dir | passed pre-flight (it accepted a writable *parent*), failed later at `mv` | refuses up front, suggests `--bin-dir` or sudo |
| version with no build | dumped four raw URLs | names the release and links its tag page |

All routed through one `die` helper, with a single `EXIT` trap for anything undiagnosed. **There must be exactly one such trap** — `download_binary` installed its own cleanup trap, which silently replaced the error handler meant to catch these.

## Two that were not cosmetic

**Verification failed open.** A checksum *mismatch* aborted correctly, but missing or unfetchable checksums printed `No checksums available` and carried on installing. Every release publishes `checksums.txt`, so its absence means the download path is not what it should be. Now fails closed; `JOSHBOT_SKIP_CHECKSUM=1` overrides deliberately.

**The install was not atomic.** The binary was staged in `/tmp` and moved *across filesystems* onto the target — a copy, not a rename — so an interruption could leave a truncated binary at the exact path the user runs. Now staged inside the install directory and renamed.

## Verification

`scripts/test-install.sh` — 16 checks against the real release, covering directory creation, argument handling, overwrite protection, permissions, and both checksum failure modes.

```
  16 passed, 0 failed
```

Reverting just the `--bin-dir` fix fails 5 of them, so it is a real reproducer rather than a suite that passes by construction.

**Deliberately not in CI:** it downloads published artifacts, so it needs the network and would fail on a release that has not been tagged yet. It is a pre-release checklist item in `CLAUDE.md` and `AGENTS.md` instead — flagged here because a test nobody runs is worse than no test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)