### PR TITLE
chore(release): cut v1.47.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.47.1] - 2026-08-10
+
 ### Fixed
 - **The release Docker image failed to build after the stale `pkg/` duplicate was deleted** — `Dockerfile` still ran `COPY pkg/ ./pkg/`, so the v1.47.0 Docker job died with `"/pkg": not found` after the tag had already been pushed and every platform binary had shipped. The image is now built on every pull request (`docker-build` in `.github/workflows/ci.yml`, one platform, no push), so a Dockerfile that drifts from the tree fails on the PR instead of at release time.
 


### PR DESCRIPTION
## What

Closes `[Unreleased]` as `## [1.47.1] - 2026-08-10`.

Patch release with one purpose: publish the Docker image that `v1.47.0` never got. The `v1.47.0` tag still carries the Dockerfile with the stale `COPY pkg/ ./pkg/`, so re-running that release's Docker job fails identically — a new tag off fixed main is the only route.

Contents: the #182 fix (drop the stale copy, build the image on every PR via `docker-build`). No code change beyond that.

## Verification

`docker-build` has now passed on two PRs (#182, #183) exercising the exact `COPY` sequence that failed at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)