### PR TITLE
docs: lead with the single-binary wedge on README and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@
 
 A lightweight personal AI assistant written in Go, featuring self-learning memory, skill self-creation, subagent delegation, and Telegram integration. Inspired by [nanobot](https://github.com/HKUDS/nanobot).
 
+**One ~17MB static binary. No Python, no venv, no Docker daemon, no runtime dependencies.** Self-hosted — your conversations and API keys stay on your machine.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash
+joshbot onboard   # pick a model, paste an API key
+joshbot agent     # start chatting
+```
+
 ## Features
 
 - **Self-Learning Memory** - Automatically remembers important facts across conversations using a structured fact system (categorized with SHA256-based IDs, confidence scoring, source tracking, and deduplication)

--- a/site/index.html
+++ b/site/index.html
@@ -419,7 +419,7 @@ footer a:hover { text-decoration: underline; }
 <section class="hero">
   <div class="prompt-symbol">$ _</div>
   <h1>your <span class="highlight">personal</span><br>AI <span class="highlight-green">agent</span></h1>
-  <p class="tagline">joshbot is a lightweight, self-learning AI assistant that lives in your terminal. Memory, skills, tool use, Telegram — everything you need, nothing you don't.</p>
+  <p class="tagline">A single ~17MB Go binary. No Python, no venv, no Docker daemon, no runtime dependencies. Self-hosted — your conversations and API keys stay on your machine.</p>
   <div class="actions">
     <a href="https://github.com/bigknoxy/joshbot#quick-start" class="btn btn-primary">Install Now</a>
     <a href="#how" class="btn btn-secondary">How It Works</a>
@@ -435,6 +435,7 @@ footer a:hover { text-decoration: underline; }
       joshbot — interactive session
     </div>
     <div class="term-body">
+      <div class="line"><span class="prompt">$</span> curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash</div>
       <div class="line"><span class="prompt">$</span> joshbot agent</div>
       <div class="line"><span class="prompt">></span> what was that article about Go concurrency patterns?</div>
       <div class="line output amber">[memory_search] Found 3 relevant facts...</div>
@@ -568,7 +569,7 @@ footer a:hover { text-decoration: underline; }
 <section class="cta-section">
   <div class="section-label">Get Started</div>
   <h2>One command to install</h2>
-  <p class="subtitle" style="margin: 0 auto 1rem;">Open source, MIT licensed. Your data stays on your machine.</p>
+  <p class="subtitle" style="margin: 0 auto 1rem;">Open source, MIT licensed. A single ~17MB binary — no Python, no Docker, no runtime deps. Your data stays on your machine.</p>
   <div class="install-code">
     curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash
     <button class="copy-btn" onclick="navigator.clipboard.writeText('curl -fsSL https://raw.githubusercontent.com/bigknoxy/joshbot/main/install.sh | bash');this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',2000)">Copy</button>


### PR DESCRIPTION
## Summary

Follow-up to the panel review on #175. The OSS-growth expert's finding: the README opened with a feature list (converts people who already want a thing), while the actual differentiator — a single ~17MB static Go binary, no Python/venv/Docker/runtime deps, curl-to-running — was buried below the fold and only in the GitHub description.

This PR surfaces the wedge on the first screen of both the README and the site:

- **README**: a one-line wedge + copy-paste `install → onboard → agent` block right after the intro, before the feature list.
- **site/index.html**: the hero tagline now states the wedge; the terminal demo opens with the `curl | bash` install line; the CTA subtitle repeats it.

Docs-only change — no code touched. The site nav stays in sync (untouched).

## Verification
- `go build ./...` clean (no code changed).
- HTML tag balance checked; nav links in sync between `index.html` and `architecture.html`.