### PR TITLE
feat(configure): --migrate to the model-centric config format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`joshbot configure --migrate` converts a legacy provider config to the
+  model-centric format.** All-or-nothing and deliberately non-lossy: a
+  provider it cannot represent faithfully (github-copilot, a per-provider
+  `timeout` or `max_retries`, a model whose provider detection would not
+  round-trip) aborts the run naming the obstacle instead of silently
+  dropping the setting. The legacy default and `fallback_order` become
+  `agent.model` and `agent.fallback`, wire models round-trip exactly, and
+  the legacy block is removed. Separately, a config with **both** formats
+  populated now logs a loud startup warning naming the ignored legacy
+  provider — filling in the `models_config` stub used to flip the entire
+  routing regime with no signal at all.
+
 ## [1.53.0] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ joshbot mcp list    # Review MCP servers and the tools they advertise
 joshbot mcp trust <name>    # Approve an MCP server's tool manifest
 joshbot configure # Configure LLM providers and settings
 joshbot configure --fallback "nvidia,poolside" # Set the provider fallback order ("" clears)
+joshbot configure --migrate # Convert a legacy provider config to the model-centric format
 joshbot auth github-copilot # Authenticate with GitHub Copilot
 joshbot service install # Install joshbot as a system service
 joshbot update # Update to the latest release

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -457,6 +457,10 @@ func newApp() *cli.App {
 						Name:  "fallback",
 						Usage: "Comma-separated provider fallback order (e.g. \"nvidia,poolside\"); pass \"\" to clear",
 					},
+					&cli.BoolFlag{
+						Name:  "migrate",
+						Usage: "Convert a legacy provider config to the model-centric format (refuses lossy conversions)",
+					},
 				},
 				Action: withJSONErrors(runConfigure),
 			},
@@ -605,6 +609,17 @@ func registerProviders(cfg *config.Config, multiProvider *providers.MultiProvide
 	if cfg.UseModelsConfig() {
 		// Use new model-centric configuration
 		log.Info("Using model-centric configuration")
+		// Both formats populated is almost always an accident — a legacy
+		// operator filled in the models_config stub — and the flip is
+		// silent: the legacy block simply stops being read. Say so.
+		for name, p := range cfg.Providers {
+			if p.APIKey != "" && p.Enabled {
+				log.Warn("Both models_config and legacy providers are populated; the legacy block is ignored",
+					"ignored_provider", name,
+					"hint", "run `joshbot configure --migrate` on a legacy config, or empty models_config.models")
+				break
+			}
+		}
 
 		resolvedModels := cfg.GetAllModelConfigs()
 		for i, resolved := range resolvedModels {
@@ -4284,6 +4299,17 @@ func runConfigure(c *cli.Context) error {
 	}
 
 	conf := configure.New(cfg)
+
+	if c.Bool("migrate") {
+		report, err := conf.MigrateToModelsConfig()
+		if err != nil {
+			return err
+		}
+		for _, line := range report {
+			fmt.Println("  " + line)
+		}
+		return flushConfig(cfg)
+	}
 
 	if c.Bool("list") {
 		format, err := outputFormat(c)

--- a/docs/HERMES_PARITY.md
+++ b/docs/HERMES_PARITY.md
@@ -75,8 +75,12 @@ path** from install to working multi-provider fallback.
 - [x] `joshbot configure fallback` (flag + interactive) — first CLI path that
       writes a fallback chain
 - [x] Onboard offers fallback when a second provider key is present in env
-- [ ] Converge on one canonical config format + `joshbot configure migrate`;
-      stop serializing the empty `models_config` stub
+- [x] `joshbot configure --migrate` converts a legacy config to model-centric
+      (all-or-nothing, refuses lossy conversions), and a config with both
+      formats populated warns loudly at startup naming the ignored block
+- [ ] Stop serializing the empty `models_config` stub (blocked on
+      `encoding/json` having no omitempty for struct values; needs a pointer
+      or custom marshal)
 - [x] Full provider menu derived from `configure.SupportedProviders()`
 - [x] Actionable error mapping at the `Process` boundary (401 → configure
       hint, 429-all-failed → fallback hint, model 404 → `/model`/preflight,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -331,6 +331,7 @@ If a provider is present but not registered, `status` says why — for example `
 | `joshbot mcp list` \| `trust <name>` \| `untrust <name>` | Review and approve MCP servers' advertised tools |
 | `joshbot configure` | Configure LLM providers and settings |
 | `joshbot configure --fallback "nvidia,poolside"` | Set the provider fallback order; `""` clears it |
+| `joshbot configure --migrate` | Convert a legacy provider config to the model-centric format (refuses lossy conversions) |
 | `joshbot sessions list` \| `show <id>` \| `prune <id>` \| `new <id>` \| `export <id>` | Inspect, manage and export stored conversations |
 | `joshbot memory status` \| `consolidate` | Inspect and run the Dream two-stage memory system (`agents.defaults.dream_mode`) |
 | `joshbot auth github-copilot [--force]` \| `status` | Manage OAuth authentication |

--- a/internal/configure/migrate.go
+++ b/internal/configure/migrate.go
@@ -1,0 +1,144 @@
+package configure
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bigknoxy/joshbot/internal/config"
+	"github.com/bigknoxy/joshbot/internal/providers"
+)
+
+// MigrateToModelsConfig converts a legacy provider-centric config into the
+// model-centric format and clears the legacy block, returning a human-readable
+// report of what was written.
+//
+// The migration is all-or-nothing and refuses to be lossy: a provider it
+// cannot represent faithfully (github-copilot, whose runtime provider is not
+// an OpenAI-compatible endpoint; a per-provider timeout or max_retries, which
+// ModelConfig has no field for; a model whose provider detection would not
+// round-trip) aborts the whole run with an error naming the obstacle, because
+// a migration that silently drops a setting is worse than no migration. The
+// caller decides whether to save.
+func (c *Configurator) MigrateToModelsConfig() ([]string, error) {
+	cfg := c.cfg
+	if cfg.UseModelsConfig() {
+		return nil, fmt.Errorf("config already uses models_config; nothing to migrate")
+	}
+	if len(cfg.Providers) == 0 {
+		return nil, fmt.Errorf("no legacy providers configured; nothing to migrate")
+	}
+
+	names := make([]string, 0, len(cfg.Providers))
+	for name := range cfg.Providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var models []config.ModelConfig
+	var report []string
+	for _, name := range names {
+		p := cfg.Providers[name]
+		if !p.Enabled {
+			report = append(report, fmt.Sprintf("skipped %s: not enabled", name))
+			continue
+		}
+		if name == "github-copilot" {
+			return nil, fmt.Errorf("cannot migrate github-copilot: its runtime provider is not an OpenAI-compatible endpoint the model-centric format can express; remove it (joshbot configure --remove github-copilot) or keep the legacy format")
+		}
+		if p.Timeout != 0 {
+			return nil, fmt.Errorf("cannot migrate %s: providers.%s.timeout has no model-centric equivalent; clear it first or keep the legacy format", name, name)
+		}
+		if p.MaxRetries != nil {
+			return nil, fmt.Errorf("cannot migrate %s: providers.%s.max_retries has no model-centric equivalent; clear it first or keep the legacy format", name, name)
+		}
+
+		model := p.Model
+		if model == "" {
+			model = providers.GetDefaultModel(name)
+		}
+		if model == "" {
+			return nil, fmt.Errorf("cannot migrate %s: no model configured and no known default", name)
+		}
+		// The model-centric format routes by prefix, so the provider name
+		// becomes the prefix unless the model already carries it (poolside
+		// IDs carry theirs on the wire and DetectProvider recognises them).
+		prefixed := model
+		if config.DetectProvider(model).Name != name {
+			prefixed = name + "/" + model
+		}
+
+		models = append(models, config.ModelConfig{
+			Name:      name,
+			Model:     prefixed,
+			APIKey:    p.APIKey,
+			APIKeys:   p.APIKeys,
+			APIBase:   p.APIBase,
+			Extra:     p.ExtraHeaders,
+			ExtraBody: p.ExtraBody,
+		})
+		report = append(report, fmt.Sprintf("migrated %s -> model %q (wire model %q)", name, name, model))
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("no enabled legacy providers to migrate")
+	}
+
+	// Agent routing: the legacy default becomes agent.model, the rest of the
+	// fallback order (or every other migrated entry) becomes agent.fallback.
+	primary := cfg.ProviderDefaults.Default
+	if !hasModel(models, primary) {
+		primary = models[0].Name
+	}
+	var fallback []string
+	if len(cfg.ProviderDefaults.FallbackOrder) > 0 {
+		for _, n := range cfg.ProviderDefaults.FallbackOrder {
+			if n != primary && hasModel(models, n) {
+				fallback = append(fallback, n)
+			}
+		}
+	} else {
+		for _, m := range models {
+			if m.Name != primary {
+				fallback = append(fallback, m.Name)
+			}
+		}
+	}
+
+	trial := *cfg
+	trial.ModelsConfig = config.ModelsConfig{
+		Models: models,
+		Agent:  config.AgentModelConfig{Model: primary, Fallback: fallback},
+	}
+	// Round-trip check: every migrated entry must resolve, and resolve to the
+	// provider it came from — a detection mismatch means requests would be
+	// attributed (vision screening, notices, fallback rules) to the wrong
+	// provider, so it aborts rather than migrating approximately. "custom"
+	// is exempt from the name check: it is not a real upstream, and its
+	// explicit api_base is what the resolution dials.
+	for _, m := range models {
+		resolved, err := trial.ResolveModelConfig(m.Name)
+		if err != nil {
+			return nil, fmt.Errorf("migration would not resolve %q: %w", m.Name, err)
+		}
+		if m.Name != "custom" && resolved.Provider != m.Name {
+			return nil, fmt.Errorf("cannot migrate %s: model %q resolves to provider %q, not %s — migrate this entry by hand", m.Name, m.Model, resolved.Provider, m.Name)
+		}
+	}
+
+	cfg.ModelsConfig = trial.ModelsConfig
+	cfg.Providers = nil
+	cfg.ProviderDefaults = config.ProviderDefaults{}
+	report = append(report,
+		fmt.Sprintf("agent.model = %q, agent.fallback = [%s]", primary, strings.Join(fallback, ", ")),
+		"legacy providers block removed")
+	return report, nil
+}
+
+func hasModel(models []config.ModelConfig, name string) bool {
+	for _, m := range models {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/configure/migrate_test.go
+++ b/internal/configure/migrate_test.go
@@ -1,0 +1,95 @@
+package configure
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bigknoxy/joshbot/internal/config"
+)
+
+func legacyConfig() *config.Config {
+	cfg := config.Defaults()
+	cfg.ModelsConfig = config.ModelsConfig{}
+	cfg.Providers = map[string]config.ProviderConfig{
+		"nvidia":   {APIKey: "k1", Enabled: true, Model: "z-ai/glm-5.2", APIBase: "https://integrate.api.nvidia.com/v1"},
+		"poolside": {APIKey: "k2", Enabled: true, Model: "poolside/laguna-s-2.1"},
+		"groq":     {APIKey: "k3", Enabled: false},
+	}
+	cfg.ProviderDefaults = config.ProviderDefaults{Default: "nvidia", FallbackOrder: []string{"nvidia", "poolside"}}
+	return cfg
+}
+
+func TestMigrateToModelsConfig(t *testing.T) {
+	cfg := legacyConfig()
+	report, err := New(cfg).MigrateToModelsConfig()
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !cfg.UseModelsConfig() {
+		t.Fatal("config does not use models_config after migration")
+	}
+	if cfg.Providers != nil {
+		t.Error("legacy providers block was not cleared")
+	}
+	if cfg.ModelsConfig.Agent.Model != "nvidia" {
+		t.Errorf("agent.model = %q, want nvidia", cfg.ModelsConfig.Agent.Model)
+	}
+	if len(cfg.ModelsConfig.Agent.Fallback) != 1 || cfg.ModelsConfig.Agent.Fallback[0] != "poolside" {
+		t.Errorf("agent.fallback = %v", cfg.ModelsConfig.Agent.Fallback)
+	}
+	// The wire behaviour must round-trip: nvidia's model gains the routing
+	// prefix and strips back to the exact legacy wire model; poolside's
+	// prefix is part of the real ID and is kept whole.
+	nv, err := cfg.ResolveModelConfig("nvidia")
+	if err != nil || nv.ModelID != "z-ai/glm-5.2" || nv.Provider != "nvidia" || nv.APIKey != "k1" {
+		t.Errorf("nvidia resolved = %+v, err=%v", nv, err)
+	}
+	ps, err := cfg.ResolveModelConfig("poolside")
+	if err != nil || ps.ModelID != "poolside/laguna-s-2.1" || ps.Provider != "poolside" {
+		t.Errorf("poolside resolved = %+v, err=%v", ps, err)
+	}
+	joined := strings.Join(report, "\n")
+	if !strings.Contains(joined, "skipped groq") {
+		t.Errorf("report should note the disabled provider: %v", report)
+	}
+}
+
+func TestMigrateRefusesLossyConversions(t *testing.T) {
+	for name, mutate := range map[string]func(*config.Config){
+		"timeout": func(c *config.Config) {
+			p := c.Providers["nvidia"]
+			p.Timeout = config.Duration(600e9)
+			c.Providers["nvidia"] = p
+		},
+		"max_retries": func(c *config.Config) {
+			p := c.Providers["nvidia"]
+			n := 5
+			p.MaxRetries = &n
+			c.Providers["nvidia"] = p
+		},
+		"github-copilot": func(c *config.Config) {
+			c.Providers["github-copilot"] = config.ProviderConfig{Enabled: true}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := legacyConfig()
+			mutate(cfg)
+			if _, err := New(cfg).MigrateToModelsConfig(); err == nil {
+				t.Fatal("a lossy migration must refuse, not drop the setting")
+			}
+			if cfg.UseModelsConfig() || cfg.Providers == nil {
+				t.Error("a refused migration must leave the config untouched")
+			}
+		})
+	}
+}
+
+func TestMigrateRefusesWhenAlreadyMigrated(t *testing.T) {
+	cfg := legacyConfig()
+	if _, err := New(cfg).MigrateToModelsConfig(); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	if _, err := New(cfg).MigrateToModelsConfig(); err == nil {
+		t.Fatal("second migrate must refuse")
+	}
+}


### PR DESCRIPTION
## Summary
Final Phase 2 item of the Hermes parity plan (config convergence).

`joshbot configure --migrate` converts a legacy provider config to the model-centric format in one command:
- **All-or-nothing, never lossy**: github-copilot, per-provider `timeout`/`max_retries`, or a model whose provider detection wouldn't round-trip abort the run naming the obstacle — a migration that silently drops a setting is worse than none.
- **Round-trip checked before writing**: every migrated entry must `ResolveModelConfig` back to the provider it came from (`custom` exempt from the name check — its explicit `api_base` is what gets dialled).
- Legacy `default`/`fallback_order` → `agent.model`/`agent.fallback`; wire models identical; legacy block removed.
- **Both-formats warning**: a config with legacy providers *and* a populated `models_config` now logs a loud startup warning naming the ignored provider — filling the stub used to silently flip the whole routing regime.

Left open in the plan: not serializing the empty `models_config` stub (encoding/json has no omitempty for struct values; needs a pointer field or custom marshal — a bigger change than this PR should carry).

## Proof
- Unit tests: successful migration (round-trip of nvidia's prefixed model and poolside's prefix-is-the-ID model, fallback mapping, disabled-provider skip), all three lossy refusals leave the config untouched, double-migrate refuses.
- **Binary dogfood**: onboard → `--fallback` → `--migrate` → runtime behaved identically: rate-limited primary fell over to poolside with its own model and the fallback notice.

Docs: README, docs/INSTALL.md, CHANGELOG, HERMES_PARITY (item split: migrate shipped, stub-serialization tracked as blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)