### PR TITLE
fix(agent): report session-load failure through ReplyPrefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A session-load failure now reports through `agent.ReplyPrefix`, so it reaches `agent -m` as exit 1 and the HTTP API as a 502 (audit find).** `Process` returned `"Error: Failed to load session: ..."` — a bespoke prefix `ReplyError` does not match — so a corrupt sessions directory produced a 200 whose answer was an error string, and a monitoring script wrapping `agent -m` reported green forever. This is the same class fixed for the session-lock path earlier; `TestProcessFailureRepliesCarryReplyPrefix` pins the contract behaviourally (a failed turn's reply must satisfy `ReplyError`) rather than pinning the string.
+
 ## [1.60.0] - 2026-08-21
 
 ### Added

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -514,7 +514,11 @@ func (a *Agent) process(ctx context.Context, msg bus.InboundMessage) (string, er
 	sess, err := a.sessions.GetOrCreate(ctx, sessionKey)
 	if err != nil {
 		a.logger.Error("Failed to get session", "error", err)
-		return fmt.Sprintf("Error: Failed to load session: %v", err), nil
+		// ReplyPrefix, never a bespoke prefix: this is a failed turn, and a
+		// non-interactive caller translates it back into an error only when
+		// the text matches ReplyError. The old "Error: Failed to load
+		// session" reached the HTTP API as a 200 and `agent -m` as exit 0.
+		return ReplyPrefix + fmt.Sprintf("failed to load session: %v", err), nil
 	}
 
 	startSessionLen := len(sess.Messages)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -88,6 +88,9 @@ func (m *mockToolExecutor) GetSchemas() []providers.Tool {
 // mockSessionManager is a mock session manager for testing.
 type mockSessionManager struct {
 	sessions map[string]*session.Session
+	// getErr, when set, makes every GetOrCreate fail — the corrupt-sessions-
+	// directory case, unreachable through the real manager in a test.
+	getErr error
 	// saveErr, when set, makes every Save fail. Persistence failure is not
 	// reachable through the real manager without breaking the filesystem, and
 	// the checkpoint path branches on it (#244).
@@ -110,6 +113,9 @@ func (m *mockSessionManager) GetOrCreate(ctx context.Context, key string) (*sess
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
 	if sess, ok := m.sessions[key]; ok {
 		return sess, nil
 	}
@@ -1311,5 +1317,25 @@ func TestProcessPutsTheTurnsChannelOnTheToolContext(t *testing.T) {
 	}
 	if seen != "telegram" {
 		t.Errorf("tool saw channel %q, want the turn's own channel", seen)
+	}
+}
+
+// Every failed turn must report through ReplyPrefix, so ReplyError translates
+// it back into a real error for `agent -m` (exit 1) and the HTTP API (502). A
+// bespoke prefix here is the shipped bug class: "Error: Failed to load
+// session" reached the API as a 200 and scripts as exit 0.
+func TestProcessFailureRepliesCarryReplyPrefix(t *testing.T) {
+	sessions := newMockSessionManager()
+	sessions.getErr = errors.New("sessions directory unreadable")
+	a := NewAgent(config.Defaults(), &mockProvider{}, &mockToolExecutor{}, sessions, newMockLogger())
+
+	reply, err := a.Process(context.Background(), bus.InboundMessage{
+		Channel: "cli", SenderID: "u1", Content: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Process reports failures in band, got err = %v", err)
+	}
+	if ReplyError(reply) == nil {
+		t.Fatalf("a failed turn's reply must match ReplyError, got %q", reply)
 	}
 }


### PR DESCRIPTION
## Summary

Audit find (item 1 of the quality-foundation cycle): `Process` returned `"Error: Failed to load session: ..."` with a nil error — a bespoke prefix `agent.ReplyError` does not match — so a corrupt sessions directory produced an HTTP 200 whose answer was an error string, and a script wrapping `agent -m` exited 0 over it forever. The turn path now uses `ReplyPrefix`. (The remaining `"Error: ..."` strings in `handleCommand` are command replies — informational chat answers, not failed turns — and are deliberately untouched.)

## Test

`TestProcessFailureRepliesCarryReplyPrefix` pins the contract behaviourally — a failed turn's reply must satisfy `ReplyError` — via a new `getErr` knob on the mock session manager, so a future bespoke-prefix regression fails regardless of wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)