### PR TITLE
chore: release v1.45.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.45.3] - 2026-08-09
+
 ### Fixed
 - **The installer failed silently when `--bin-dir` named a directory that did not exist** — it reported a successful download and checksum, then died on a bare `mv: No such file or directory` with nothing else printed. `--bin-dir` now creates the directory, including nested paths. Several other failure modes were mute or misleading for the same underlying reason: `--bin-dir` with no value exited on `shift 2` printing nothing at all, a read-only install directory passed the pre-flight check (which accepted a writable *parent*) and failed later at the `mv`, and a version with no matching build printed four raw URLs. Each now names what went wrong and what to do about it, and a single `EXIT` trap reports anything undiagnosed — previously `download_binary` installed its own cleanup trap, which silently replaced the error handler.
 


### PR DESCRIPTION
Patch release. Cuts `[Unreleased]` as `1.45.3`.

All from #167, found by dogfooding:

- `--bin-dir` naming a directory that did not exist reported a successful download and verified checksum, then died on a bare `mv` error. It now creates the directory.
- `--bin-dir` with no value printed nothing at all; a read-only install dir passed pre-flight and failed later; a version with no build dumped four raw URLs. All now diagnose themselves.
- Verification failed open: missing or unfetchable checksums installed anyway. Now fails closed, with `JOSHBOT_SKIP_CHECKSUM=1` as a deliberate override.
- The binary was moved across filesystems onto the target path — a copy, not a rename — so an interruption could leave a truncated binary where the user runs it. Now staged in the install directory and renamed.

`scripts/test-install.sh` (16 checks) passes; it is not in CI because it downloads published artifacts.

No code changes in this PR beyond the CHANGELOG heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)