### PR TITLE
Fix checkpoint save error handling (issue #244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Hitting the max iteration limit no longer tells you to type `/resume` when the
+  checkpoint was not persisted. The save error was discarded, so a failed write
+  still produced the suggestion and `/resume` then answered "No checkpoint
+  found" with the interrupted task gone and no error anywhere. The failure is
+  now logged with the session id, and the suggestion is withheld both when the
+  save fails and when there is no session manager at all. (#244)
+
 ## [1.52.0] - 2026-08-13
 
 ### Added

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -789,7 +789,14 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 	a.logger.Warn("Hit max iterations", "max", a.maxIterations)
 
 	// Persist a checkpoint marker in the session for /resume detection.
-	var checkpointSaveErr error
+	//
+	// checkpointSaved gates the `/resume` suggestion, and it is a bool rather
+	// than a nil error check because there are two ways not to have a
+	// checkpoint: the save failed, or there is no session manager at all. A
+	// `err == nil` gate reads the second case as success and offers `/resume`,
+	// which then answers "session manager not initialized" — the same dead end
+	// the discarded error caused (#244).
+	checkpointSaved := false
 	if a.sessions != nil {
 		sess.Checkpoint = &session.Checkpoint{
 			Iteration:     a.maxIterations,
@@ -799,16 +806,17 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 		}
 		// Save the session so the checkpoint survives across requests.
 		saveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		checkpointSaveErr = a.sessions.Save(saveCtx, sess)
+		err := a.sessions.Save(saveCtx, sess)
 		cancel()
-		if checkpointSaveErr != nil {
-			a.logger.Error("Failed to save checkpoint", "session", sess.ID, "error", checkpointSaveErr)
+		if err != nil {
+			a.logger.Error("Failed to save checkpoint", "session", sess.ID, "error", err)
 		}
+		checkpointSaved = err == nil
 	}
 
-	respBase := "I've been working on this for a while. Here's what I found so far.\n\n⚠️ Hit the max iteration limit (%d)."
-	resp := fmt.Sprintf(respBase, a.maxIterations)
-	if checkpointSaveErr == nil {
+	resp := fmt.Sprintf("I've been working on this for a while. Here's what I found so far.\n\n"+
+		"⚠️ Hit the max iteration limit (%d).", a.maxIterations)
+	if checkpointSaved {
 		resp += "\nTo continue, type `/resume` and I'll pick up where we left off."
 	}
 	return resp, nil

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -789,6 +789,7 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 	a.logger.Warn("Hit max iterations", "max", a.maxIterations)
 
 	// Persist a checkpoint marker in the session for /resume detection.
+	var checkpointSaveErr error
 	if a.sessions != nil {
 		sess.Checkpoint = &session.Checkpoint{
 			Iteration:     a.maxIterations,
@@ -798,13 +799,18 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 		}
 		// Save the session so the checkpoint survives across requests.
 		saveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		_ = a.sessions.Save(saveCtx, sess)
+		checkpointSaveErr = a.sessions.Save(saveCtx, sess)
 		cancel()
+		if checkpointSaveErr != nil {
+			a.logger.Error("Failed to save checkpoint", "session", sess.ID, "error", checkpointSaveErr)
+		}
 	}
 
-	resp := fmt.Sprintf("I've been working on this for a while. Here's what I found so far.\n\n"+
-		"⚠️ Hit the max iteration limit (%d).\n"+
-		"To continue, type `/resume` and I'll pick up where we left off.", a.maxIterations)
+	respBase := "I've been working on this for a while. Here's what I found so far.\n\n⚠️ Hit the max iteration limit (%d)."
+	resp := fmt.Sprintf(respBase, a.maxIterations)
+	if checkpointSaveErr == nil {
+		resp += "\nTo continue, type `/resume` and I'll pick up where we left off."
+	}
 	return resp, nil
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -88,7 +88,11 @@ func (m *mockToolExecutor) GetSchemas() []providers.Tool {
 // mockSessionManager is a mock session manager for testing.
 type mockSessionManager struct {
 	sessions map[string]*session.Session
-	mu       sync.Mutex
+	// saveErr, when set, makes every Save fail. Persistence failure is not
+	// reachable through the real manager without breaking the filesystem, and
+	// the checkpoint path branches on it (#244).
+	saveErr error
+	mu      sync.Mutex
 }
 
 func newMockSessionManager() *mockSessionManager {
@@ -113,6 +117,9 @@ func (m *mockSessionManager) GetOrCreate(ctx context.Context, key string) (*sess
 func (m *mockSessionManager) Save(ctx context.Context, sess *session.Session) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.saveErr != nil {
+		return m.saveErr
+	}
 	m.sessions[sess.ID] = sess
 	return nil
 }

--- a/internal/agent/resume_test.go
+++ b/internal/agent/resume_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -233,4 +234,104 @@ func TestResumeCommand_RealSessionManager(t *testing.T) {
 	if !strings.Contains(resp, "Resuming from checkpoint") {
 		t.Errorf("expected 'Resuming from checkpoint' in response, got: %s", resp)
 	}
+}
+
+// iterationLimitAgent builds an agent whose provider never stops calling tools,
+// so reactLoop always reaches the max-iteration checkpoint path.
+func iterationLimitAgent(t *testing.T, sm SessionManager) *Agent {
+	t.Helper()
+	InvalidatePromptCache()
+	cfg := config.Defaults()
+	cfg.Agents.Defaults.Workspace = t.TempDir()
+
+	tc := providers.ToolCall{
+		ID:   "tc_1",
+		Type: "function",
+		Function: providers.FunctionCall{
+			Name:      "shell",
+			Arguments: `{"command":"echo test"}`,
+		},
+	}
+	provider := &scriptedProvider{
+		turns: []scriptedTurn{
+			{toolCalls: []providers.ToolCall{tc}},
+			{toolCalls: []providers.ToolCall{tc}},
+			{toolCalls: []providers.ToolCall{tc}},
+		},
+	}
+	agent := NewAgent(cfg, provider, &mockToolExecutor{}, sm, newMockLogger())
+	agent.SetMaxIterations(2)
+	return agent
+}
+
+// TestIterationLimitOffersResumeOnlyWhenCheckpointPersisted is the #244
+// regression. The reply told the user to type /resume even when the checkpoint
+// save had failed, and /resume then answered "No checkpoint found" — the
+// interrupted task was gone with no error anywhere. The suggestion must track
+// whether the checkpoint actually landed.
+func TestIterationLimitOffersResumeOnlyWhenCheckpointPersisted(t *testing.T) {
+	const resumeHint = "/resume"
+
+	t.Run("saved", func(t *testing.T) {
+		sm := newMockSessionManager()
+		agent := iterationLimitAgent(t, sm)
+
+		resp, err := agent.Process(context.Background(), bus.InboundMessage{
+			SenderID: "user", Channel: "cli", Content: "loop forever", Timestamp: time.Now(),
+		})
+		if err != nil {
+			t.Fatalf("Process returned %v", err)
+		}
+		if !strings.Contains(resp, "max iteration limit") {
+			t.Fatalf("expected the iteration-limit reply, got: %s", resp)
+		}
+		if !strings.Contains(resp, resumeHint) {
+			t.Errorf("checkpoint saved, so the reply must offer %s; got: %s", resumeHint, resp)
+		}
+	})
+
+	t.Run("save fails", func(t *testing.T) {
+		sm := newMockSessionManager()
+		agent := iterationLimitAgent(t, sm)
+		sm.mu.Lock()
+		sm.saveErr = errors.New("disk full")
+		sm.mu.Unlock()
+
+		resp, err := agent.Process(context.Background(), bus.InboundMessage{
+			SenderID: "user", Channel: "cli", Content: "loop forever", Timestamp: time.Now(),
+		})
+		if err != nil {
+			t.Fatalf("Process returned %v", err)
+		}
+		if !strings.Contains(resp, "max iteration limit") {
+			t.Fatalf("expected the iteration-limit reply, got: %s", resp)
+		}
+		if strings.Contains(resp, resumeHint) {
+			t.Errorf("checkpoint save failed, so the reply must not offer %s; got: %s", resumeHint, resp)
+		}
+	})
+
+	// No session manager at all is the second way not to have a checkpoint. An
+	// `err == nil` gate reads it as success, and /resume then answers "session
+	// manager not initialized" — the same dead end as a failed save.
+	t.Run("no session manager", func(t *testing.T) {
+		sm := newMockSessionManager()
+		agent := iterationLimitAgent(t, sm)
+		sess, err := sm.GetOrCreate(context.Background(), "cli:user")
+		if err != nil {
+			t.Fatalf("GetOrCreate: %v", err)
+		}
+		agent.sessions = nil
+
+		resp, err := agent.reactLoop(context.Background(), nil, sess, "cli", "user", "loop forever", &compactionState{})
+		if err != nil {
+			t.Fatalf("reactLoop returned %v", err)
+		}
+		if !strings.Contains(resp, "max iteration limit") {
+			t.Fatalf("expected the iteration-limit reply, got: %s", resp)
+		}
+		if strings.Contains(resp, resumeHint) {
+			t.Errorf("no session manager, so the reply must not offer %s; got: %s", resumeHint, resp)
+		}
+	})
 }


### PR DESCRIPTION
Addresses issue #244.

- Log failed checkpoint save with session id and error
- Do not offer /resume when checkpoint was not persisted

Tests pass.