### PR TITLE
docs: cut CHANGELOG section for v1.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,13 +95,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   429 counts as authenticated (a rate limit is issued to a real key), and
   anything else reports "could not verify" rather than claiming a check that
   never ran.
-- The background services started at startup — cron, the heartbeat and the
-  memory consolidator — are now stopped on shutdown. Nothing held a handle to
-  them, and the consolidator runs its first pass immediately from a goroutine,
-  so they kept writing into the workspace after the process was on its way out.
-  The same leak made `cmd/joshbot`'s tests flaky: a consolidator writing into
-  `workspace/memory` raced `t.TempDir` cleanup and failed the run with
-  "directory not empty".
 
 ## [1.52.1] - 2026-08-14
 
@@ -124,6 +117,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   found" with the interrupted task gone and no error anywhere. The failure is
   now logged with the session id, and the suggestion is withheld both when the
   save fails and when there is no session manager at all. (#244)
+- The background services started at startup — cron, the heartbeat and the
+  memory consolidator — are now stopped on shutdown. Nothing held a handle to
+  them, and the consolidator runs its first pass immediately from a goroutine,
+  so they kept writing into the workspace after the process was on its way out.
+  The same leak made `cmd/joshbot`'s tests flaky: a consolidator writing into
+  `workspace/memory` raced `t.TempDir` cleanup and failed the run with
+  "directory not empty".
 
 ## [1.52.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.53.0] - 2026-08-14
+
 ### Added
 
 - **Onboarding builds a fallback chain from keys already in the environment.**
@@ -26,50 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   doesn't support my provider". The menus (and `configure --list`) now
   derive from the supported-provider registry; azure/custom/litellm stay
   flag-only because they need `--api-base`.
-
-### Fixed
-
-- **An `anthropic` or `openai` entry in a legacy config is now actually
-  registered at runtime.** `joshbot configure --provider anthropic` happily
-  wrote the entry, but the legacy registration path only knew the six
-  original providers, so the config was silently ignored and the agent
-  reported no such provider. Registry-backed registration now covers both,
-  honouring `fallback_order`, `max_retries` and the per-provider timeout
-  like every other provider.
-- **Common LLM failures now end with one actionable next step.** A raw
-  provider error says what broke, never what to do about it. The reply
-  keeps the full error (the `Error processing request:` contract and its
-  exit-code/HTTP translations are unchanged) and appends a hint: a 401/403
-  points at `joshbot configure` naming the provider when known; a model 404
-  points at `/model` and `joshbot preflight` (or `ollama pull` for ollama);
-  a 429 points at `joshbot configure --fallback`; and the
-  all-providers-failed aggregate points at `preflight` rather than picking
-  one of its several statuses arbitrarily.
-
-### Added
-
 - **`joshbot configure --fallback "nvidia,poolside"`** — the first CLI path
   that writes `provider_defaults.fallback_order`; configuring the headline
   fallback feature previously required hand-editing config.json. Every name
   must be a configured, enabled provider (a typo would silently vanish from
   the chain at the exact moment the primary is down); the error names the
   providers that are configured. `--fallback ""` clears the order.
-
-### Fixed
-
-- **Onboarding no longer prints "✓ credentials validated" for a key that
-  would fail the first real request.** Validation listed the provider's
-  models, but several providers' `/models` endpoint is unauthenticated —
-  OpenRouter answers 200 to *any* Authorization header — so a typo'd key
-  earned a checkmark and then greeted the user's first message with a raw
-  401. Validation is now a one-token chat completion: 401/403 reports
-  "credential rejected" with the upstream text and the provider's key URL, a
-  429 counts as authenticated (a rate limit is issued to a real key), and
-  anything else reports "could not verify" rather than claiming a check that
-  never ran.
-
-### Added
-
 - **A stream that dies before delivering any text is retried invisibly.**
   It used to end the turn with `[stream error: ...]` standing in for an
   answer the provider chain could still have produced — and the most common
@@ -79,9 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Retry-After` handling and the fallback chain with it; the reply arrives
   unstreamed. A stream that dies *after* text has appeared keeps the visible
   marker: shown text cannot be retried.
-
-### Added
-
 - **Transient provider failures are now retried on the same provider before the
   fallback chain moves on.** A single 429/5xx/network blip used to switch the
   conversation to a different provider — and therefore a different model —
@@ -106,6 +67,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   text carries it too, so the streamed buffer and the recorded answer stay
   identical.
 
+### Fixed
+
+- **An `anthropic` or `openai` entry in a legacy config is now actually
+  registered at runtime.** `joshbot configure --provider anthropic` happily
+  wrote the entry, but the legacy registration path only knew the six
+  original providers, so the config was silently ignored and the agent
+  reported no such provider. Registry-backed registration now covers both,
+  honouring `fallback_order`, `max_retries` and the per-provider timeout
+  like every other provider.
+- **Common LLM failures now end with one actionable next step.** A raw
+  provider error says what broke, never what to do about it. The reply
+  keeps the full error (the `Error processing request:` contract and its
+  exit-code/HTTP translations are unchanged) and appends a hint: a 401/403
+  points at `joshbot configure` naming the provider when known; a model 404
+  points at `/model` and `joshbot preflight` (or `ollama pull` for ollama);
+  a 429 points at `joshbot configure --fallback`; and the
+  all-providers-failed aggregate points at `preflight` rather than picking
+  one of its several statuses arbitrarily.
+- **Onboarding no longer prints "✓ credentials validated" for a key that
+  would fail the first real request.** Validation listed the provider's
+  models, but several providers' `/models` endpoint is unauthenticated —
+  OpenRouter answers 200 to *any* Authorization header — so a typo'd key
+  earned a checkmark and then greeted the user's first message with a raw
+  401. Validation is now a one-token chat completion: 401/403 reports
+  "credential rejected" with the upstream text and the provider's key URL, a
+  429 counts as authenticated (a rate limit is issued to a real key), and
+  anything else reports "could not verify" rather than claiming a check that
+  never ran.
+- The background services started at startup — cron, the heartbeat and the
+  memory consolidator — are now stopped on shutdown. Nothing held a handle to
+  them, and the consolidator runs its first pass immediately from a goroutine,
+  so they kept writing into the workspace after the process was on its way out.
+  The same leak made `cmd/joshbot`'s tests flaky: a consolidator writing into
+  `workspace/memory` raced `t.TempDir` cleanup and failed the run with
+  "directory not empty".
+
 ## [1.52.1] - 2026-08-14
 
 ### Fixed
@@ -127,13 +124,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   found" with the interrupted task gone and no error anywhere. The failure is
   now logged with the session id, and the suggestion is withheld both when the
   save fails and when there is no session manager at all. (#244)
-- The background services started at startup — cron, the heartbeat and the
-  memory consolidator — are now stopped on shutdown. Nothing held a handle to
-  them, and the consolidator runs its first pass immediately from a goroutine,
-  so they kept writing into the workspace after the process was on its way out.
-  The same leak made `cmd/joshbot`'s tests flaky: a consolidator writing into
-  `workspace/memory` raced `t.TempDir` cleanup and failed the run with
-  "directory not empty".
 
 ## [1.52.0] - 2026-08-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # joshbot — Architect's Guide
 
-joshbot is a self-hosted Go personal AI assistant (~38.3K LOC non-test, 2,113 test functions across 234 test files — measured 2026-08-13). Single binary, zero runtime deps.
+joshbot is a self-hosted Go personal AI assistant (~39.3K LOC non-test, 2,145 test functions across 241 test files in cmd+internal — measured 2026-08-14). Single binary, zero runtime deps.
 
 **`AGENTS.md` (repo root) is the full agent guide** — key interfaces, code style, naming, concurrency and logging patterns, complete gotchas list. Read it before non-trivial work. This file is the quick index.
 

--- a/site/index.html
+++ b/site/index.html
@@ -593,6 +593,11 @@ footer a:hover { text-decoration: underline; }
       <p>Attach a picture with <code>joshbot agent -m "what is this?" --image shot.png</code> (repeatable), or just send a photo on Telegram. The type is decided by sniffing the bytes, never by the extension or by what the sender declared — PNG, JPEG, GIF and WebP, 5&nbsp;MB per image and 20&nbsp;MB per request. If no configured model is known to accept images, the run fails before any provider call with an error naming the models it tried; unknown models count as not vision-capable, so a typo reads as a typo rather than a provider 400. Sessions record what was sent — type, size, SHA-256 — not the bytes.</p>
     </div>
     <div class="case-card">
+      <div class="icon">🔁</div>
+      <h3>Resilient Multi-Provider Fallback</h3>
+      <p>A transient 429 or 5xx is retried on the same provider with backoff — honouring the upstream <code>Retry-After</code> — before the fallback chain moves on, so one blip never silently switches the model mid-conversation. A provider that keeps failing is deprioritized for a cooldown window instead of being re-dialled on every turn, and when a fallback does answer, the reply says so in one line. Set the chain from the CLI: <code>joshbot configure --fallback "nvidia,poolside"</code>. Common failures end with an actionable next step, not just an upstream error dump.</p>
+    </div>
+    <div class="case-card">
       <div class="icon">🔀</div>
       <h3>Named Profiles</h3>
       <p>Define profiles for a hosted model and your local Ollama, then pick one per run with <code>--profile</code> — on <code>agent</code>, <code>gateway</code> and <code>preflight</code>. A profile stores the <em>name</em> of the environment variable holding its key, never the key, and a typo, a disabled profile or an unset variable stops the run at startup instead of surfacing as a 401 mid-conversation. <code>joshbot profiles list</code> shows what each would dial and is safe to paste into a bug report.</p>


### PR DESCRIPTION
Stamps `[Unreleased]` as **1.53.0** — the Hermes-parity Phase 1–2 release: same-provider retry with `Retry-After`, provider cooldown, mid-stream retry, visible fallback notices, real credential validation, `configure --fallback`, the full provider menu with anthropic/openai legacy registration, actionable error hints, and the background-services shutdown fix.

Also: consolidates the per-PR duplicate `### Added`/`### Fixed` headers, moves the #250 bullet a rebase had mis-anchored inside the released 1.52.1 section, re-measures the CLAUDE.md counts, and adds the resilient-fallback capability card to `site/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)