### PR TITLE
docs: cut CHANGELOG section for v1.52.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-joshbot is a lightweight personal AI assistant (~31,200 LOC Go non-test, 1,377 test functions across 121 test files — measured 2026-08-10) with self-learning memory, auto-skill-creation from tool usage patterns, and Telegram and Discord integration. Architecture: goroutine-based message bus decoupling chat channels from a ReAct agent loop backed by multi-provider LLM via OpenRouter-compatible APIs.
+joshbot is a lightweight personal AI assistant (~38,300 LOC Go non-test, 2,113 test functions across 234 test files — measured 2026-08-13) with self-learning memory, auto-skill-creation from tool usage patterns, and Telegram and Discord integration. Architecture: goroutine-based message bus decoupling chat channels from a ReAct agent loop backed by multi-provider LLM via OpenRouter-compatible APIs.
 
 Module: `github.com/bigknoxy/joshbot`. Go 1.24.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.52.0] - 2026-08-13
+
 ### Added
 - **`agents.defaults.timeout` bounds one agent turn** (#241). It was hardcoded at
   2 minutes with no config key, which is wrong for exactly the deployment that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # joshbot — Architect's Guide
 
-joshbot is a self-hosted Go personal AI assistant (~31.2K LOC non-test, 1,377 test functions across 121 test files — measured 2026-08-10). Single binary, zero runtime deps.
+joshbot is a self-hosted Go personal AI assistant (~38.3K LOC non-test, 2,113 test functions across 234 test files — measured 2026-08-13). Single binary, zero runtime deps.
 
 **`AGENTS.md` (repo root) is the full agent guide** — key interfaces, code style, naming, concurrency and logging patterns, complete gotchas list. Read it before non-trivial work. This file is the quick index.
 

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -329,7 +329,7 @@ footer a:hover { text-decoration: underline; }
 <div class="container">
   <div class="page-hero">
     <h1>Architecture</h1>
-    <div class="meta"><span>joshbot</span> &middot; Go 1.24 &middot; ~29,000 LOC non-test &middot; 1,284 test functions</div>
+    <div class="meta"><span>joshbot</span> &middot; Go 1.24 &middot; ~38,300 LOC non-test &middot; 2,113 test functions</div>
   </div>
 
   <section>
@@ -435,7 +435,7 @@ footer a:hover { text-decoration: underline; }
     <p>The project follows Go conventions with <code>cmd/</code> for the entry point and <code>internal/</code> for all implementation packages.</p>
 
     <div class="file-tree">joshbot/
-├── <span class="dir">cmd/joshbot/</span>       <span class="highlight">← CLI entry point, service wiring (~5,920 LOC)</span>
+├── <span class="dir">cmd/joshbot/</span>       <span class="highlight">← CLI entry point, service wiring (~8,040 LOC)</span>
 │   ├── main.go             entry point, flags, gateway
 │   ├── editor.go           raw-mode line editor for the interactive CLI (Tab completion, history, multiline)
 │   ├── terminal.go         ANSI key parsing + raw-mode helpers for the editor


### PR DESCRIPTION
Release prep for v1.52.0.

- Cuts the `[Unreleased]` section to `[1.52.0] - 2026-08-13`.
- Re-measures every count quoted in the docs. `site/architecture.html` was the
  worst drift: 1,284 test functions claimed against 2,113 actual, and ~29,000
  LOC against ~38,300.

Contents of the release: the config duration fix (#240, #241), the API error
redaction fix (#238), the session concurrency fix (#236), and the
`MultiProvider.parseModel` data race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)