### PR TITLE
chore(release): cut v1.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.50.0] - 2026-08-12
+
 ### Added
 - Dream two-stage memory consolidation is now reachable (#193). The subsystem
   was fully implemented in `internal/memory/dream.go` and wired to nothing — no


### PR DESCRIPTION
Stamps the `[Unreleased]` entries (## 193 Dream wiring, ## 194 subagent delegation + leaf-role enforcement, ## 220 JSON error doc, ## 216 coverage) under a v1.50.0 section and opens a fresh empty `[Unreleased]`.\n\nNo code changes. The tag will be cut after this merges and CI is green.