### PR TITLE
feat(telegram): honest replies for media the agent cannot perceive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Imperceptible Telegram media is answered honestly, not hallucinated
+  about.** A voice message, audio file or video used to be forwarded to the
+  agent as a "[Voice message]" placeholder, which earned a confident answer
+  about content nobody heard. Captionless media now gets a direct "I can't
+  listen/watch yet" reply from the channel — threaded, no LLM turn spent —
+  and captioned media forwards the caption framed so the model knows what
+  it cannot perceive. Stickers are quietly ignored instead of spending a
+  turn on a confused reply.
+
 ## [1.54.0] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ joshbot agent -m "what is in this screenshot?" --image ~/Desktop/shot.png
 
 `--image <path>` attaches a picture to the message. It is repeatable, and it
 requires `-m`/`--message` — an image with no question attached has nothing to
-answer. Telegram photos and image documents are attached automatically.
+answer. Telegram photos and image documents are attached automatically. Media
+the agent cannot perceive — voice messages, audio, video — gets an honest
+"I can't listen/watch yet" reply instead of a confident answer about content
+nobody heard; a caption on such media is forwarded as the message text,
+framed so the model knows what it cannot see. Stickers are quietly ignored.
 
 Three things are enforced, in this order, and all of them before any provider
 is called:

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -708,13 +708,19 @@ func (t *TelegramChannel) handleVoice(ctx telebot.Context) error {
 		return nil
 	}
 
+	// A voice message the agent cannot hear must not be forwarded as a
+	// "[Voice message]" placeholder: the model answers it confidently, about
+	// nothing. Without a caption there is no content at all, so the channel
+	// answers honestly itself — no agent turn, no hallucination. With a
+	// caption, the caption is real text and is forwarded framed so the model
+	// knows what it cannot perceive.
+	voice := msg.Voice
+	if voice.Caption == "" {
+		return t.replyCannotPerceive(ctx, "🎙️ I can't listen to voice messages yet — mind typing that out?")
+	}
 	t.startTyping(ctx.Chat())
 
-	voice := msg.Voice
-	content := "[Voice message]"
-	if voice.Caption != "" {
-		content = fmt.Sprintf("[Voice message with caption]: %s", voice.Caption)
-	}
+	content := fmt.Sprintf("[The user sent a voice message you cannot hear. Its caption]: %s", voice.Caption)
 
 	inbound := bus.InboundMessage{
 		SenderID:  fmt.Sprintf("telegram_%d", msg.Sender.ID),
@@ -810,13 +816,14 @@ func (t *TelegramChannel) handleAudio(ctx telebot.Context) error {
 		return nil
 	}
 
+	// Same honesty rule as voice: no caption, no agent turn.
+	audio := msg.Audio
+	if audio.Caption == "" {
+		return t.replyCannotPerceive(ctx, "🎵 I can't listen to audio yet.")
+	}
 	t.startTyping(ctx.Chat())
 
-	audio := msg.Audio
-	content := fmt.Sprintf("[Audio: %s]", audio.Title)
-	if audio.Caption != "" {
-		content = fmt.Sprintf("[Audio: %s - %s]", audio.Title, audio.Caption)
-	}
+	content := fmt.Sprintf("[The user sent an audio file you cannot hear (%s). Its caption]: %s", audio.Title, audio.Caption)
 
 	inbound := bus.InboundMessage{
 		SenderID:  fmt.Sprintf("telegram_%d", msg.Sender.ID),
@@ -856,13 +863,14 @@ func (t *TelegramChannel) handleVideo(ctx telebot.Context) error {
 		return nil
 	}
 
+	// Same honesty rule as voice: no caption, no agent turn.
+	video := msg.Video
+	if video.Caption == "" {
+		return t.replyCannotPerceive(ctx, "🎬 I can't watch videos yet.")
+	}
 	t.startTyping(ctx.Chat())
 
-	video := msg.Video
-	content := "[Video]"
-	if video.Caption != "" {
-		content = fmt.Sprintf("[Video with caption]: %s", video.Caption)
-	}
+	content := fmt.Sprintf("[The user sent a video you cannot watch. Its caption]: %s", video.Caption)
 
 	inbound := bus.InboundMessage{
 		SenderID:  fmt.Sprintf("telegram_%d", msg.Sender.ID),
@@ -902,35 +910,23 @@ func (t *TelegramChannel) handleSticker(ctx telebot.Context) error {
 		return nil
 	}
 
-	// Stickers are just acknowledged, not sent to the agent
-	content := "[Sticker]"
-
-	inbound := bus.InboundMessage{
-		SenderID:  fmt.Sprintf("telegram_%d", msg.Sender.ID),
-		Content:   content,
-		Channel:   t.name,
-		Timestamp: time.Now(),
-		Metadata: map[string]any{
-			"message_id":     msg.ID,
-			"chat_id":        msg.Chat.ID,
-			"username":       msg.Sender.Username,
-			"first_name":     msg.Sender.FirstName,
-			"last_name":      msg.Sender.LastName,
-			"media_type":     "sticker",
-			"file_id":        msg.Sticker.File.FileID,
-			"file_unique_id": msg.Sticker.File.UniqueID,
-			"emoji":          msg.Sticker.Emoji,
-			"set_name":       msg.Sticker.SetName,
-			"is_animated":    msg.Sticker.Animated,
-			"is_video":       msg.Sticker.Video,
-		},
-	}
-
-	if !t.bus.Send(inbound) {
-		log.Error("failed to send sticker message to bus", "error", "queue full")
-	}
-
+	// A sticker carries no content the agent can act on, and forwarding
+	// "[Sticker]" spent a full LLM turn on producing a confused answer.
+	// Ignore it quietly — a sticker accompanies conversation, it isn't a
+	// question.
+	log.Debug("ignoring sticker", "emoji", msg.Sticker.Emoji, "set", msg.Sticker.SetName)
 	return nil
+}
+
+// replyCannotPerceive answers a media message the agent has no way to
+// perceive (voice, audio, video) honestly from the channel itself, spending
+// no agent turn. Forwarding a "[Voice message]" placeholder instead got the
+// user a confident answer about content nobody heard. Threaded to the media
+// message; plain text on purpose (the note contains no formatting).
+func (t *TelegramChannel) replyCannotPerceive(ctx telebot.Context, note string) error {
+	t.stopTyping(ctx.Chat())
+	_, err := ctx.Bot().Send(ctx.Chat(), note, &telebot.SendOptions{ReplyTo: ctx.Message()})
+	return err
 }
 
 // handleCallback processes callback queries from inline buttons.

--- a/internal/channels/telegram_media_test.go
+++ b/internal/channels/telegram_media_test.go
@@ -75,10 +75,9 @@ func TestTelegramMediaHandlersForwardToTheBus(t *testing.T) {
 		wantContent string
 		wantFileID  string
 	}{
-		{kind: "voice", wantContent: "[Voice message with caption]: listen", wantFileID: "v1"},
-		{kind: "audio", wantContent: "[Audio: song - track]", wantFileID: "a1"},
-		{kind: "video", wantContent: "[Video with caption]: clip", wantFileID: "vid1"},
-		{kind: "sticker", wantContent: "[Sticker]", wantFileID: "s1"},
+		{kind: "voice", wantContent: "[The user sent a voice message you cannot hear. Its caption]: listen", wantFileID: "v1"},
+		{kind: "audio", wantContent: "[The user sent an audio file you cannot hear (song). Its caption]: track", wantFileID: "a1"},
+		{kind: "video", wantContent: "[The user sent a video you cannot watch. Its caption]: clip", wantFileID: "vid1"},
 		{kind: "edited", wantContent: "[Edited]: corrected text"},
 	}
 	for _, tc := range cases {
@@ -288,5 +287,62 @@ func TestTelegramHandleCallbackAnswersAndForwards(t *testing.T) {
 	case got := <-tg.bus.InboundChannel():
 		t.Fatalf("a disallowed sender's button press reached the agent: %q", got.Content)
 	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// A captionless voice/audio/video carries nothing the agent can perceive, so
+// the channel answers honestly itself — threaded, no agent turn — instead of
+// forwarding a placeholder the model would answer confidently about nothing.
+// A sticker is ignored outright: it accompanies conversation, it is not a
+// question, and it used to spend a full LLM turn on a confused reply.
+func TestImperceptibleMediaGetsAnHonestReplyNotAnAgentTurn(t *testing.T) {
+	cases := []struct {
+		kind     string
+		wantNote string
+	}{
+		{kind: "voice", wantNote: "can't listen to voice messages"},
+		{kind: "audio", wantNote: "can't listen to audio"},
+		{kind: "video", wantNote: "can't watch videos"},
+		{kind: "sticker", wantNote: ""}, // silent ignore
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			srv := newFakeTelegramServer(t)
+			bot := srv.bot(t)
+			tg := mediaChannel(t, "1234")
+			tg.mu.Lock()
+			tg.bot = bot
+			tg.mu.Unlock()
+
+			msg := mediaMessage(tc.kind, 1234)
+			switch tc.kind {
+			case "voice":
+				msg.Voice.Caption = ""
+			case "audio":
+				msg.Audio.Caption = ""
+			case "video":
+				msg.Video.Caption = ""
+			}
+			if err := mediaHandler(tg, tc.kind)(bot.NewContext(telebot.Update{Message: msg})); err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+
+			select {
+			case got := <-tg.bus.InboundChannel():
+				t.Fatalf("an imperceptible %s reached the agent as %q", tc.kind, got.Content)
+			case <-time.After(100 * time.Millisecond):
+			}
+
+			texts := srv.texts()
+			if tc.wantNote == "" {
+				if len(texts) != 0 {
+					t.Fatalf("a sticker was answered: %v", texts)
+				}
+				return
+			}
+			if len(texts) != 1 || !strings.Contains(texts[0], tc.wantNote) {
+				t.Fatalf("honest reply = %v, want one message containing %q", texts, tc.wantNote)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Telegram-UX audit item 3/7: a voice message used to reach the agent as "[Voice message]" and earn a confident answer about content nobody heard.

## What
- Captionless voice/audio/video: the channel replies honestly itself ("🎙️ I can't listen to voice messages yet — mind typing that out?"), threaded to the media message, spending no LLM turn.
- Captioned voice/audio/video: the caption is real text and is forwarded, framed as "[The user sent a voice message you cannot hear. Its caption]: ..." so the model knows what it cannot perceive.
- Stickers: quietly ignored (debug log) — they accompany conversation, they aren't questions, and each one used to burn a full agent turn on a confused reply.

## Tests
- Forwarding pins updated to the new framed captions; sticker removed from the forward set.
- New `TestImperceptibleMediaGetsAnHonestReplyNotAnAgentTurn`: per media kind, asserts nothing reaches the bus, the honest note (or sticker silence) via the fake Telegram server.
- `go test -race ./internal/channels` green; vet/gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)