### PR TITLE
docs: cut CHANGELOG section for v1.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.64.0] - 2026-08-24
+
 ### Added
 
 - **A retired-model fallback notice carries the model picker on Telegram** — the notice says "pick another with /model", and on a phone the buttons are the shortest way to do that (#348 follow-up). `agent.WithFallbackObserver` is a per-request callback fired only with the notice the user sees in full (the first turn of an outage, never the marker turns), `Picker.NoticeKeyboard` builds the model keyboard for a notice whose `ModelRetired()` (404/410) is true, and the gateway attaches it on whichever path delivers the reply: `TelegramStreamer.SetFinalMarkup` puts it on the final edit of a streamed answer (interim edits keep the Stop button, the final edit swaps to the picker), the bus path sets `reply_markup`. A failed turn carries nothing, for the same reason the `/model` picker does not.


### PR DESCRIPTION
Moves the `[Unreleased]` entry (#354, model picker under a retired-model fallback notice) under `## [1.64.0] - 2026-08-24`. Tag `v1.64.0` follows once this is on main and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)