### PR TITLE
feat(agent): --continue with session recap; empty replies are real errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`joshbot agent --continue` (`-c`) resumes the most recently updated
+  session** — no session id needed. A one-line recap goes to stderr so
+  scripted stdout stays data-only; `--continue` with `--resume` is a
+  validation error. Interactive `joshbot agent` now opens with a short
+  recap of the last exchange when the session has history ("Continuing
+  conversation (4 messages). Last exchange: ..."), silent on a fresh
+  session.
+
+### Fixed
+
+- **An empty model reply is now reported as the failure it is.** Empty
+  content with no tool calls used to become "I've processed your request."
+  — and a choiceless response "I didn't get a response. Please try again."
+  — both with a nil error, which reached scripts as exit 0 and the HTTP
+  API as a 200. Both now go through the in-band error contract: `agent -m`
+  exits 1, the API returns 502, and the message says it is a provider
+  problem.
+
+### Added
+
 - **`joshbot configure --migrate` converts a legacy provider config to the
   model-centric format.** All-or-nothing and deliberately non-lossy: a
   provider it cannot represent faithfully (github-copilot, a per-provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`joshbot agent --continue` (`-c`) resumes the most recently updated
   session** — no session id needed. A one-line recap goes to stderr so
   scripted stdout stays data-only; `--continue` with `--resume` is a
-  validation error. Interactive `joshbot agent` now opens with a short
+  validation error, and so is `--continue` without `-m` — the interactive
+  loop always continues `cli:cli_user`, so honouring it there would
+  announce one session and then talk in another. Interactive `joshbot
+  agent` instead opens with a short
   recap of the last exchange when the session has history ("Continuing
   conversation (4 messages). Last exchange: ..."), silent on a fresh
   session.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ joshbot agent -m "run the tests" --output-format stream-json
 # Resume a prior session by the id echoed in a previous json result
 joshbot agent -m "and now lint it" --output-format json --resume <session-id>
 
+# Or just continue the most recently updated session, no id needed
+joshbot agent -m "and now lint it" --continue
+
 # Attach an image (repeatable; requires a vision-capable model)
 joshbot agent -m "what is in this screenshot?" --image ~/Desktop/shot.png
 ```

--- a/cmd/joshbot/continue_test.go
+++ b/cmd/joshbot/continue_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bigknoxy/joshbot/internal/session"
+)
+
+func newTestSessions(t *testing.T) *session.Manager {
+	t.Helper()
+	mgr, err := session.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mgr
+}
+
+func addTurn(t *testing.T, mgr *session.Manager, id, user, assistant string) {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := mgr.GetOrCreate(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess.AddMessage(session.Message{Role: session.RoleUser, Content: user, Timestamp: time.Now()})
+	sess.AddMessage(session.Message{Role: session.RoleAssistant, Content: assistant, Timestamp: time.Now()})
+	if err := mgr.Save(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// --continue resolves to the most recently updated session, whatever channel
+// it came from.
+func TestLatestSessionPicksMostRecent(t *testing.T) {
+	mgr := newTestSessions(t)
+	addTurn(t, mgr, "cli:cli_user", "old question", "old answer")
+	time.Sleep(20 * time.Millisecond) // mtime granularity
+	addTurn(t, mgr, "telegram:12345", "newer question", "newer answer")
+
+	info, err := latestSession(context.Background(), mgr)
+	if err != nil {
+		t.Fatalf("latestSession: %v", err)
+	}
+	if info.ID != "telegram:12345" {
+		t.Errorf("latestSession = %q, want the newer telegram session", info.ID)
+	}
+}
+
+func TestLatestSessionEmptyDirErrors(t *testing.T) {
+	mgr := newTestSessions(t)
+	if _, err := latestSession(context.Background(), mgr); err == nil {
+		t.Fatal("no sessions must be an error, not a silent fresh session")
+	}
+}
+
+// The interactive recap shows the last exchange and is silent for a fresh
+// session — a banner about nothing is noise.
+func TestPrintSessionRecap(t *testing.T) {
+	mgr := newTestSessions(t)
+	var out bytes.Buffer
+	printSessionRecap(context.Background(), mgr, &out)
+	if out.Len() != 0 {
+		t.Errorf("fresh session should print nothing, got %q", out.String())
+	}
+
+	addTurn(t, mgr, "cli:cli_user", "what is the plan for today", "Ship phase three.")
+	out.Reset()
+	printSessionRecap(context.Background(), mgr, &out)
+	s := out.String()
+	for _, want := range []string{"Continuing conversation", "what is the plan for today", "Ship phase three.", "/new"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("recap missing %q:\n%s", want, s)
+		}
+	}
+}
+
+func TestTruncateLineFlattensAndCaps(t *testing.T) {
+	got := truncateLine("a\nb\t c   d", 100)
+	if got != "a b c d" {
+		t.Errorf("flatten = %q", got)
+	}
+	long := strings.Repeat("x", 150)
+	if got := truncateLine(long, 100); len([]rune(got)) != 101 || !strings.HasSuffix(got, "…") {
+		t.Errorf("cap = %q (len %d)", got, len([]rune(got)))
+	}
+}

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -1497,11 +1497,16 @@ func runAgent(c *cli.Context) error {
 
 	// --continue threads onto the most recently updated session without the
 	// caller having to know its id. The recap goes to stderr so scripted
-	// stdout stays data-only.
+	// stdout stays data-only. It is headless-only: the interactive loop
+	// always opens cli:cli_user, so honouring --continue there would
+	// announce one session and then talk in another.
 	resume := c.String("resume")
 	if c.Bool("continue") {
 		if resume != "" {
 			return exitErrorf(exitValidation, "--continue and --resume are mutually exclusive")
+		}
+		if !jsonMode && c.String("message") == "" {
+			return exitErrorf(exitValidation, "--continue requires -m/--message: the interactive session always continues cli:cli_user (a recap is shown on startup)")
 		}
 		info, err := latestSession(ctx, sessionMgr)
 		if err != nil {

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -303,6 +303,11 @@ func newApp() *cli.App {
 						Aliases: []string{"session"},
 						Usage:   "Resume a prior session by its id (from a previous json result)",
 					},
+					&cli.BoolFlag{
+						Name:    "continue",
+						Aliases: []string{"c"},
+						Usage:   "Resume the most recently updated session (mutually exclusive with --resume)",
+					},
 					&cli.StringFlag{
 						Name:    "message",
 						Aliases: []string{"m"},
@@ -1441,7 +1446,7 @@ func runAgent(c *cli.Context) error {
 	log.Info("Starting agent mode", "model", modelName)
 
 	// Setup components
-	_, _, _, agentInstance, toolsRegistry, messageSender, err := setupComponents(cfg)
+	_, _, sessionMgr, agentInstance, toolsRegistry, messageSender, err := setupComponents(cfg)
 	defer closeMCPServers()
 	defer stopBackgroundServices()
 	if err != nil {
@@ -1490,20 +1495,42 @@ func runAgent(c *cli.Context) error {
 		}
 	}()
 
+	// --continue threads onto the most recently updated session without the
+	// caller having to know its id. The recap goes to stderr so scripted
+	// stdout stays data-only.
+	resume := c.String("resume")
+	if c.Bool("continue") {
+		if resume != "" {
+			return exitErrorf(exitValidation, "--continue and --resume are mutually exclusive")
+		}
+		info, err := latestSession(ctx, sessionMgr)
+		if err != nil {
+			return exitErrorf(exitGeneral, "--continue: %w", err)
+		}
+		resume = info.ID
+		fmt.Fprintf(os.Stderr, "Continuing session %s (%d messages, last active %s)\n",
+			info.ID, info.Messages, humanizeSince(info.UpdatedAt))
+	}
+
 	// Non-interactive JSON modes: machine-readable single turn.
 	if jsonMode {
-		err := runAgentJSON(ctx, agentInstance, c.String("message"), format, c.String("resume"), os.Stdout, os.Stderr, messageSender, images...)
+		err := runAgentJSON(ctx, agentInstance, c.String("message"), format, resume, os.Stdout, os.Stderr, messageSender, images...)
 		time.Sleep(2 * time.Second) // let async callbacks drain to stderr
 		return err
 	}
 
 	// Non-interactive text mode: send single message and exit.
 	if message := c.String("message"); message != "" {
-		err := runAgentSingleMessage(ctx, agentInstance, message, c.String("resume"), os.Stdout, messageSender, images...)
+		err := runAgentSingleMessage(ctx, agentInstance, message, resume, os.Stdout, messageSender, images...)
 		// Wait a bit for async callbacks
 		time.Sleep(2 * time.Second)
 		return err
 	}
+
+	// Interactive sessions always continue cli:cli_user, so say what is being
+	// continued: a short recap of the last exchange, the way a resumed
+	// conversation opens anywhere else. Silent for a fresh session.
+	printSessionRecap(ctx, sessionMgr, os.Stdout)
 
 	done := make(chan struct{})
 	setupGracefulShutdown(ctx, cancel, done)
@@ -1933,6 +1960,88 @@ func parseLogLevel(s string) (log.Level, error) {
 func applyNoColor() {
 	log.Get().Logger.SetColorProfile(termenv.Ascii)
 	lipgloss.SetColorProfile(termenv.Ascii)
+}
+
+// latestSession returns the most recently updated session's Info, for
+// --continue. Corrupt sessions still count: their mtime is real, and refusing
+// to continue the conversation the user just had because one line failed to
+// parse would be the wrong trade.
+func latestSession(ctx context.Context, mgr *session.Manager) (session.Info, error) {
+	infos, err := mgr.ListInfo(ctx)
+	if err != nil {
+		return session.Info{}, fmt.Errorf("could not list sessions: %w", err)
+	}
+	if len(infos) == 0 {
+		return session.Info{}, fmt.Errorf("no sessions to continue — start one with `joshbot agent -m \"...\"`")
+	}
+	latest := infos[0]
+	for _, info := range infos[1:] {
+		if info.UpdatedAt.After(latest.UpdatedAt) {
+			latest = info
+		}
+	}
+	return latest, nil
+}
+
+// humanizeSince renders a time as a coarse "2h ago" style age.
+func humanizeSince(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 48*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+// printSessionRecap opens an interactive run with a short recap of the CLI
+// session's last exchange, so continuing a conversation reads as continuing
+// one. Best-effort and silent on any failure or a fresh session — a recap is
+// never worth blocking startup for.
+func printSessionRecap(ctx context.Context, mgr *session.Manager, output io.Writer) {
+	if mgr == nil {
+		return
+	}
+	sess, err := mgr.Load(ctx, "cli:cli_user")
+	if err != nil || sess == nil || len(sess.Messages) == 0 {
+		return
+	}
+	var lastUser, lastAssistant string
+	for i := len(sess.Messages) - 1; i >= 0; i-- {
+		m := sess.Messages[i]
+		if lastAssistant == "" && m.Role == session.RoleAssistant && m.Content != "" {
+			lastAssistant = m.Content
+		}
+		if m.Role == session.RoleUser && m.Content != "" {
+			lastUser = m.Content
+			break
+		}
+	}
+	if lastUser == "" && lastAssistant == "" {
+		return
+	}
+	fmt.Fprintf(output, "Continuing conversation (%d messages). Last exchange:\n", len(sess.Messages))
+	if lastUser != "" {
+		fmt.Fprintf(output, "  you: %s\n", truncateLine(lastUser, 100))
+	}
+	if lastAssistant != "" {
+		fmt.Fprintf(output, "  joshbot: %s\n", truncateLine(lastAssistant, 100))
+	}
+	fmt.Fprintln(output, "Type /new to start fresh.")
+}
+
+// truncateLine flattens a message to one line and caps its width.
+func truncateLine(s string, width int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) <= width {
+		return s
+	}
+	return string(r[:width]) + "…"
 }
 
 // headlessSession resolves the (channel, senderID) pair that getSessionKey in

--- a/docs/HERMES_PARITY.md
+++ b/docs/HERMES_PARITY.md
@@ -88,9 +88,9 @@ path** from install to working multi-provider fallback.
 
 ### Phase 3 — session & loop polish
 
-- [ ] `joshbot agent --continue` + short recap on resume
+- [x] `joshbot agent --continue` + short recap on resume
 - [ ] Session search over the JSONL store
-- [ ] Empty LLM content surfaces as a provider error, not "I've processed
+- [x] Empty LLM content surfaces as a provider error, not "I've processed
       your request."
 - [ ] Esc interrupts a running CLI turn, marked interrupted in the session
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -655,8 +655,11 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 
 		// Check if we have a valid response
 		if len(resp.Choices) == 0 {
+			// Same contract as empty content below: a choiceless response is
+			// a failure, and returning friendly text with a nil error let it
+			// reach scripts as exit 0 and the HTTP API as a 200.
 			a.logger.Warn("Empty response from LLM")
-			return "I didn't get a response. Please try again.", nil
+			return "", fmt.Errorf("the model returned a response with no choices — this is a provider problem, not an answer")
 		}
 
 		choice := resp.Choices[0]
@@ -674,11 +677,17 @@ func (a *Agent) reactLoop(ctx context.Context, messages []providers.Message, ses
 		if len(assistantMsg.ToolCalls) == 0 {
 			content := assistantMsg.Content
 			if content == "" {
-				a.logger.Warn("Empty content from LLM - triggering fallback message",
+				// An empty reply with no tool calls is a provider problem,
+				// and it used to be papered over with "I've processed your
+				// request." — a confident non-answer that reached scripts as
+				// exit 0 and the HTTP API as a 200. Report it as the failure
+				// it is; Process wraps it into the in-band ReplyPrefix
+				// contract every caller already translates.
+				a.logger.Warn("Empty content from LLM",
 					"model", a.getModelName(),
 					"iteration", iteration+1,
 				)
-				content = "I've processed your request."
+				return "", fmt.Errorf("the model returned an empty reply (no text, no tool calls) — this is a provider problem, not an answer")
 			}
 
 			// Sanitize: strip internal context tags from response

--- a/internal/agent/empty_reply_test.go
+++ b/internal/agent/empty_reply_test.go
@@ -1,0 +1,58 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bigknoxy/joshbot/internal/bus"
+	"github.com/bigknoxy/joshbot/internal/providers"
+)
+
+// An empty reply is a provider failure, not an answer. It used to become
+// "I've processed your request." with a nil error — exit 0 for scripts, a 200
+// for the HTTP API — so the contract here is that it reaches Process's
+// in-band error path, which every non-interactive caller already translates.
+func TestProcess_EmptyContentIsAnError(t *testing.T) {
+	cfg := newNonStreamingConfig()
+	provider := &mockProvider{
+		chatFn: func(ctx context.Context, req providers.ChatRequest) (*providers.ChatResponse, error) {
+			return &providers.ChatResponse{Choices: []providers.Choice{{
+				Message: providers.Message{Role: providers.RoleAssistant, Content: ""},
+			}}}, nil
+		},
+	}
+	a := NewAgent(cfg, provider, &mockToolExecutor{}, newMockSessionManager(), newMockLogger())
+	got, err := a.Process(context.Background(), bus.InboundMessage{
+		SenderID: "u", Content: "hi", Channel: "cli", Timestamp: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if ReplyError(got) == nil {
+		t.Fatalf("empty content must be an in-band error, got %q", got)
+	}
+	if strings.Contains(got, "I've processed your request") {
+		t.Errorf("the confident non-answer is back: %q", got)
+	}
+}
+
+func TestProcess_NoChoicesIsAnError(t *testing.T) {
+	cfg := newNonStreamingConfig()
+	provider := &mockProvider{
+		chatFn: func(ctx context.Context, req providers.ChatRequest) (*providers.ChatResponse, error) {
+			return &providers.ChatResponse{}, nil
+		},
+	}
+	a := NewAgent(cfg, provider, &mockToolExecutor{}, newMockSessionManager(), newMockLogger())
+	got, err := a.Process(context.Background(), bus.InboundMessage{
+		SenderID: "u", Content: "hi", Channel: "cli", Timestamp: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if ReplyError(got) == nil {
+		t.Fatalf("a choiceless response must be an in-band error, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
Phase 3 of the Hermes parity plan, first two items.

**`joshbot agent --continue` (`-c`)** — resumes the most recently updated session across all channels, no id needed. Recap to stderr (scripted stdout stays data-only); `--continue` + `--resume` is a validation error (exit 3). Interactive `joshbot agent` opens with a short recap of the last exchange when history exists — the Hermes recap panel, minimally.

**Empty replies are failures** — empty content and choiceless responses used to become confident non-answers with nil errors (exit 0 / HTTP 200). Both now flow through the in-band `ReplyPrefix` contract: `agent -m` exits 1, the API 502s, and the message names it a provider problem.

## Proof
- Unit tests: latest-session selection by mtime across channels, empty-dir error, recap content + fresh-session silence, truncation, both empty-reply error paths translate via `ReplyError`.
- **Sandbox dogfood** (isolated HOME + fake provider): `--continue` threaded onto the prior session (2 → 4 messages) with the stderr recap; interactive run opened with the last exchange; empty-reply fake → exit 1 with the provider-problem message; `--continue --resume` → exit 3.

Docs: README, CHANGELOG, HERMES_PARITY checkboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)