### PR TITLE
chore(release): cut v1.47.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-joshbot is a lightweight personal AI assistant (~30,100 LOC Go non-test, 1,330 test functions across 114 test files — measured 2026-08-10) with self-learning memory, auto-skill-creation from tool usage patterns, and Telegram and Discord integration. Architecture: goroutine-based message bus decoupling chat channels from a ReAct agent loop backed by multi-provider LLM via OpenRouter-compatible APIs.
+joshbot is a lightweight personal AI assistant (~31,200 LOC Go non-test, 1,377 test functions across 121 test files — measured 2026-08-10) with self-learning memory, auto-skill-creation from tool usage patterns, and Telegram and Discord integration. Architecture: goroutine-based message bus decoupling chat channels from a ReAct agent loop backed by multi-provider LLM via OpenRouter-compatible APIs.
 
 Module: `github.com/bigknoxy/joshbot`. Go 1.24.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.47.0] - 2026-08-10
+
 ### ⚠️ Breaking
 - **Telegram: an empty `allow_from` now denies every sender** (previously it allowed everyone). A bot with no allowlist handed anyone on the internet a direct line into an agent loop holding the shell tool. `IsAllowed` now fails closed on an empty allowlist and `Start` logs a loud warning naming the exact key to set (`channels.telegram.allow_from`, or the comma-separated `JOSHBOT_CHANNELS__TELEGRAM__ALLOW_FROM` env override; Discord has the matching `channels.discord.allow_from` / `JOSHBOT_CHANNELS__DISCORD__ALLOW_FROM`). **If you relied on an open bot, add your numeric Telegram user ID to `allow_from` or it will reject all messages.** The new Discord channel enforces the same fail-closed rule.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # joshbot — Architect's Guide
 
-joshbot is a self-hosted Go personal AI assistant (~30.1K LOC non-test, 1,330 test functions across 114 test files — measured 2026-08-10). Single binary, zero runtime deps.
+joshbot is a self-hosted Go personal AI assistant (~31.2K LOC non-test, 1,377 test functions across 121 test files — measured 2026-08-10). Single binary, zero runtime deps.
 
 **`AGENTS.md` (repo root) is the full agent guide** — key interfaces, code style, naming, concurrency and logging patterns, complete gotchas list. Read it before non-trivial work. This file is the quick index.
 


### PR DESCRIPTION
## What

Closes the `[Unreleased]` CHANGELOG section as `## [1.47.0] - 2026-08-10` and opens a fresh empty `[Unreleased]` above it.

Also re-measures the counts quoted in `CLAUDE.md` and `AGENTS.md` instead of carrying the previous release's numbers forward, per the "No unverifiable numbers" rule:

| Claim | Was | Now |
|---|---|---|
| LOC (non-test) | ~30.1K | ~31.2K |
| Test functions | 1,330 | 1,377 |
| Test files | 114 | 121 |
| Binary (darwin/arm64) | ~19MB | 18.8MB — claim still holds, unchanged |

## What ships in 1.47.0

- ⚠️ Breaking: Telegram/Discord empty `allow_from` now denies every sender; the default shell allowlist drops `find`/`go`/`git`/`rg`/`sort` and refuses redirection.
- Human approval gate for shell commands (#130)
- `api_key_env` credentials and `joshbot preflight` (#128)
- MCP servers actually started by `cmd/joshbot`
- Agent-friendly CLI parity (#144, #148, #149)

## Pre-release checklist

- [x] `go build ./cmd/joshbot`, `go vet ./...`, `gofmt -l .` empty, `go test -race ./...` all green
- [x] Every quoted count/size re-measured
- [x] README.md, docs/INSTALL.md, SECURITY.md, site/*.html, AGENTS.md/CLAUDE.md gotchas and bundled SKILL.md files were updated in the PRs that changed the behaviour

Tag `v1.47.0` goes on main after CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)