### PR TITLE
chore: gitignore .opencode tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ htmlcov/
 # gstack skill scratch artifacts
 .gstack/
 .dogfood/
+
+# opencode tooling artifacts (.opencode/ is local-only; the npm lockfile is
+# generated, not project-owned)
+.opencode/package-lock.json
+.opencode/node_modules/


### PR DESCRIPTION
Ignore the npm-generated .opencode/package-lock.json (and node_modules) at the repo root — .opencode/ is local-only tooling, not project-owned.