### PR TITLE
docs: cut CHANGELOG section for v1.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.55.0] - 2026-08-15
+
 ### Added
 
 - **Telegram voice messages are transcribed.** With `stt.provider` set to a


### PR DESCRIPTION
Moves the [Unreleased] entries — voice transcription (#281/#276), text documents read into the turn (#274), honest imperceptible-media replies (#272), edited-as-correction framing (#273) — into a [1.55.0] section dated 2026-08-15. Tag v1.55.0 follows once this merges green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)