### PR TITLE
docs: cut CHANGELOG section for v1.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.54.0] - 2026-08-14
+
 ### Added
 
 - **Reminders survive gateway restarts all the way to delivery.** Cron


### PR DESCRIPTION
Moves the [Unreleased] entries — chat-id persistence (#269), Telegram tool progress (#270), conversation search (#266/#267), Markdown + threading + typing hygiene (#268), --continue/recap and empty-reply errors (#265), configure --migrate — into a [1.54.0] section dated 2026-08-14. Tag v1.54.0 follows once this merges green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)