### PR TITLE
feat(onboard): fallback chain from provider keys in the environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Onboarding builds a fallback chain from keys already in the environment.**
+  A `JOSHBOT_PROVIDERS__<NAME>__API_KEY` (or shorthand) for a provider other
+  than the one being onboarded is the strongest possible signal a fallback is
+  wanted. Interactive onboarding asks per provider (default yes);
+  `--force` runs add them with a printed notice, since a non-interactive run
+  cannot ask and an exported env var is an explicit choice. The fallback
+  order is written primary-first.
+
+### Added
+
 - **The onboard and configure menus now offer every provider the guided path
   can set up — including Anthropic and OpenAI.** The menus hardcoded six
   names, so the two providers a newcomer is most likely to already hold a

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -3186,6 +3186,14 @@ func runOnboard(c *cli.Context) error {
 		}
 		cfg.ProviderDefaults.Default = provider
 		providerConfigured = true
+
+		// The environment may hold keys for other providers — the strongest
+		// possible signal the user has them and would want a fallback chain,
+		// which otherwise needs a second command (or used to need a text
+		// editor). Interactive runs ask; --force runs add them with a printed
+		// notice, since a non-interactive run cannot ask and an env var the
+		// user exported is an explicit choice.
+		offerEnvFallbacks(cfg, provider, force)
 	}
 
 	// A non-interactive --force run that ends up with no usable provider must
@@ -3361,6 +3369,44 @@ func selectProvider(existingCfg *config.Config) string {
 		return providerList[idx-1]
 	}
 	return providerList[0]
+}
+
+// offerEnvFallbacks scans the environment for other providers' API keys and
+// wires them in as fallbacks after the primary. Interactive runs confirm per
+// provider (default yes; EOF or "n" declines); force runs add with a notice.
+// The fallback order is written explicitly — primary first — because that is
+// the feature the second key exists for.
+func offerEnvFallbacks(cfg *config.Config, primary string, force bool) {
+	var added []string
+	for _, name := range interactiveProviderMenu() {
+		if name == primary || name == "github-copilot" || name == "ollama" {
+			continue // keyless or OAuth providers have no env key to find
+		}
+		key := providerAPIKeyFromEnv(name)
+		if key == "" {
+			continue
+		}
+		if !force {
+			fmt.Printf("\nFound a %s API key in the environment. Add %s as a fallback provider? [Y/n]: ",
+				configure.GetProviderDisplayName(name), name)
+			var answer string
+			fmt.Scanln(&answer)
+			if a := strings.ToLower(strings.TrimSpace(answer)); a == "n" || a == "no" {
+				continue
+			}
+		}
+		cfg.Providers[name] = config.ProviderConfig{
+			APIKey:  key,
+			Enabled: true,
+			Model:   providers.GetDefaultModel(name),
+		}
+		added = append(added, name)
+		fmt.Printf("  + %s added as a fallback (key from environment)\n", configure.GetProviderDisplayName(name))
+	}
+	if len(added) > 0 {
+		cfg.ProviderDefaults.FallbackOrder = append([]string{primary}, added...)
+		fmt.Printf("  Fallback order: %s\n", strings.Join(cfg.ProviderDefaults.FallbackOrder, " → "))
+	}
 }
 
 // interactiveProviderMenu is the ordered provider list for the onboard and

--- a/cmd/joshbot/onboard_test.go
+++ b/cmd/joshbot/onboard_test.go
@@ -622,3 +622,66 @@ func TestRunOnboard_Force_PreservesExistingAPIKey(t *testing.T) {
 		t.Error("existing enabled provider must stay enabled")
 	}
 }
+
+// A second provider's key in the environment becomes a fallback: in --force
+// mode automatically (a non-interactive run cannot ask, and an exported env
+// var is an explicit choice), with the fallback order written primary-first.
+func TestOfferEnvFallbacksForce(t *testing.T) {
+	t.Setenv("JOSHBOT_PROVIDERS__GROQ__API_KEY", "gsk-env")
+	t.Setenv("JOSHBOT_PROVIDERS__ANTHROPIC__API_KEY", "")
+
+	cfg := config.Defaults()
+	cfg.Providers = map[string]config.ProviderConfig{
+		"nvidia": {APIKey: "k", Enabled: true},
+	}
+	cfg.ProviderDefaults.Default = "nvidia"
+
+	captureStdout(t, func() { offerEnvFallbacks(cfg, "nvidia", true) })
+
+	p, ok := cfg.Providers["groq"]
+	if !ok || !p.Enabled || p.APIKey != "gsk-env" {
+		t.Fatalf("groq not added from env: %+v", cfg.Providers)
+	}
+	order := cfg.ProviderDefaults.FallbackOrder
+	if len(order) != 2 || order[0] != "nvidia" || order[1] != "groq" {
+		t.Errorf("FallbackOrder = %v, want [nvidia groq]", order)
+	}
+	if _, ok := cfg.Providers["anthropic"]; ok {
+		t.Error("an empty env var must not add a provider")
+	}
+}
+
+// Interactively, 'n' declines and nothing is written.
+func TestOfferEnvFallbacksInteractiveDecline(t *testing.T) {
+	t.Setenv("JOSHBOT_PROVIDERS__GROQ__API_KEY", "gsk-env")
+
+	cfg := config.Defaults()
+	cfg.Providers = map[string]config.ProviderConfig{"nvidia": {APIKey: "k", Enabled: true}}
+	cfg.ProviderDefaults.Default = "nvidia"
+
+	withStdinInput(t, "n\n")
+	captureStdout(t, func() { offerEnvFallbacks(cfg, "nvidia", false) })
+
+	if _, ok := cfg.Providers["groq"]; ok {
+		t.Error("declined provider was added anyway")
+	}
+	if cfg.ProviderDefaults.FallbackOrder != nil {
+		t.Errorf("FallbackOrder = %v, want none", cfg.ProviderDefaults.FallbackOrder)
+	}
+}
+
+// Interactively, bare Enter (and EOF) accepts — the default is yes.
+func TestOfferEnvFallbacksInteractiveDefaultYes(t *testing.T) {
+	t.Setenv("JOSHBOT_PROVIDERS__GROQ__API_KEY", "gsk-env")
+
+	cfg := config.Defaults()
+	cfg.Providers = map[string]config.ProviderConfig{"nvidia": {APIKey: "k", Enabled: true}}
+	cfg.ProviderDefaults.Default = "nvidia"
+
+	withStdinInput(t, "\n")
+	captureStdout(t, func() { offerEnvFallbacks(cfg, "nvidia", false) })
+
+	if _, ok := cfg.Providers["groq"]; !ok {
+		t.Error("bare Enter should accept the fallback")
+	}
+}

--- a/docs/HERMES_PARITY.md
+++ b/docs/HERMES_PARITY.md
@@ -74,7 +74,7 @@ path** from install to working multi-provider fallback.
       checkmark for unauthenticated `/models` endpoints)
 - [x] `joshbot configure fallback` (flag + interactive) — first CLI path that
       writes a fallback chain
-- [ ] Onboard offers fallback when a second provider key is present in env
+- [x] Onboard offers fallback when a second provider key is present in env
 - [ ] Converge on one canonical config format + `joshbot configure migrate`;
       stop serializing the empty `models_config` stub
 - [x] Full provider menu derived from `configure.SupportedProviders()`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -208,6 +208,10 @@ model comes from the provider you selected (e.g. `llama3.1:8b` for `ollama`).
 `--api-key` falls back to `JOSHBOT_PROVIDERS__<PROVIDER>__API_KEY`, and
 `azure`/`custom` also need `--api-base`.
 
+Keys for *other* providers found in the environment are offered as fallbacks:
+interactive runs ask per provider, `--force` runs add them with a printed
+notice, and `provider_defaults.fallback_order` is written primary-first.
+
 Onboarding **exits non-zero when no provider ended up configured** — including
 interactive runs with stdin closed. The config and workspace scaffold are still
 written; only the exit status reports the failure. Credential validation after


### PR DESCRIPTION
## Summary
Phase 2 of the Hermes parity plan: the last step of zero-edit multi-provider setup. Keys for *other* providers found in the environment during onboarding become fallbacks:

- Interactive: asks per provider — `Found a Groq API key in the environment. Add groq as a fallback provider? [Y/n]` (default yes, matching the wizard's EOF-takes-default convention).
- `--force`: adds with a printed notice — a non-interactive run cannot ask, and an exported env var is an explicit user choice.
- `provider_defaults.fallback_order` is written primary-first; ollama/github-copilot skipped (no env key to find); empty env vars ignored.

## Proof
- Unit tests: force-adds with correct order, interactive decline writes nothing, bare-Enter accepts, empty env var ignored.
- **Binary dogfood**: `onboard --force --provider nvidia` with two env keys → `Fallback order: nvidia → groq → anthropic` and a config with all three providers — one command, zero edits.

Docs: docs/INSTALL.md, CHANGELOG, HERMES_PARITY checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)