### PR TITLE
feat(agent): actionable hints on common LLM failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reported no such provider. Registry-backed registration now covers both,
   honouring `fallback_order`, `max_retries` and the per-provider timeout
   like every other provider.
+- **Common LLM failures now end with one actionable next step.** A raw
+  provider error says what broke, never what to do about it. The reply
+  keeps the full error (the `Error processing request:` contract and its
+  exit-code/HTTP translations are unchanged) and appends a hint: a 401/403
+  points at `joshbot configure` naming the provider when known; a model 404
+  points at `/model` and `joshbot preflight` (or `ollama pull` for ollama);
+  a 429 points at `joshbot configure --fallback`; and the
+  all-providers-failed aggregate points at `preflight` rather than picking
+  one of its several statuses arbitrarily.
 
 ### Added
 

--- a/docs/HERMES_PARITY.md
+++ b/docs/HERMES_PARITY.md
@@ -78,7 +78,7 @@ path** from install to working multi-provider fallback.
 - [ ] Converge on one canonical config format + `joshbot configure migrate`;
       stop serializing the empty `models_config` stub
 - [x] Full provider menu derived from `configure.SupportedProviders()`
-- [ ] Actionable error mapping at the `Process` boundary (401 → configure
+- [x] Actionable error mapping at the `Process` boundary (401 → configure
       hint, 429-all-failed → fallback hint, model 404 → `/model`/preflight,
       ollama 404 → `ollama pull`)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -519,7 +519,15 @@ func (a *Agent) process(ctx context.Context, msg bus.InboundMessage) (string, er
 		if ctx.Err() == context.DeadlineExceeded {
 			return "I'm sorry, but processing your request took too long. Please try again or simplify your request.", nil
 		}
-		return fmt.Sprintf("Error processing request: %v", err), nil
+		reply := fmt.Sprintf("Error processing request: %v", err)
+		// A raw provider error tells the user what broke, never what to do
+		// about it. The hint is appended, not substituted: callers that
+		// match on the error text (tests, the ReplyPrefix contract, humans
+		// filing issues) keep the full detail.
+		if hint := llmErrorHint(err); hint != "" {
+			reply += "\n\n" + hint
+		}
+		return reply, nil
 	}
 
 	if a.history != nil {
@@ -1010,6 +1018,38 @@ func (a *Agent) streamChat(ctx context.Context, req providers.ChatRequest, sink 
 	sink(StreamEvent{Done: true})
 
 	return resp, nil
+}
+
+// llmErrorHint maps the common LLM failure classes to one actionable next
+// step. The raw error stays in the reply (see the call site); this only adds
+// what to do about it. An empty return means no hint applies.
+func llmErrorHint(err error) string {
+	if err == nil {
+		return ""
+	}
+	// The aggregate "all providers failed" error carries several statuses at
+	// once; a single-status hint would pick one arbitrarily and mislead.
+	if strings.Contains(err.Error(), "all providers failed") {
+		return "Every provider in the fallback chain failed. Run `joshbot preflight` to check the configuration without dialling anyone, or add a fallback with `joshbot configure --fallback`."
+	}
+
+	provider := providers.ProviderFromError(err)
+	switch providers.StatusCodeFromError(err) {
+	case 401, 403:
+		who := "The provider"
+		if provider != "" {
+			who = provider
+		}
+		return fmt.Sprintf("%s rejected the API key — update it with `joshbot configure --provider <name> --api-key <key>`, or run `joshbot preflight` to see which credential is in use.", who)
+	case 404:
+		if provider == "ollama" {
+			return "Ollama does not have that model — pull it with `ollama pull <model>`."
+		}
+		return "The model was not found — check the model name with `/model`, or run `joshbot preflight` to see the exact ID being sent."
+	case 429:
+		return "The provider is rate-limiting — a fallback provider keeps the conversation going: `joshbot configure --fallback \"<primary>,<backup>\"`."
+	}
+	return ""
 }
 
 // formatFallbackNotice renders the one-line, user-facing note that a reply

--- a/internal/agent/error_hint_test.go
+++ b/internal/agent/error_hint_test.go
@@ -1,0 +1,42 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bigknoxy/joshbot/internal/providers"
+)
+
+func TestLLMErrorHint(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string // substring; "" means no hint
+	}{
+		{"nil", nil, ""},
+		{"bad key plain", fmt.Errorf("LLM call failed: API error (401): bad key"), "rejected the API key"},
+		{"forbidden", fmt.Errorf("API error (403): denied"), "rejected the API key"},
+		{"bad key structured", &providers.FallbackError{StatusCode: 401, Provider: "openrouter", Message: "no"}, "openrouter rejected the API key"},
+		{"model 404", fmt.Errorf("API error (404): no such model"), "check the model name"},
+		{"ollama 404", &providers.FallbackError{StatusCode: 404, Provider: "ollama", Message: "not found"}, "ollama pull"},
+		{"rate limit", &providers.FallbackError{StatusCode: 429, Provider: "nvidia", Message: "slow down"}, "--fallback"},
+		{"aggregate", fmt.Errorf("all providers failed (tried: a → b; a: HTTP 429; b: HTTP 503): boom"), "preflight"},
+		{"plain error", errors.New("something odd"), ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := llmErrorHint(tc.err)
+			if tc.want == "" {
+				if got != "" {
+					t.Errorf("llmErrorHint(%v) = %q, want no hint", tc.err, got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("llmErrorHint(%v) = %q, want substring %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/providers/errors.go
+++ b/internal/providers/errors.go
@@ -161,6 +161,30 @@ func IsFallbackError(err error, providerName string) bool {
 	return false
 }
 
+// StatusCodeFromError exposes the HTTP status carried by (or parsed out of)
+// an error chain, or 0 when there is none. A FallbackError's structured code
+// wins over text scanning.
+func StatusCodeFromError(err error) int {
+	if err == nil {
+		return 0
+	}
+	var fallbackErr *FallbackError
+	if errors.As(err, &fallbackErr) && fallbackErr.StatusCode > 0 {
+		return fallbackErr.StatusCode
+	}
+	return extractStatusCode(err.Error())
+}
+
+// ProviderFromError names the provider an error chain came from, or "" when
+// the error carries no structured provider (plain non-fallback errors).
+func ProviderFromError(err error) string {
+	var fallbackErr *FallbackError
+	if errors.As(err, &fallbackErr) {
+		return fallbackErr.Provider
+	}
+	return ""
+}
+
 // RetryAfterFromError extracts the upstream Retry-After hint from an error
 // chain, or zero when there is none.
 func RetryAfterFromError(err error) time.Duration {


### PR DESCRIPTION
## Summary
Phase 2 of the Hermes parity plan: error legibility. Common failures now end with what to do about them, on every channel:

- 401/403 → `<provider> rejected the API key — update it with joshbot configure ...`
- model 404 → check with `/model` / `joshbot preflight` (ollama: `ollama pull <model>`)
- 429 → add a fallback: `joshbot configure --fallback`
- all-providers-failed aggregate → `joshbot preflight` (a single-status hint would pick one of its statuses arbitrarily)

The full raw error stays in the reply — the hint is **appended, never substituted**, so the `ReplyPrefix` in-band contract, `agent -m` exit codes, and the HTTP API's 502 translation are all unchanged. `providers` gains `StatusCodeFromError`/`ProviderFromError` so the agent reads structured `FallbackError` fields instead of scanning prose.

## Proof
- Table-driven unit tests over all hint classes plus the no-hint cases.
- Binary dogfood: a model 404 in the CLI ends with the `/model` + `preflight` hint under the full error.

Docs: CHANGELOG, HERMES_PARITY checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)