### PR TITLE
feat(telegram): frame edited messages as corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Edited Telegram messages are forwarded as corrections.** The bare
+  "[Edited]:" framing read as brand-new context and earned a full fresh
+  answer; the edit is now framed as the corrected version of an
+  already-seen message, so the model answers the fixed question instead of
+  re-answering everything.
 - **Imperceptible Telegram media is answered honestly, not hallucinated
   about.** A voice message, audio file or video used to be forwarded to the
   agent as a "[Voice message]" placeholder, which earned a confident answer

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -976,7 +976,11 @@ func (t *TelegramChannel) handleEdited(ctx telebot.Context) error {
 		return nil
 	}
 
-	content := fmt.Sprintf("[Edited]: %s", msg.Text)
+	// An edit is almost always a correction of a message the agent already
+	// answered. The bare "[Edited]:" framing read as brand-new context and
+	// earned a full fresh answer; naming it a correction lets the model
+	// answer the fixed question and skip re-answering what did not change.
+	content := fmt.Sprintf("[The user edited a previous message; treat this as the corrected version]: %s", msg.Text)
 
 	inbound := bus.InboundMessage{
 		SenderID:  fmt.Sprintf("telegram_%d", msg.Sender.ID),

--- a/internal/channels/telegram_media_test.go
+++ b/internal/channels/telegram_media_test.go
@@ -78,7 +78,7 @@ func TestTelegramMediaHandlersForwardToTheBus(t *testing.T) {
 		{kind: "voice", wantContent: "[The user sent a voice message you cannot hear. Its caption]: listen", wantFileID: "v1"},
 		{kind: "audio", wantContent: "[The user sent an audio file you cannot hear (song). Its caption]: track", wantFileID: "a1"},
 		{kind: "video", wantContent: "[The user sent a video you cannot watch. Its caption]: clip", wantFileID: "vid1"},
-		{kind: "edited", wantContent: "[Edited]: corrected text"},
+		{kind: "edited", wantContent: "[The user edited a previous message; treat this as the corrected version]: corrected text"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.kind, func(t *testing.T) {


### PR DESCRIPTION
Telegram-UX audit item 7 (second half; stickers landed in #272): editing a typo in an already-answered message used to trigger a complete fresh answer, because the agent saw "[Edited]: ..." as new context.

The forwarded content is now "[The user edited a previous message; treat this as the corrected version]: ..." — the model answers the corrected question and skips re-answering what didn't change. Test pin updated; CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)