### PR TITLE
test(cmd): trailing-flags guard learns sessions search --limit

### DIFF
--- a/cmd/joshbot/app_surface_test.go
+++ b/cmd/joshbot/app_surface_test.go
@@ -100,7 +100,10 @@ func TestDocumentedCommandsExist(t *testing.T) {
 // silently reports an unknown flag or drops it. Pin the set so that addition
 // has to be deliberate.
 func TestSessionsSubcommandFlagsAreKnownToTheTrailingParser(t *testing.T) {
-	known := map[string]bool{"force": true, "last": true, "older-than": true, "out": true}
+	// "limit" is handled by runSessionsSearch's own trailing parse (its
+	// positional is free text, not a session id, so parseSessionArgs does
+	// not apply); the others by parseSessionArgs.
+	known := map[string]bool{"force": true, "last": true, "older-than": true, "out": true, "limit": true}
 
 	var sessions *cli.Command
 	for _, c := range newApp().Commands {

--- a/cmd/joshbot/continue_test.go
+++ b/cmd/joshbot/continue_test.go
@@ -88,3 +88,30 @@ func TestTruncateLineFlattensAndCaps(t *testing.T) {
 		t.Errorf("cap = %q (len %d)", got, len([]rune(got)))
 	}
 }
+
+func TestHumanizeSince(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		age  time.Duration
+		want string
+	}{
+		{30 * time.Second, "just now"},
+		{5 * time.Minute, "5m ago"},
+		{3 * time.Hour, "3h ago"},
+		{72 * time.Hour, "3d ago"},
+	}
+	for _, tc := range cases {
+		if got := humanizeSince(now.Add(-tc.age)); got != tc.want {
+			t.Errorf("humanizeSince(-%v) = %q, want %q", tc.age, got, tc.want)
+		}
+	}
+}
+
+func TestSplitCommaList(t *testing.T) {
+	if got := splitCommaList(" a, b ,,c "); len(got) != 3 || got[0] != "a" || got[2] != "c" {
+		t.Errorf("splitCommaList = %v", got)
+	}
+	if got := splitCommaList(""); got != nil {
+		t.Errorf("empty should be nil, got %v", got)
+	}
+}

--- a/cmd/joshbot/sessions_cmd_test.go
+++ b/cmd/joshbot/sessions_cmd_test.go
@@ -519,3 +519,51 @@ func TestPruneRejectsIdAndOlderThanInEitherOrder(t *testing.T) {
 		}
 	}
 }
+
+// The search subcommand: query joined from positionals, trailing --limit
+// parsed by hand, redacted output, usage error on no query.
+func TestSessionsSearchCommand(t *testing.T) {
+	configPath, dir := sessionsEnv(t)
+	seedCLISession(t, dir, "cli:alpha", "the magic word is banana", "unrelated chatter")
+	seedCLISession(t, dir, "telegram:99", "banana bread recipe", "apikey = sk-supersecret99")
+
+	out, code := runSessionsCmd(t, configPath, "search", "banana")
+	if code != 0 {
+		t.Fatalf("search exited %d:\n%s", code, out)
+	}
+	for _, want := range []string{"cli:alpha", "telegram:99", "2 match(es)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+
+	// Trailing --limit after the positional (the urfave parse-stop trap).
+	out, code = runSessionsCmd(t, configPath, "search", "banana", "--limit", "1")
+	if code != 0 || !strings.Contains(out, "1 match(es)") {
+		t.Errorf("trailing --limit dropped: code=%d\n%s", code, out)
+	}
+	out, code = runSessionsCmd(t, configPath, "search", "banana", "--limit=1")
+	if code != 0 || !strings.Contains(out, "1 match(es)") {
+		t.Errorf("--limit= form dropped: code=%d\n%s", code, out)
+	}
+
+	// Multi-word query without quotes.
+	out, _ = runSessionsCmd(t, configPath, "search", "magic", "word")
+	if !strings.Contains(out, "magic word") {
+		t.Errorf("multi-word query not joined:\n%s", out)
+	}
+
+	// Output is redacted: a stored credential must not print.
+	out, _ = runSessionsCmd(t, configPath, "search", "apikey")
+	if strings.Contains(out, "sk-supersecret99") {
+		t.Errorf("credential printed:\n%s", out)
+	}
+
+	// No query is a usage error, not a crash or an empty search.
+	if _, code := runSessionsCmd(t, configPath, "search"); code == 0 {
+		t.Error("search with no query must not exit 0")
+	}
+	if out, code := runSessionsCmd(t, configPath, "search", "durian"); code != 0 || !strings.Contains(out, "No matches") {
+		t.Errorf("no-match: code=%d out=%s", code, out)
+	}
+}

--- a/internal/tools/session_search_test.go
+++ b/internal/tools/session_search_test.go
@@ -1,0 +1,69 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bigknoxy/joshbot/internal/session"
+)
+
+func searchToolFixture(t *testing.T) *SessionSearchTool {
+	t.Helper()
+	mgr, err := session.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	sess, err := mgr.GetOrCreate(ctx, "cli:cli_user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess.AddMessage(session.Message{Role: session.RoleUser, Content: "deploy the banana service", Timestamp: time.Now()})
+	sess.AddMessage(session.Message{Role: session.RoleAssistant, Content: "api_key = sk-verysecretvalue123", Timestamp: time.Now()})
+	if err := mgr.Save(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+	return NewSessionSearchTool(mgr)
+}
+
+func TestSessionSearchToolFindsAndFormats(t *testing.T) {
+	tool := searchToolFixture(t)
+	res := tool.Execute(context.Background(), map[string]any{"query": "banana", "max_results": float64(5)})
+	if res.Error != nil {
+		t.Fatalf("Execute: %v", res.Error)
+	}
+	for _, want := range []string{"1 match(es)", "cli:cli_user", "banana service"} {
+		if !strings.Contains(res.Output, want) {
+			t.Errorf("output missing %q:\n%s", want, res.Output)
+		}
+	}
+}
+
+func TestSessionSearchToolNoMatchAndValidation(t *testing.T) {
+	tool := searchToolFixture(t)
+	res := tool.Execute(context.Background(), map[string]any{"query": "durian"})
+	if res.Error != nil || !strings.Contains(res.Output, "No past messages match") {
+		t.Errorf("no-match = %+v", res)
+	}
+	if res := tool.Execute(context.Background(), map[string]any{}); res.Error == nil {
+		t.Error("missing query must error")
+	}
+}
+
+// Session files are stored unredacted; the tool's output re-enters a live
+// conversation and must not resurface a captured credential.
+func TestSessionSearchToolRedactsOutput(t *testing.T) {
+	tool := searchToolFixture(t)
+	res := tool.Execute(context.Background(), map[string]any{"query": "api_key"})
+	if res.Error != nil {
+		t.Fatalf("Execute: %v", res.Error)
+	}
+	if strings.Contains(res.Output, "sk-verysecretvalue123") {
+		t.Errorf("credential resurfaced: %s", res.Output)
+	}
+	if !strings.Contains(res.Output, "api_key") {
+		t.Errorf("match itself lost: %s", res.Output)
+	}
+}


### PR DESCRIPTION
Unbreaks main after #266 (merged while this guard test was red — a merge-discipline slip on my side, flagged transparently).

The guard assumed every `sessions` subcommand with a positional routes trailing flags through `parseSessionArgs`. `search`'s positional is a free-text query, not a session id, and `runSessionsSearch` parses its own trailing `--limit` (verified working: `sessions search banana --limit 1`). The guard now knows that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)