### PR TITLE
fix(providers): replace the dead NVIDIA default model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A session-load failure now reports through `agent.ReplyPrefix`, so it reaches `agent -m` as exit 1 and the HTTP API as a 502 (audit find).** `Process` returned `"Error: Failed to load session: ..."` — a bespoke prefix `ReplyError` does not match — so a corrupt sessions directory produced a 200 whose answer was an error string, and a monitoring script wrapping `agent -m` reported green forever. This is the same class fixed for the session-lock path earlier; `TestProcessFailureRepliesCarryReplyPrefix` pins the contract behaviourally (a failed turn's reply must satisfy `ReplyError`) rather than pinning the string.
 
+### Fixed
+
+- **The NVIDIA provider's default model was dead (found by the hardened live eval).** `moonshotai/kimi-k2-thinking` — the model a fresh `joshbot onboard --provider nvidia` configures when none is named — now answers HTTP 410 Gone, so a new NVIDIA install failed on its very first message. The default is `deepseek-ai/deepseek-v4-flash-0731`, verified live before the change. A hosted default rots silently; the live eval's first run against a defaults-configured sandbox is what surfaced it.
+
 ## [1.60.0] - 2026-08-21
 
 ### Added

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -184,7 +184,7 @@ The wizard will guide you through:
    ```
 
 3. **Model Selection**
-   - Default depends on the provider you configured — e.g. `moonshotai/kimi-k2-thinking` for NVIDIA NIM, `openrouter/free` for OpenRouter
+   - Default depends on the provider you configured — e.g. `deepseek-ai/deepseek-v4-flash-0731` for NVIDIA NIM, `openrouter/free` for OpenRouter
    - You can specify any model supported by your provider
 
 ### Onboarding Options

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -245,9 +245,13 @@ func init() {
 			return NewLiteLLMProvider(cfg), nil
 		},
 		DefaultAPIBase: "https://integrate.api.nvidia.com/v1",
-		DefaultModel:   "moonshotai/kimi-k2-thinking",
-		DisplayName:    "NVIDIA NIM",
-		Description:    "Free tier available",
+		// A hosted default rots: the previous one (moonshotai/kimi-k2-thinking)
+		// started answering HTTP 410 Gone, so a fresh nvidia onboarding got a
+		// dead model out of the box — caught by the live eval, 2026-08.
+		// Verified live before changing; do the same when this one rots.
+		DefaultModel: "deepseek-ai/deepseek-v4-flash-0731",
+		DisplayName:  "NVIDIA NIM",
+		Description:  "Free tier available",
 	})
 
 	// Register Groq


### PR DESCRIPTION
## Summary

Found by the hardened live eval's first real run: NVIDIA's registry default `moonshotai/kimi-k2-thinking` — what a fresh `joshbot onboard --provider nvidia` configures when no model is named — answers **HTTP 410 Gone**, so a brand-new NVIDIA install failed on its very first message.

New default: `deepseek-ai/deepseek-v4-flash-0731` — verified live against the real endpoint before the change (200 in 0.75s; the old id verified 410). Fast, current, and tool-capable in dogfooding. Registry comment documents the verify-before-change rule for when this one rots too.

Docs: INSTALL.md default-model example; CHANGELOG under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)