### PR TITLE
feat(session): conversation search (CLI + agent tool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent the same recall — "what did we decide about X last week" is now
   answered from the transcripts, on any channel, instead of guessed.
 
-### Added
-
 - **`joshbot agent --continue` (`-c`) resumes the most recently updated
   session** — no session id needed. A one-line recap goes to stderr so
   scripted stdout stays data-only; `--continue` with `--resume` is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Conversation search.** `joshbot sessions search <query> [--limit N]`
+  greps every session transcript (case-insensitive, newest first, redacted
+  output, sidecars excluded), and the new `session_search` tool gives the
+  agent the same recall — "what did we decide about X last week" is now
+  answered from the transcripts, on any channel, instead of guessed.
+
+### Added
+
 - **`joshbot agent --continue` (`-c`) resumes the most recently updated
   session** — no session id needed. A one-line recap goes to stderr so
   scripted stdout stays data-only; `--continue` with `--resume` is a

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ commands give you is a way to see what exists, read one back, and clear one.
 joshbot sessions list                    # ID, message count, size, age, notes
 joshbot sessions show <id>               # print the conversation (redacted)
 joshbot sessions show <id> --last 20     # just the tail
+joshbot sessions search "magic word"     # grep every transcript, newest first
 joshbot sessions prune <id>              # delete one conversation
 joshbot sessions prune --older-than 30d  # delete everything untouched for 30 days
 joshbot sessions new <id>                # archive it and start empty

--- a/cmd/joshbot/main.go
+++ b/cmd/joshbot/main.go
@@ -1050,6 +1050,12 @@ func setupComponents(cfg *config.Config) (*bus.MessageBus, providers.Provider, *
 	asyncCallbackCh := make(chan tools.AsyncResult, 100)
 	toolsRegistry.SetAsyncCallback(asyncCallbackCh)
 	toolsRegistry.Register(tools.NewMemorySearchTool(memoryManager))
+	// Conversation recall across every channel — "what did we decide about X"
+	// answered from transcripts. Registered only with a live session manager,
+	// like the cron tool.
+	if sessionMgr != nil {
+		toolsRegistry.Register(tools.NewSessionSearchTool(sessionMgr))
+	}
 
 	// Create subagent runner for parallel and chain execution tools
 	agentModel := cfg.Agents.Defaults.Model

--- a/cmd/joshbot/sessions_cmd.go
+++ b/cmd/joshbot/sessions_cmd.go
@@ -62,6 +62,18 @@ func sessionsCommand() *cli.Command {
 				Action: runSessionsShow,
 			},
 			{
+				Name:      "search",
+				Usage:     "Search every session transcript for a phrase (redacted output)",
+				ArgsUsage: "<query>",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "limit",
+						Usage: "Max matches to show (default 10)",
+					},
+				},
+				Action: runSessionsSearch,
+			},
+			{
 				Name:      "prune",
 				Usage:     "Delete a session, or every session older than a duration",
 				ArgsUsage: "[session id]",
@@ -476,4 +488,57 @@ func parseSessionArgs(args []string, allowLast, allowOlderThan, allowOut bool) (
 		}
 	}
 	return out, nil
+}
+
+// runSessionsSearch greps every transcript for a phrase. The query is every
+// positional argument joined, so quoting is optional; a trailing --limit is
+// parsed by hand because urfave/cli stops flag parsing at the first
+// positional (the `prune <id> --force` trap, same treatment).
+func runSessionsSearch(c *cli.Context) error {
+	limit := c.Int("limit")
+	var words []string
+	args := c.Args().Slice()
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--limit" && i+1 < len(args):
+			if n, err := strconv.Atoi(args[i+1]); err == nil {
+				limit = n
+			}
+			i++
+		case strings.HasPrefix(arg, "--limit="):
+			if n, err := strconv.Atoi(strings.TrimPrefix(arg, "--limit=")); err == nil {
+				limit = n
+			}
+		default:
+			words = append(words, arg)
+		}
+	}
+	query := strings.TrimSpace(strings.Join(words, " "))
+	if query == "" {
+		return exitErrorf(exitValidation, "usage: joshbot sessions search <query> [--limit N]")
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+
+	mgr, err := sessionManagerForCLI(c)
+	if err != nil {
+		return err
+	}
+	matches, err := mgr.Search(c.Context, query, limit)
+	if err != nil {
+		return exitErrorf(exitGeneral, "search failed: %w", err)
+	}
+	out := sessionsOut()
+	if len(matches) == 0 {
+		fmt.Fprintf(out, "No matches for %q.\n", query)
+		return nil
+	}
+	for _, m := range matches {
+		fmt.Fprintf(out, "%s  %s  %s\n    %s\n",
+			m.Timestamp.Format("2006-01-02 15:04"), m.SessionID, m.Role, m.Snippet)
+	}
+	fmt.Fprintf(out, "\n%d match(es).\n", len(matches))
+	return nil
 }

--- a/docs/HERMES_PARITY.md
+++ b/docs/HERMES_PARITY.md
@@ -89,7 +89,7 @@ path** from install to working multi-provider fallback.
 ### Phase 3 — session & loop polish
 
 - [x] `joshbot agent --continue` + short recap on resume
-- [ ] Session search over the JSONL store
+- [x] Session search over the JSONL store
 - [x] Empty LLM content surfaces as a provider error, not "I've processed
       your request."
 - [ ] Esc interrupts a running CLI turn, marked interrupted in the session

--- a/internal/session/search.go
+++ b/internal/session/search.go
@@ -104,13 +104,20 @@ func (m *Manager) Search(ctx context.Context, query string, limit int) ([]Search
 // occurrence of needle (already lower-cased).
 func snippetAround(content, needle string) string {
 	flat := strings.Join(strings.Fields(content), " ")
-	idx := strings.Index(strings.ToLower(flat), needle)
+	lower := strings.ToLower(flat)
+	idx := strings.Index(lower, needle)
 	if idx < 0 {
 		idx = 0
 	}
 	runes := []rune(flat)
-	// Byte index -> rune index for the window start.
-	start := len([]rune(flat[:idx]))
+	// The byte offset is into the lowered string, whose byte and rune
+	// lengths can differ from the original's (İ lowers to two runes), so
+	// convert within the lowered string and clamp: a slightly drifted
+	// window on exotic Unicode beats a slice panic.
+	start := len([]rune(lower[:idx]))
+	if start > len(runes) {
+		start = len(runes)
+	}
 	from := start - maxSnippetRunes/4
 	if from < 0 {
 		from = 0

--- a/internal/session/search.go
+++ b/internal/session/search.go
@@ -1,0 +1,130 @@
+package session
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// SearchMatch is one message that matched a session search.
+type SearchMatch struct {
+	SessionID string
+	Role      Role
+	Snippet   string // the matching message flattened and trimmed around the hit
+	Timestamp time.Time
+}
+
+// maxSnippetRunes bounds a snippet so a match inside a pasted document does
+// not return the document.
+const maxSnippetRunes = 200
+
+// Search scans every live session transcript for messages containing query
+// (case-insensitive) and returns the newest matches first, capped at limit.
+//
+// It is deliberately grep-grade: session files are line-delimited JSON read
+// with the same leniency as Load (an unparseable line is skipped, never
+// fatal), sidecars are excluded via isSessionFile, and nothing is written —
+// like ListInfo, an inventory operation must not quarantine or rewrite.
+// Compaction summaries are searched too: after a compaction they are the only
+// remaining record of the earlier conversation.
+func (m *Manager) Search(ctx context.Context, query string, limit int) ([]SearchMatch, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	needle := strings.ToLower(query)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	entries, err := os.ReadDir(m.sessionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var matches []SearchMatch
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if entry.IsDir() {
+			continue
+		}
+		id, ok := isSessionFile(entry.Name())
+		if !ok {
+			continue
+		}
+		file, err := os.Open(filepath.Join(m.sessionsDir, entry.Name()))
+		if err != nil {
+			continue // transient read errors skip the session, not the search
+		}
+		scanner := bufio.NewScanner(file)
+		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for scanner.Scan() {
+			var msg Message
+			if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+				continue
+			}
+			if msg.Content == "" {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(msg.Content), needle) {
+				continue
+			}
+			matches = append(matches, SearchMatch{
+				SessionID: id,
+				Role:      msg.Role,
+				Snippet:   snippetAround(msg.Content, needle),
+				Timestamp: msg.Timestamp,
+			})
+		}
+		file.Close()
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].Timestamp.After(matches[j].Timestamp)
+	})
+	if len(matches) > limit {
+		matches = matches[:limit]
+	}
+	return matches, nil
+}
+
+// snippetAround flattens content to one line and windows it around the first
+// occurrence of needle (already lower-cased).
+func snippetAround(content, needle string) string {
+	flat := strings.Join(strings.Fields(content), " ")
+	idx := strings.Index(strings.ToLower(flat), needle)
+	if idx < 0 {
+		idx = 0
+	}
+	runes := []rune(flat)
+	// Byte index -> rune index for the window start.
+	start := len([]rune(flat[:idx]))
+	from := start - maxSnippetRunes/4
+	if from < 0 {
+		from = 0
+	}
+	to := from + maxSnippetRunes
+	if to > len(runes) {
+		to = len(runes)
+	}
+	s := string(runes[from:to])
+	if from > 0 {
+		s = "…" + s
+	}
+	if to < len(runes) {
+		s += "…"
+	}
+	return s
+}

--- a/internal/session/search_test.go
+++ b/internal/session/search_test.go
@@ -1,0 +1,96 @@
+package session
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func searchFixture(t *testing.T) *Manager {
+	t.Helper()
+	mgr, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	add := func(id string, role Role, content string, at time.Time) {
+		sess, err := mgr.GetOrCreate(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sess.AddMessage(Message{Role: role, Content: content, Timestamp: at})
+		if err := mgr.Save(ctx, sess); err != nil {
+			t.Fatal(err)
+		}
+	}
+	base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	add("cli:cli_user", RoleUser, "let's plan the banana deployment", base)
+	add("cli:cli_user", RoleAssistant, "The BANANA deployment is scheduled for Friday.", base.Add(time.Minute))
+	add("telegram:12345", RoleUser, "remind me about the apple harvest", base.Add(2*time.Minute))
+	return mgr
+}
+
+func TestSearchFindsAcrossSessionsCaseInsensitive(t *testing.T) {
+	mgr := searchFixture(t)
+	matches, err := mgr.Search(context.Background(), "banana", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("matches = %d, want 2 (case-insensitive)", len(matches))
+	}
+	// Newest first.
+	if !matches[0].Timestamp.After(matches[1].Timestamp) {
+		t.Errorf("matches not newest-first: %v then %v", matches[0].Timestamp, matches[1].Timestamp)
+	}
+	if matches[0].Role != RoleAssistant || !strings.Contains(matches[0].Snippet, "BANANA deployment") {
+		t.Errorf("match[0] = %+v", matches[0])
+	}
+}
+
+func TestSearchLimitAndNoMatch(t *testing.T) {
+	mgr := searchFixture(t)
+	matches, err := mgr.Search(context.Background(), "banana", 1)
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("limit ignored: %d matches, err=%v", len(matches), err)
+	}
+	matches, err = mgr.Search(context.Background(), "durian", 10)
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("phantom matches: %v, err=%v", matches, err)
+	}
+	if m, err := mgr.Search(context.Background(), "   ", 10); err != nil || m != nil {
+		t.Fatalf("blank query must return nothing, got %v, %v", m, err)
+	}
+}
+
+func TestSearchSkipsSidecars(t *testing.T) {
+	mgr := searchFixture(t)
+	ctx := context.Background()
+	// The compaction archive also ends in .jsonl; a search over it would
+	// resurrect messages compaction removed and report a phantom session.
+	if err := mgr.Archive(ctx, "cli:cli_user", []Message{{Role: RoleUser, Content: "archived banana", Timestamp: time.Now()}}); err != nil {
+		t.Fatal(err)
+	}
+	matches, err := mgr.Search(ctx, "archived banana", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("search read a sidecar: %+v", matches)
+	}
+}
+
+func TestSnippetWindowsAroundTheHit(t *testing.T) {
+	long := strings.Repeat("pad ", 100) + "NEEDLE here" + strings.Repeat(" tail", 100)
+	s := snippetAround(long, "needle")
+	if !strings.Contains(s, "NEEDLE") {
+		t.Fatalf("snippet lost the hit: %q", s)
+	}
+	if len([]rune(s)) > maxSnippetRunes+2 {
+		t.Errorf("snippet too long: %d runes", len([]rune(s)))
+	}
+	if !strings.HasPrefix(s, "…") || !strings.HasSuffix(s, "…") {
+		t.Errorf("snippet should mark truncation on both ends: %q", s)
+	}
+}

--- a/internal/tools/session_search.go
+++ b/internal/tools/session_search.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bigknoxy/joshbot/internal/session"
+)
+
+// SessionSearchTool lets the agent search its own past conversations across
+// every channel — "what did we decide about X last week" answered from the
+// transcripts instead of guessed. Registered only when a session manager is
+// wired, like the cron tool: the agent is never offered a search over a store
+// that is not there.
+type SessionSearchTool struct {
+	sessions *session.Manager
+}
+
+func NewSessionSearchTool(sessions *session.Manager) *SessionSearchTool {
+	return &SessionSearchTool{sessions: sessions}
+}
+
+func (t *SessionSearchTool) Name() string { return "session_search" }
+
+func (t *SessionSearchTool) Description() string {
+	return "session_search: search past conversation transcripts across all channels for a phrase; returns the newest matching messages with timestamps. Use when asked about something discussed earlier that is not in the current context."
+}
+
+func (t *SessionSearchTool) Parameters() []Parameter {
+	return []Parameter{
+		{
+			Name:        "query",
+			Type:        "string",
+			Description: "Text to search for (case-insensitive substring)",
+			Required:    true,
+		},
+		{
+			Name:        "max_results",
+			Type:        "integer",
+			Description: "Max matches to return (default 10)",
+		},
+	}
+}
+
+func (t *SessionSearchTool) Execute(ctx interface{}, args map[string]any) ToolResult {
+	query, _ := args["query"].(string)
+	if strings.TrimSpace(query) == "" {
+		return ToolResult{Error: fmt.Errorf("query is required")}
+	}
+	limit := 10
+	if m, ok := args["max_results"].(float64); ok && int(m) > 0 {
+		limit = int(m)
+	}
+
+	execCtx, ok := ctx.(context.Context)
+	if !ok {
+		execCtx = context.Background()
+	}
+	matches, err := t.sessions.Search(execCtx, query, limit)
+	if err != nil {
+		return ToolResult{Error: fmt.Errorf("search failed: %w", err)}
+	}
+	if len(matches) == 0 {
+		return ToolResult{Output: fmt.Sprintf("No past messages match %q.", query)}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d match(es) for %q, newest first:\n", len(matches), query)
+	for _, m := range matches {
+		fmt.Fprintf(&b, "- [%s] %s (%s): %s\n",
+			m.Timestamp.Format(time.DateTime), m.SessionID, m.Role, m.Snippet)
+	}
+	return ToolResult{Output: b.String()}
+}

--- a/internal/tools/session_search.go
+++ b/internal/tools/session_search.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bigknoxy/joshbot/internal/redact"
 	"github.com/bigknoxy/joshbot/internal/session"
 )
 
@@ -72,5 +73,8 @@ func (t *SessionSearchTool) Execute(ctx interface{}, args map[string]any) ToolRe
 		fmt.Fprintf(&b, "- [%s] %s (%s): %s\n",
 			m.Timestamp.Format(time.DateTime), m.SessionID, m.Role, m.Snippet)
 	}
-	return ToolResult{Output: b.String()}
+	// Session files are stored unredacted (the 0600 mode is the boundary),
+	// and this output re-enters a live conversation — an old transcript that
+	// captured a credential must not resurface it into the current chat.
+	return ToolResult{Output: redact.String(b.String())}
 }


### PR DESCRIPTION
## Summary
Phase 3 of the Hermes parity plan: session search over the JSONL store.

- `joshbot sessions search <query> [--limit N]` — case-insensitive grep across every live transcript, newest first, snippets windowed around the hit, redacted output. Sidecars excluded (searching the compaction archive would resurrect removed messages); read-only with Load's leniency; trailing `--limit` parsed by hand (the urfave/cli first-positional trap).
- `session_search` agent tool — the same recall for the agent itself, on any channel. From Telegram: "what did we decide about X last week" now gets answered from the transcripts. Registered only when a session manager is wired (the cron-tool pattern).

## Proof
- Unit tests: cross-session case-insensitive matching, newest-first ordering, limit, blank-query, sidecar exclusion, snippet windowing.
- Sandbox dogfood: `sessions search banana` and `search "magic word" --limit 2` found the earlier dogfood turns; `/status` shows the tool registered (24 → 25).

Docs: README, CHANGELOG, HERMES_PARITY checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)