### PR TITLE
docs: cut CHANGELOG section for v1.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.56.0] - 2026-08-15
+
 ### Fixed
 
 - **A streamed turn's synthesized replies reach the user (#283).** The


### PR DESCRIPTION
Cut the v1.56.0 CHANGELOG section, moving the #283 streamed-reply/persistence entries out of [Unreleased].