### PR TITLE
feat(configure): --fallback flag for the provider fallback order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`joshbot configure --fallback "nvidia,poolside"`** — the first CLI path
+  that writes `provider_defaults.fallback_order`; configuring the headline
+  fallback feature previously required hand-editing config.json. Every name
+  must be a configured, enabled provider (a typo would silently vanish from
+  the chain at the exact moment the primary is down); the error names the
+  providers that are configured. `--fallback ""` clears the order.
+
 ### Fixed
 
 - **Onboarding no longer prints "✓ credentials validated" for a key that

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ joshbot skills trust <name> # Approve a workspace skill after reviewing it
 joshbot mcp list    # Review MCP servers and the tools they advertise
 joshbot mcp trust <name>    # Approve an MCP server's tool manifest
 joshbot configure # Configure LLM providers and settings
+joshbot configure --fallback "nvidia,poolside" # Set the provider fallback order ("" clears)
 joshbot auth github-copilot # Authenticate with GitHub Copilot
 joshbot service install # Install joshbot as a system service
 joshbot update # Update to the latest release
@@ -1371,8 +1372,13 @@ Debug output will show:
 
 Rate limits (HTTP 429) and transient server errors are retried on the same
 provider with backoff before falling over — `providers.<name>.max_retries`
-(default 2) controls how many times. If you see persistent 429s, configure
-fallback providers in your config for resilience.
+(default 2) controls how many times. If you see persistent 429s, add a fallback
+chain from the CLI — no config editing needed:
+
+```bash
+joshbot configure --provider groq --api-key "$GROQ_API_KEY"
+joshbot configure --fallback "nvidia,groq"
+```
 
 ## License
 

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -453,6 +453,10 @@ func newApp() *cli.App {
 						Name:  "remove",
 						Usage: "Remove a configured provider",
 					},
+					&cli.StringFlag{
+						Name:  "fallback",
+						Usage: "Comma-separated provider fallback order (e.g. \"nvidia,poolside\"); pass \"\" to clear",
+					},
 				},
 				Action: withJSONErrors(runConfigure),
 			},
@@ -1167,6 +1171,18 @@ func defaultReminderChannel(cfg *config.Config) string {
 }
 
 // indexOf returns the index of needle in haystack, or -1 if not found.
+// splitCommaList splits a comma-separated flag value into trimmed, non-empty
+// entries; "" yields nil, which callers treat as "clear".
+func splitCommaList(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
 func indexOf(haystack []string, needle string) int {
 	for i, s := range haystack {
 		if s == needle {
@@ -4194,7 +4210,21 @@ func runConfigure(c *cli.Context) error {
 		fmt.Printf("Default provider set to %q with model %q.\n", provider, cfg.Agents.Defaults.Model)
 	}
 
-	if c.IsSet("provider") || c.IsSet("set-default") {
+	// --fallback is IsSet-gated rather than non-empty-gated on purpose:
+	// `--fallback ""` is the documented way to clear the order.
+	if c.IsSet("fallback") {
+		names := splitCommaList(c.String("fallback"))
+		if err := conf.SetFallbackOrder(names); err != nil {
+			return err
+		}
+		if len(names) == 0 {
+			fmt.Println("Fallback order cleared.")
+		} else {
+			fmt.Printf("Fallback order set to %s.\n", strings.Join(names, " → "))
+		}
+	}
+
+	if c.IsSet("provider") || c.IsSet("set-default") || c.IsSet("fallback") {
 		return flushConfig(cfg)
 	}
 

--- a/docs/HERMES_PARITY.md
+++ b/docs/HERMES_PARITY.md
@@ -72,7 +72,7 @@ path** from install to working multi-provider fallback.
 
 - [x] Fix false-positive credential validation (1-token completion, or no
       checkmark for unauthenticated `/models` endpoints)
-- [ ] `joshbot configure fallback` (flag + interactive) — first CLI path that
+- [x] `joshbot configure fallback` (flag + interactive) — first CLI path that
       writes a fallback chain
 - [ ] Onboard offers fallback when a second provider key is present in env
 - [ ] Converge on one canonical config format + `joshbot configure migrate`;

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -326,6 +326,7 @@ If a provider is present but not registered, `status` says why — for example `
 | `joshbot skills list` \| `trust <name>` \| `untrust <name>` | Review and approve workspace skills |
 | `joshbot mcp list` \| `trust <name>` \| `untrust <name>` | Review and approve MCP servers' advertised tools |
 | `joshbot configure` | Configure LLM providers and settings |
+| `joshbot configure --fallback "nvidia,poolside"` | Set the provider fallback order; `""` clears it |
 | `joshbot sessions list` \| `show <id>` \| `prune <id>` \| `new <id>` \| `export <id>` | Inspect, manage and export stored conversations |
 | `joshbot memory status` \| `consolidate` | Inspect and run the Dream two-stage memory system (`agents.defaults.dream_mode`) |
 | `joshbot auth github-copilot [--force]` \| `status` | Manage OAuth authentication |

--- a/internal/configure/configure.go
+++ b/internal/configure/configure.go
@@ -2,6 +2,7 @@ package configure
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -81,6 +82,38 @@ func (c *Configurator) ConfigureProvider(opts ProviderOptions) error {
 		c.cfg.Agents.Defaults.Model = p.Model
 	}
 
+	return nil
+}
+
+// SetFallbackOrder writes provider_defaults.fallback_order — the order the
+// runtime dials providers when the primary fails. Every name must refer to a
+// configured, enabled provider: a typo here would silently vanish from the
+// chain at the exact moment the primary is down, which is the last place a
+// misconfiguration should first surface. An empty list clears the order.
+func (c *Configurator) SetFallbackOrder(names []string) error {
+	if len(names) == 0 {
+		c.cfg.ProviderDefaults.FallbackOrder = nil
+		return nil
+	}
+	seen := make(map[string]bool, len(names))
+	for _, name := range names {
+		p, ok := c.cfg.Providers[name]
+		if !ok || !p.Enabled {
+			configured := make([]string, 0, len(c.cfg.Providers))
+			for n, cp := range c.cfg.Providers {
+				if cp.Enabled {
+					configured = append(configured, n)
+				}
+			}
+			sort.Strings(configured)
+			return fmt.Errorf("provider %q is not configured and enabled; configured providers: %s", name, strings.Join(configured, ", "))
+		}
+		if seen[name] {
+			return fmt.Errorf("provider %q appears twice in the fallback order", name)
+		}
+		seen[name] = true
+	}
+	c.cfg.ProviderDefaults.FallbackOrder = names
 	return nil
 }
 

--- a/internal/configure/configure_fallback_test.go
+++ b/internal/configure/configure_fallback_test.go
@@ -1,0 +1,67 @@
+package configure
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bigknoxy/joshbot/internal/config"
+)
+
+func fallbackTestConfig() *config.Config {
+	cfg := config.Defaults()
+	cfg.Providers = map[string]config.ProviderConfig{
+		"nvidia":   {APIKey: "k1", Enabled: true},
+		"poolside": {APIKey: "k2", Enabled: true},
+		"groq":     {APIKey: "k3", Enabled: false}, // configured but disabled
+	}
+	return cfg
+}
+
+func TestSetFallbackOrderWritesOrder(t *testing.T) {
+	cfg := fallbackTestConfig()
+	c := New(cfg)
+	if err := c.SetFallbackOrder([]string{"nvidia", "poolside"}); err != nil {
+		t.Fatalf("SetFallbackOrder = %v", err)
+	}
+	got := cfg.ProviderDefaults.FallbackOrder
+	if len(got) != 2 || got[0] != "nvidia" || got[1] != "poolside" {
+		t.Errorf("FallbackOrder = %v", got)
+	}
+}
+
+func TestSetFallbackOrderRejectsUnknownAndDisabled(t *testing.T) {
+	cfg := fallbackTestConfig()
+	c := New(cfg)
+	err := c.SetFallbackOrder([]string{"nvidia", "nosuch"})
+	if err == nil || !strings.Contains(err.Error(), `"nosuch"`) {
+		t.Fatalf("unknown provider must be rejected by name, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "nvidia") || !strings.Contains(err.Error(), "poolside") {
+		t.Errorf("error should list the configured providers, got %v", err)
+	}
+	if err := c.SetFallbackOrder([]string{"groq"}); err == nil {
+		t.Fatal("a disabled provider must be rejected — it would vanish from the chain silently")
+	}
+	if cfg.ProviderDefaults.FallbackOrder != nil {
+		t.Errorf("a rejected order must not be written, got %v", cfg.ProviderDefaults.FallbackOrder)
+	}
+}
+
+func TestSetFallbackOrderRejectsDuplicates(t *testing.T) {
+	c := New(fallbackTestConfig())
+	if err := c.SetFallbackOrder([]string{"nvidia", "nvidia"}); err == nil {
+		t.Fatal("duplicates must be rejected")
+	}
+}
+
+func TestSetFallbackOrderEmptyClears(t *testing.T) {
+	cfg := fallbackTestConfig()
+	cfg.ProviderDefaults.FallbackOrder = []string{"nvidia"}
+	c := New(cfg)
+	if err := c.SetFallbackOrder(nil); err != nil {
+		t.Fatalf("clear = %v", err)
+	}
+	if cfg.ProviderDefaults.FallbackOrder != nil {
+		t.Errorf("clear left %v", cfg.ProviderDefaults.FallbackOrder)
+	}
+}


### PR DESCRIPTION
## Summary
Phase 2 of the Hermes parity plan: the first scriptable CLI path from one provider to working multi-provider fallback. Previously `provider_defaults.fallback_order` was hand-edit-only (the interactive wizard had a step; scripts and docs had nothing).

- `joshbot configure --fallback "nvidia,poolside"` writes the order; `--fallback ""` clears it.
- Validation: every name must be a **configured and enabled** provider — a typo would silently vanish from the chain exactly when the primary is down, so it errors naming the configured providers. Duplicates refused. A rejected order writes nothing.

## Proof
- Unit tests for write/reject-unknown/reject-disabled/reject-duplicate/clear.
- **Binary dogfood, zero hand-edits**: `onboard` + `configure --provider poolside` + `configure --fallback "custom,poolside"`, then with the primary rate-limited the reply came from poolside with the fallback notice naming both providers. The typo'd name `poolsde` was refused with `configured providers: custom, poolside`.

Docs: README (usage + troubleshooting recipe), docs/INSTALL.md, CHANGELOG, HERMES_PARITY checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)