### PR TITLE
docs: cut CHANGELOG section for v1.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.51.0] - 2026-08-12
+
 ### Added
 - **OpenAI-compatible HTTP API** (#202). `joshbot serve` exposes
   `POST /v1/chat/completions` (with SSE streaming) and `GET /v1/models`, so any


### PR DESCRIPTION
Moves the accumulated `[Unreleased]` entries under a `[1.51.0]` heading ahead of tagging. No code change.

Headline items in the release: the OpenAI-compatible HTTP API (#202) and the subagent fan-out cap (#228).

🤖 Generated with [Claude Code](https://claude.com/claude-code)