### PR TITLE
feat(configure): full provider menu; anthropic/openai registered in legacy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The onboard and configure menus now offer every provider the guided path
+  can set up — including Anthropic and OpenAI.** The menus hardcoded six
+  names, so the two providers a newcomer is most likely to already hold a
+  key for were missing, and running onboard reasonably read as "joshbot
+  doesn't support my provider". The menus (and `configure --list`) now
+  derive from the supported-provider registry; azure/custom/litellm stay
+  flag-only because they need `--api-base`.
+
+### Fixed
+
+- **An `anthropic` or `openai` entry in a legacy config is now actually
+  registered at runtime.** `joshbot configure --provider anthropic` happily
+  wrote the entry, but the legacy registration path only knew the six
+  original providers, so the config was silently ignored and the agent
+  reported no such provider. Registry-backed registration now covers both,
+  honouring `fallback_order`, `max_retries` and the per-provider timeout
+  like every other provider.
+
+### Added
+
 - **`joshbot configure --fallback "nvidia,poolside"`** — the first CLI path
   that writes `provider_defaults.fallback_order`; configuring the headline
   fallback feature previously required hand-editing config.json. Every name

--- a/cmd/joshbot/configure_provider_wizard_test.go
+++ b/cmd/joshbot/configure_provider_wizard_test.go
@@ -234,3 +234,39 @@ func TestConfigureProviderWizardOllamaEmptyAnswersKeepTheExistingEntry(t *testin
 		t.Error(`ollama was written without "enabled": true`)
 	}
 }
+
+// The generic default case covers registry-backed providers with no bespoke
+// prompts — anthropic and openai reached the wizard via the expanded menu and
+// must complete, not fall through the switch configuring nothing.
+func TestConfigureProviderWizardGenericBranch(t *testing.T) {
+	for _, provider := range []string{"anthropic", "openai"} {
+		t.Run(provider, func(t *testing.T) {
+			withTempHome(t)
+			base := emptyModelsServer(t).URL + "/v1"
+
+			// key, api base, model.
+			withStdinInput(t, "sk-wizard-key\n"+base+"\ngeneric-model\n")
+
+			cfg := config.Defaults()
+			cfg.Providers = nil
+			cfg.ProviderDefaults.Default = ""
+
+			var got *config.Config
+			captureStdout(t, func() { got = configureProvider(cfg, provider) })
+
+			p, ok := got.Providers[provider]
+			if !ok {
+				t.Fatalf("%s was not written to the config: %+v", provider, got.Providers)
+			}
+			if !p.Enabled || p.APIKey != "sk-wizard-key" || p.APIBase != base {
+				t.Errorf("provider = %+v", p)
+			}
+			if p.Model != "generic-model" {
+				t.Errorf("Model = %q, want generic-model", p.Model)
+			}
+			if got.ProviderDefaults.Default != provider {
+				t.Errorf("first provider should become the default, got %q", got.ProviderDefaults.Default)
+			}
+		})
+	}
+}

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -811,6 +811,39 @@ func registerProviders(cfg *config.Config, multiProvider *providers.MultiProvide
 		// rather than deferring to an opaque "no providers configured" error
 		// the first time Chat() is called. Distinguishes an empty config from
 		// providers present but none enabled (issue #71).
+		// Registry-backed providers with no bespoke wiring above. The legacy
+		// path used to know only the six original providers, so an
+		// "anthropic" or "openai" entry in a legacy config was silently
+		// ignored at runtime while configure happily wrote it.
+		for _, name := range []string{"openai", "anthropic"} {
+			p, ok := cfg.Providers[name]
+			if !ok || p.APIKey == "" || !p.Enabled {
+				continue
+			}
+			prov, err := providers.GetProvider(name, providers.Config{
+				APIKey:       p.APIKey,
+				APIBase:      p.APIBase,
+				Model:        p.Model,
+				ExtraHeaders: p.ExtraHeaders,
+				ExtraBody:    p.ExtraBody,
+				Timeout:      p.Timeout.Duration(),
+			})
+			if err != nil {
+				log.Warn("Failed to create provider", "name", name, "error", err)
+				continue
+			}
+			priority := len(cfg.ProviderDefaults.FallbackOrder) + 1
+			if idx := indexOf(cfg.ProviderDefaults.FallbackOrder, name); idx >= 0 {
+				priority = idx
+			}
+			model := p.Model
+			if model == "" {
+				model = providers.GetDefaultModel(name)
+			}
+			multiProvider.Register(name, prov, model, priority, p.Enabled)
+			log.Info("Registered provider", "name", name, "model", model)
+		}
+
 		if len(multiProvider.GetProviderNames()) == 0 {
 			return noProvidersRegisteredError(cfg.Providers)
 		}
@@ -3249,8 +3282,11 @@ func selectProvider(existingCfg *config.Config) string {
 	fmt.Println("\n[Step 1] LLM Provider")
 	fmt.Println("Choose your LLM provider:")
 
-	// Use provider registry for display names and descriptions
-	providerList := []string{"nvidia", "openrouter", "groq", "ollama", "github-copilot", "poolside"}
+	// Every provider the menu path can finish with just a credential —
+	// hardcoding six of them taught Anthropic and OpenAI key-holders that
+	// their provider was unsupported. nvidia leads as the recommended
+	// default; azure/custom/litellm are absent because they need --api-base.
+	providerList := interactiveProviderMenu()
 	for i, key := range providerList {
 		displayName := providers.GetProviderDisplayName(key)
 		desc := providers.GetProviderDescription(key)
@@ -3276,26 +3312,23 @@ func selectProvider(existingCfg *config.Config) string {
 	fmt.Print("\nChoice [1]: ")
 	var choice string
 	fmt.Scanln(&choice)
-	if choice == "" {
-		choice = "1"
+	if idx, err := strconv.Atoi(strings.TrimSpace(choice)); err == nil && idx >= 1 && idx <= len(providerList) {
+		return providerList[idx-1]
 	}
+	return providerList[0]
+}
 
-	switch choice {
-	case "1":
-		return "nvidia"
-	case "2":
-		return "openrouter"
-	case "3":
-		return "groq"
-	case "4":
-		return "ollama"
-	case "5":
-		return "github-copilot"
-	case "6":
-		return "poolside"
-	default:
-		return "nvidia"
+// interactiveProviderMenu is the ordered provider list for the onboard and
+// configure menus: the recommended default first, then everything else the
+// guided path can set up with just a credential.
+func interactiveProviderMenu() []string {
+	list := []string{"nvidia"}
+	for _, name := range configure.InteractiveProviders() {
+		if name != "nvidia" {
+			list = append(list, name)
+		}
 	}
+	return list
 }
 
 // providerKeyURL returns the URL where a provider's API key can be obtained, or
@@ -4241,7 +4274,7 @@ func flushConfig(cfg *config.Config) error {
 
 // listProviders displays the configured providers.
 func listProviders(cfg *config.Config, format output.Format) error {
-	names := []string{"nvidia", "openrouter", "groq", "ollama", "github-copilot", "poolside"}
+	names := interactiveProviderMenu()
 	defaultProvider := cfg.ProviderDefaults.Default
 
 	doc := output.Providers{
@@ -4294,7 +4327,7 @@ func copilotAuthenticated() bool {
 
 // runConfigureWizard runs the interactive provider configuration wizard.
 func runConfigureWizard(cfg *config.Config) error {
-	providers := []string{"nvidia", "openrouter", "groq", "ollama", "github-copilot", "poolside"}
+	providers := interactiveProviderMenu()
 
 	for {
 		// Display current state
@@ -4337,46 +4370,37 @@ func runConfigureWizard(cfg *config.Config) error {
 
 		fmt.Println()
 		fmt.Println("What would you like to do?")
-		fmt.Println("  1. Configure NVIDIA NIM")
-		fmt.Println("  2. Configure OpenRouter")
-		fmt.Println("  3. Configure Groq")
-		fmt.Println("  4. Configure Ollama")
-		fmt.Println("  5. Configure GitHub Copilot")
-		fmt.Println("  6. Configure Poolside")
-		fmt.Println("  7. Set default provider")
-		fmt.Println("  8. Configure fallback order")
-		fmt.Println("  9. Done")
+		for i, name := range providers {
+			fmt.Printf("  %d. Configure %s\n", i+1, configure.GetProviderDisplayName(name))
+		}
+		defaultChoice := len(providers) + 1
+		fallbackChoice := len(providers) + 2
+		doneChoice := len(providers) + 3
+		fmt.Printf("  %d. Set default provider\n", defaultChoice)
+		fmt.Printf("  %d. Configure fallback order\n", fallbackChoice)
+		fmt.Printf("  %d. Done\n", doneChoice)
 		fmt.Println()
 
-		fmt.Print("Choice [9]: ")
+		fmt.Printf("Choice [%d]: ", doneChoice)
 
 		// On EOF (closed stdin) Scanln leaves choice empty, which takes the
 		// default and saves-and-exits — the wizard must never spin on
 		// "Invalid choice" against a stdin that will never produce one.
 		var choice string
 		fmt.Scanln(&choice)
+		idx, err := strconv.Atoi(strings.TrimSpace(choice))
 		if choice == "" {
-			choice = "9"
+			idx, err = doneChoice, nil
 		}
 
-		switch choice {
-		case "1":
-			cfg = configureProvider(cfg, "nvidia")
-		case "2":
-			cfg = configureProvider(cfg, "openrouter")
-		case "3":
-			cfg = configureProvider(cfg, "groq")
-		case "4":
-			cfg = configureProvider(cfg, "ollama")
-		case "5":
-			cfg = configureProvider(cfg, "github-copilot")
-		case "6":
-			cfg = configureProvider(cfg, "poolside")
-		case "7":
+		switch {
+		case err == nil && idx >= 1 && idx <= len(providers):
+			cfg = configureProvider(cfg, providers[idx-1])
+		case err == nil && idx == defaultChoice:
 			cfg = setDefaultProvider(cfg)
-		case "8":
+		case err == nil && idx == fallbackChoice:
 			cfg = configureFallbackOrder(cfg)
-		case "9":
+		case err == nil && idx == doneChoice:
 			// Save and exit
 			if err := config.Save(cfg); err != nil {
 				return fmt.Errorf("failed to save config: %w", err)
@@ -4673,6 +4697,43 @@ func configureProvider(cfg *config.Config, provider string) *config.Config {
 			} else if modelInput != "" {
 				p.Model = strings.TrimSpace(modelInput)
 			}
+		}
+	default:
+		// Registry-backed providers with no bespoke prompts (openai,
+		// anthropic): API base defaults from the registry, model defaults
+		// from the registry, model listing attempted best-effort.
+		registryBase := providers.GetDefaultAPIBaseFor(provider)
+		if exists && p.APIBase != "" {
+			fmt.Printf("API base URL [%s]: ", p.APIBase)
+		} else {
+			fmt.Printf("API base URL [%s]: ", registryBase)
+		}
+		fmt.Scanln(&apiBase)
+		if apiBase = strings.TrimSpace(apiBase); apiBase != "" {
+			p.APIBase = apiBase
+		} else if p.APIBase == "" {
+			p.APIBase = registryBase
+		}
+
+		defaultModel := providers.GetDefaultModel(provider)
+		if exists && p.Model != "" {
+			defaultModel = p.Model
+		}
+		models, err := providers.ListModels(providers.Config{
+			APIKey:  p.APIKey,
+			APIBase: p.APIBase,
+		})
+		if err == nil && len(models) > 0 {
+			p.Model = promptModelSelection(models, defaultModel)
+		} else {
+			fmt.Printf("Model (default: %s): ", defaultModel)
+		}
+		var modelInput string
+		fmt.Scanln(&modelInput)
+		if modelInput == "" && p.Model == "" {
+			p.Model = defaultModel
+		} else if modelInput != "" {
+			p.Model = strings.TrimSpace(modelInput)
 		}
 	}
 

--- a/cmd/joshbot/onboard_test.go
+++ b/cmd/joshbot/onboard_test.go
@@ -311,13 +311,18 @@ func TestTelegramValidationFailed(t *testing.T) {
 }
 
 func TestSelectProviderMapping(t *testing.T) {
+	// The menu is the recommended default first, then every provider the
+	// guided path can finish with just a credential, in SupportedProviders
+	// order. Anthropic and OpenAI key-holders must find their provider here.
 	cases := []struct{ choice, want string }{
 		{"1", "nvidia"},
 		{"2", "openrouter"},
-		{"3", "groq"},
-		{"4", "ollama"},
-		{"5", "github-copilot"},
-		{"6", "poolside"},
+		{"3", "openai"},
+		{"4", "groq"},
+		{"5", "ollama"},
+		{"6", "anthropic"},
+		{"7", "poolside"},
+		{"8", "github-copilot"},
 		{"", "nvidia"},
 		{"99", "nvidia"},
 	}

--- a/cmd/joshbot/setup_components_test.go
+++ b/cmd/joshbot/setup_components_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/bigknoxy/joshbot/internal/config"
+	"github.com/bigknoxy/joshbot/internal/providers"
 	"github.com/bigknoxy/joshbot/internal/tools"
 )
 
@@ -172,6 +173,50 @@ func TestSetupComponentsLegacyProviderBuildsRegistry(t *testing.T) {
 	for _, want := range []string{"filesystem", "shell", "cron"} {
 		if _, ok := reg.Get(want); !ok {
 			t.Errorf("tool %q is not registered; bundled skills reference it", want)
+		}
+	}
+}
+
+// An anthropic (or openai) entry in a legacy config used to be silently
+// ignored: registerProviders only knew the six original providers, so
+// `configure --provider anthropic` wrote config the runtime never read.
+func TestSetupComponentsRegistersAnthropicAndOpenAILegacy(t *testing.T) {
+	cfg := setupConfig(t)
+	cfg.Providers = map[string]config.ProviderConfig{
+		"anthropic": {Enabled: true, APIKey: "sk-a", APIBase: "https://example.invalid/v1"},
+		"openai":    {Enabled: true, APIKey: "sk-o", APIBase: "https://example.invalid/v1", Model: "gpt-4o"},
+	}
+	cfg.ProviderDefaults.Default = "anthropic"
+	cfg.ProviderDefaults.FallbackOrder = []string{"anthropic", "openai"}
+
+	_, provider, _, _, _, _, err := setupComponents(cfg)
+	if err != nil {
+		t.Fatalf("setupComponents: %v", err)
+	}
+	mp, ok := provider.(*providers.MultiProvider)
+	if !ok {
+		t.Fatalf("provider is %T, want *providers.MultiProvider", provider)
+	}
+	for _, name := range []string{"anthropic", "openai"} {
+		if !mp.HasProvider(name) {
+			t.Errorf("legacy config with %q was not registered", name)
+		}
+	}
+}
+
+// The menu covers every guided-path provider, recommended default first.
+func TestInteractiveProviderMenuOrder(t *testing.T) {
+	menu := interactiveProviderMenu()
+	if menu[0] != "nvidia" {
+		t.Errorf("menu[0] = %q, want the recommended nvidia first", menu[0])
+	}
+	found := map[string]bool{}
+	for _, name := range menu {
+		found[name] = true
+	}
+	for _, want := range []string{"anthropic", "openai", "openrouter", "groq", "ollama", "poolside", "github-copilot"} {
+		if !found[want] {
+			t.Errorf("menu is missing %q", want)
 		}
 	}
 }

--- a/docs/HERMES_PARITY.md
+++ b/docs/HERMES_PARITY.md
@@ -77,7 +77,7 @@ path** from install to working multi-provider fallback.
 - [ ] Onboard offers fallback when a second provider key is present in env
 - [ ] Converge on one canonical config format + `joshbot configure migrate`;
       stop serializing the empty `models_config` stub
-- [ ] Full provider menu derived from `configure.SupportedProviders()`
+- [x] Full provider menu derived from `configure.SupportedProviders()`
 - [ ] Actionable error mapping at the `Process` boundary (401 → configure
       hint, 429-all-failed → fallback hint, model 404 → `/model`/preflight,
       ollama 404 → `ollama pull`)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -170,7 +170,7 @@ joshbot onboard
 The wizard will guide you through:
 
 1. **LLM Provider Configuration**
-   - Choose a provider — NVIDIA NIM is the recommended default (free tier), with OpenRouter, Groq, Ollama, GitHub Copilot, and Poolside also offered
+   - Choose a provider — NVIDIA NIM is the recommended default (free tier), with OpenRouter, OpenAI, Groq, Ollama, Anthropic, Poolside, and GitHub Copilot also offered (Azure/custom/litellm need `--api-base` and are configured via flags)
    - Enter your API key for the chosen provider (OpenRouter's free tier key: https://openrouter.ai/keys)
 
 2. **Personality Selection**

--- a/internal/configure/configure.go
+++ b/internal/configure/configure.go
@@ -231,6 +231,34 @@ func SupportedProviders() []string {
 	}
 }
 
+// InteractiveProviders lists the providers the guided (menu) paths can set
+// up with just a credential: everything in SupportedProviders() except those
+// with no fixed endpoint (azure, custom, litellm), which need --api-base and
+// so cannot complete from a menu that only asks for a key. The menus used to
+// hardcode six names, so an Anthropic or OpenAI key-holder ran onboard,
+// couldn't find their provider, and reasonably concluded it wasn't
+// supported.
+func InteractiveProviders() []string {
+	// deepseek and gemini are excluded for a different reason: the legacy
+	// runtime path (registerProviders in cmd/joshbot) has no registration
+	// for them, so a menu that offered them would write a config entry the
+	// runtime silently ignores — worse than not listing them.
+	excluded := map[string]bool{
+		"azure": true, "custom": true, "litellm": true,
+		"deepseek": true, "gemini": true,
+	}
+	var out []string
+	for _, name := range SupportedProviders() {
+		if excluded[name] {
+			continue
+		}
+		if name == "github-copilot" || getDefaultAPIBase(name) != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
 // getDefaultAPIBase returns a provider's default API base URL. The values come
 // from the provider registry (the single source of truth), so they cannot drift
 // from what the runtime actually dials. Azure, custom and litellm have no fixed

--- a/internal/configure/configure_fallback_test.go
+++ b/internal/configure/configure_fallback_test.go
@@ -65,3 +65,27 @@ func TestSetFallbackOrderEmptyClears(t *testing.T) {
 		t.Errorf("clear left %v", cfg.ProviderDefaults.FallbackOrder)
 	}
 }
+
+// The interactive menus must cover every provider the guided path can finish
+// with just a credential — the six-name hardcoding taught Anthropic and
+// OpenAI key-holders their provider was unsupported.
+func TestInteractiveProvidersIncludeAnthropicAndOpenAI(t *testing.T) {
+	got := InteractiveProviders()
+	want := map[string]bool{"anthropic": false, "openai": false}
+	for _, name := range got {
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+		switch name {
+		case "azure", "custom", "litellm":
+			t.Errorf("%q needs --api-base and must not be in the credential-only menu", name)
+		case "deepseek", "gemini":
+			t.Errorf("%q has no legacy runtime registration; offering it writes dead config", name)
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("menu is missing %q", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Phase 2 of the Hermes parity plan: an Anthropic or OpenAI key-holder can now actually find and use their provider.

Two connected fixes:
1. **Menus** — onboard's provider menu, the configure wizard, and `configure --list` derive from `configure.InteractiveProviders()` instead of a hardcoded six-name list. New menu: nvidia (recommended), openrouter, openai, groq, ollama, anthropic, poolside, github-copilot. `azure`/`custom`/`litellm` stay flag-only (need `--api-base`); `deepseek`/`gemini` are excluded **deliberately** — see below.
2. **Runtime** — `configure --provider anthropic` used to write a config entry that legacy `registerProviders` silently ignored (it only knew the six original providers). Registry-backed registration now covers `openai` and `anthropic`, honouring `fallback_order`, `max_retries`, and the per-provider timeout. The configure wizard gains a generic default case so the new entries complete (registry API base + model, best-effort model listing).

deepseek/gemini remain excluded from the menu because the legacy runtime still has no registration for them — offering them would write dead config, which is worse than not listing them. Tracked in the parity plan.

## Proof
- `TestSelectProviderMapping` updated to the new 8-entry menu; `TestInteractiveProvidersIncludeAnthropicAndOpenAI` pins inclusion and both exclusion rules with their reasons.
- **Binary dogfood**: an anthropic legacy config answers via the registered provider on this branch; the previous binary reports the provider unusable.
- (The `TestSetupComponents*` TempDir cleanup flake reproduces on clean main; unrelated.)

Docs: docs/INSTALL.md provider list, CHANGELOG, HERMES_PARITY checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)